### PR TITLE
add guidance on kid

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,7 +423,7 @@
         <p>
       If <code>kid</code> is present in the <a data-cite="RFC7515#section-4.1">Protected Header</a>,
       a <a data-cite="VC-DATA-MODEL#dfn-verifier">verifier</a> can use this parameter
-      to obtain a <a data-cite="RFC7517#section-4">JSON Web Key</a> to use in the 
+      as a hint indicating which key was used to secure the verifiable credential when performing a
       <a data-cite="VC-DATA-MODEL#dfn-verify">verification</a> process as defined in <a data-cite="RFC7515#section-4.1.4">RFC7515</a>.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -423,7 +423,7 @@
         <p>
       If <code>kid</code> is present in the <a data-cite="RFC7515#section-4.1">Protected Header</a>,
       a <a data-cite="VC-DATA-MODEL#dfn-verifier">verifier</a> can use this parameter
-      as a hint indicating which key was used to secure the verifiable credential when performing a
+      as a hint indicating which key was used to secure the verifiable credential, when performing a
       <a data-cite="VC-DATA-MODEL#dfn-verify">verification</a> process as defined in <a data-cite="RFC7515#section-4.1.4">RFC7515</a>.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -391,8 +391,6 @@
       <p class="issue" data-number="31"></p>
       <p class="issue" data-number="30"></p>
       <p class="issue" data-number="15"></p>
-      <p class="issue" data-number="117"></p>
-      <p class="issue" data-number="117"></p>
       <p>
     In order to complete the <a data-cite="VC-DATA-MODEL#dfn-verify">verification</a> process, 
     a <a data-cite="VC-DATA-MODEL#dfn-verifier">verifier</a> needs to obtain the cryptographic keys used to secure the 
@@ -426,7 +424,11 @@
       If <code>kid</code> is present in the <a data-cite="RFC7515#section-4.1">Protected Header</a>,
       a <a data-cite="VC-DATA-MODEL#dfn-verifier">verifier</a> can use this parameter
       to obtain a <a data-cite="RFC7517#section-4">JSON Web Key</a> to use in the 
-      <a data-cite="VC-DATA-MODEL#dfn-verify">verification</a> process.
+      <a data-cite="VC-DATA-MODEL#dfn-verify">verification</a> process as defined in <a data-cite="RFC7515#section-4.1.4">RFC7515</a>.
+        </p>
+        <p>
+          <code>kid</code> MUST be present when the key of the <a data-cite="VC-DATA-MODEL#dfn-issuers">issuer</a>
+          or <a data-cite="VC-DATA-MODEL#dfn-subjects">subject</a> is expressed as a DID.
         </p>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -428,7 +428,7 @@
         </p>
         <p>
           <code>kid</code> MUST be present when the key of the <a data-cite="VC-DATA-MODEL#dfn-issuers">issuer</a>
-          or <a data-cite="VC-DATA-MODEL#dfn-subjects">subject</a> is expressed as a DID.
+          or <a data-cite="VC-DATA-MODEL#dfn-subjects">subject</a> is expressed as a DID URL.
         </p>
       </section>
       <section>


### PR DESCRIPTION
should align with PR #144 better

issue #117.
- add pointer to the guidance on kid in rfc7515.
- clarify that kid can be present only in the header.
- mandate kid when DIDs are used (need to add reference to a DID-Core)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/pull/153.html" title="Last updated on Sep 18, 2023, 1:25 PM UTC (f84571f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/153/9e717da...f84571f.html" title="Last updated on Sep 18, 2023, 1:25 PM UTC (f84571f)">Diff</a>