### PR TITLE
Add deprecated claim names

### DIFF
--- a/index.html
+++ b/index.html
@@ -637,6 +637,8 @@ and <a data-cite="VC-DATA-MODEL#dfn-holders">holders</a>.
 
   <section class="normative">
     <h2>IANA Considerations</h2>
+    <section id="media-type-registrations">
+    <h3>Media Types</h3>
     <section id="vc-jwt-media-type">
       <h2><code>application/vc+jwt</code></h2>
       <p>
@@ -827,6 +829,70 @@ and <a data-cite="VC-DATA-MODEL#dfn-holders">holders</a>.
           </td>
         </tr>
       </table>
+    </section>
+  </section>
+  
+
+  <section id="json-web-token-claim-registrations">
+    <h3>JSON Web Token Claims</h3>
+    <p>
+      This section retained deprecated registered claim names, 
+      that have been submitted to the Internet Engineering Steering Group
+      (IESG) for review, approval, and registration with IANA in the
+      "JSON Web Token Claims Registry".
+    </p>
+
+    <p class="issue" data-number="119"></p>
+    
+      <section id="vc-json-web-token-claim">
+        <h4>`vc`</h4>
+        <table>
+          <tr>
+            <th>Claim Name: </th>
+            <td>"vc" </td>
+          </tr>
+          <tr>
+            <th>Claim Description: </th>
+            <td>Verifiable Credential</td>
+          </tr>
+          <tr>
+            <th>Change Controller:  </th>
+            <td>W3C</td>
+          </tr>
+          <tr>
+            <th>Specification Document(s): </th>
+            <td>
+            <a href="https://www.w3.org/TR/vc-data-model/">Section 6.3.1.2: JSON Web Token
+              Extensions of Verifiable Credentials Data Model 1.0</a>
+            </td>
+          </tr>
+        </table>
+      </section>
+
+      <section id="vp-json-web-token-claim">
+        <h4>`vp`</h4>
+        <table>
+          <tr>
+            <th>Claim Name: </th>
+            <td>"vp"</td>
+          </tr>
+          <tr>
+            <th>Claim Description: </th>
+            <td>Verifiable Presentation</td>
+          </tr>
+          <tr>
+            <th>Change Controller: </th>
+            <td>W3C</td>
+          </tr>
+          <tr>
+            <th>Specification Document(s):</th>
+            <td>
+              <a href="https://www.w3.org/TR/vc-data-model/">Section 6.3.1.2: JSON Web Token
+                Extensions of Verifiable Credentials Data Model 1.0</a>
+            </td>
+          </tr>
+        </table>
+      </section>
     </section>
   </section>
   <section>

--- a/index.html
+++ b/index.html
@@ -836,9 +836,9 @@ and <a data-cite="VC-DATA-MODEL#dfn-holders">holders</a>.
   <section id="json-web-token-claim-registrations">
     <h3>JSON Web Token Claims</h3>
     <p>
-      This section retained deprecated registered claim names, 
-      that have been submitted to the Internet Engineering Steering Group
-      (IESG) for review, approval, and registration with IANA in the
+      This section retains deprecated registered claim names 
+      that were previously submitted to the Internet Engineering Steering
+      Group (IESG) for review, approval, and registration with IANA in the
       "JSON Web Token Claims Registry".
     </p>
 


### PR DESCRIPTION
We should keep them in this spec with an issue marker until IESG updates the JWT registry.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jwt/pull/124.html" title="Last updated on Jul 13, 2023, 6:37 PM UTC (9847170)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jwt/124/227499a...9847170.html" title="Last updated on Jul 13, 2023, 6:37 PM UTC (9847170)">Diff</a>