### PR TITLE
Necessary respec changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,14 +15,15 @@
 
       // specification status (e.g., WD, NOTE, etc.). If in doubt use
       // ED.
-      specStatus: "ED",
+      specStatus: "WD",
 
       // the specification's short name, as in
       // http://www.w3.org/TR/short-name/
-      shortName: "vc-jwt",
+      shortName: "vc-jose-cose",
 
       // if you wish the publication date to be other than today, set
-      // this publishDate: "2023-04-27",
+      // this 
+      publishDate: "2023-07-20",
 
       // implementationReportURI:
       // "https://w3c.github.io/vc-test-suite/implementations/", errata:
@@ -31,7 +32,8 @@
 
       // if there is a previously published draft, uncomment this and
       // set its YYYY-MM-DD date and its maturity status
-      // previousPublishDate:  "1977-03-15", previousMaturity:  "WD",
+      previousPublishDate:  "2023-07-10", 
+      previousMaturity:  "WD",
 
       // extend the bibliography entries localBiblio: vcwg.localBiblio,
       doJsonLd: true,
@@ -40,11 +42,11 @@
       //   list of normative statements: preProcess: [], postProcess:
       //   [],
 
-      github: "https://github.com/w3c/vc-jwt/",
+      github: "https://github.com/w3c/vc-jose-cose/",
       includePermalinks: false,
 
       // if there a publicly available Editor's Draft, this is the link
-      edDraftURI: "https://w3c.github.io/vc-jwt/",
+      edDraftURI: "https://w3c.github.io/vc-jose-cose/",
 
       // editors, add as many as you like only "name" is required
       editors: [


### PR DESCRIPTION
This provides all the changes to respec to change the document's short name.

Merge should happen only once the repository also changes, to avoid respec and subsequent pubrules' checkeer errors.

@deniak I have one question: in https://github.com/w3c/vc-jwt/pull/115#issuecomment-1620408736 we said that a change should happen manually on the document before the publication step, namely (quoting from the pubrules document):

> The syntax of a “history” URI must be https://www.w3.org/standards/history/shortname/, and consistent with the shortname mentioned in 'Latest Version'. Note: If there's a shortname change it must be specified using the following data attribute data-previous-shortname='previous-shortname' on the <a> element.

However, the WD generated by respec does not include and 'history' reference, so I am not sure where I would have to make a change. Please advise, thx.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jwt/pull/126.html" title="Last updated on Jul 13, 2023, 10:10 AM UTC (b7cc3d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jwt/126/227499a...b7cc3d5.html" title="Last updated on Jul 13, 2023, 10:10 AM UTC (b7cc3d5)">Diff</a>