### PR TITLE
clarify that what is secured is a document conforming to vcdm

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
       <section>
         <h2>Securing JSON-LD Verifiable Credentials with JOSE</h2>
         <p>
-          This section details how to secure with JOSE verifiable credentials conforming
+          This section details how to use JOSE to secure verifiable credentials conforming
           to the [[VC-DATA-MODEL]].
         </p>
         <p>[[rfc7515]] MAY be used to secure this media type.</p>
@@ -250,7 +250,7 @@
       <section>
         <h2>Securing JSON-LD Verifiable Presentations with JOSE</h2>
         <p>
-          This section details how to secure with JOSE verifiable presentations conforming
+          This section details how to use JOSE to secure verifiable presentations conforming
           to the [[VC-DATA-MODEL]].
         </p>
         <p>[[rfc7515]] MAY be used to secure this media type.</p>

--- a/index.html
+++ b/index.html
@@ -209,9 +209,8 @@
       <section>
         <h2>Securing JSON-LD Verifiable Credentials with JOSE</h2>
         <p>
-          This section details how to secure data payloads with the type
-          <code>application/vc+ld+json</code>
-          with JOSE.
+          This section details how to secure with JOSE verifiable credentials conforming
+          to the [[VC-DATA-MODEL]].
         </p>
         <p>[[rfc7515]] MAY be used to secure this media type.</p>
         <p>
@@ -251,9 +250,8 @@
       <section>
         <h2>Securing JSON-LD Verifiable Presentations with JOSE</h2>
         <p>
-          This section details how to secure verifiable presentations
-          with the type
-          <code>application/vp+ld+json</code> with JOSE.
+          This section details how to secure with JOSE verifiable presentations conforming
+          to the [[VC-DATA-MODEL]].
         </p>
         <p>[[rfc7515]] MAY be used to secure this media type.</p>
         <p>The <code>typ</code> parameter MUST be


### PR DESCRIPTION
for clarity. removing media types in the spirit of #143 (should probably be merged after that one, if ever.)
somewhat related to #15.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/pull/147.html" title="Last updated on Sep 12, 2023, 5:06 PM UTC (99fc1ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/147/1247eed...99fc1ca.html" title="Last updated on Sep 12, 2023, 5:06 PM UTC (99fc1ca)">Diff</a>