### PR TITLE
Use Correct Names for Things

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,12 +340,10 @@
           with COSE.
         </p>
         <p>[[rfc9052]] MAY be used to secure this media type.</p>
-        <p>When using this approach, the <code>type (TBD)</code> SHOULD be
-          <code>vc+ld+json+cose</code>
-        </p>
-        <p class="issue">
-          See <a href="https://datatracker.ietf.org/doc/draft-jones-cose-typ-header-parameter/">draft-jones-cose-typ-header-parameter</a>,
-          regarding progress towards explicit typing for COSE.
+        <p>When using this approach, the <code>typ</code> SHOULD be
+          <code>vc+ld+json+cose</code>.
+          See <a href="https://www.ietf.org/archive/id/draft-ietf-cose-typ-header-parameter-00.html/">I-D.ietf-cose-typ-header-parameter</a>
+          for the COSE "<code>typ</code>" (type) header parameter.
         </p>
         <p>When using this approach, the <code>content type (3)</code>
           SHOULD be <code>application/vc+ld+json</code></p>
@@ -357,7 +355,6 @@
             Binary Object Representation (CBOR) Tags</a> for additional
           details.</p>
       </section>
-      <p class="issue" data-number="67"></p>
     </section>
   </section>
   <section class="informative">

--- a/index.html
+++ b/index.html
@@ -86,6 +86,13 @@
           status:   "Internet-Draft",
           publisher:  "IETF"
         },
+        "SD-JWT-VC": {
+          title:    "SD-JWT-based Verifiable Credentials (SD-JWT VC)",
+          href:     "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc-00",
+          authors:  [ "Oliver Terbu", "Daniel Fett" ],
+          status:   "Internet-Draft",
+          publisher:  "IETF"
+        },
         "MULTIPLE-SUFFIXES": {
           title:    "Media Types with Multiple Suffixes",
           href:     "https://datatracker.ietf.org/doc/draft-ietf-mediaman-suffixes/",
@@ -482,99 +489,17 @@
       and <a data-cite="VC-DATA-MODEL#dfn-holders">holders</a>.
       </p>
       
-      
       <section>
-        <h2>OpenID Connect</h2>
+        <h2>JWT Issuer</h2>
             <p>
-              OpenID Connect uses <a data-cite="RFC5785#section-3">Well-Known Uniform Resource Identifiers (URIs)</a> 
-              to enable <a data-cite="VC-DATA-MODEL#dfn-issuers">issuer</a> key discovery.
+              When the issuer value is a URL using the HTTPS scheme,
+              issuer metadata including the issuer's public keys can be retrieved using the mechanism
+              defined in <a data-cite="SD-JWT-VC"></a>.
             </p>
-            <ol>
-              <li>
-                <p>
-                  The <a data-cite="VC-DATA-MODEL#dfn-verifier">verifier</a> (or relying party)
-                  decodes the JWT claimset, and obtains the <code>iss</code> claim.
-                </p>
-              </li>
-              <li>
-                <p>
-                  The <code>iss</code> value is converted to the well-known OpenID Connect Configuration 
-                  Endpoint URL by applying the following URI template:
-                </p>
-                <pre class="example">
-                  https://{iss}/.well-known/openid-configuration
-                </pre>
-              </li>
-              <li>
-                <p>
-                  The OIDC Configuration Endpoint URL is dereferenced to a JSON document which contains issuer configuration details,
-                  one of which is the <code>jwks_uri</code>. This URL might also be well-known, for example:
-                </p>
-                <pre class="example">
-                  https://{iss}/.well-known/jwks
-                </pre>
-              </li>
-              <li>
-                <p>
-                  The OIDC <code>jwks_uri</code> is dereferenced to a JSON Web Key Set.
-                </p>
-                <p>
-                  The content type of the key set could be 
-                  <a href="https://www.iana.org/assignments/media-types/application/jwk-set+json">application/jwk-set+json</a> 
-                  or <a href="https://www.iana.org/assignments/media-types/application/json">application/json</a>.
-                </p>
-                <p>
-                  Here is an example of a key set used by an issuer:
-                </p>
-                <pre class="example">
-      {
-        "keys": [
-          {
-            "alg": "RS256",
-            "kty": "RSA",
-            "use": "sig",
-            "n": "wW9TkSbcn5FV3iUJ-812sqTvwTGCFrDm6vD2U-g23gn6rrBdFZQbf2bgEnSkolph6CanOYTQ1lKVhKjHLd6Q4MDVGidbVBhESxib2YIzJVUS-0oQgizkBEJxyHI4Zl3xX_sdA_yegLUi-Ykt_gaMPSw_vpxe-pBxu-jd14i-jDfwoPJUdF8ZJGS9orCPRiHCYLDgOscC9XibH9rUbTvG8q4bAPx9Ox6malx4OLvU3pXVjew6LG3iBi2YhpCWe6voMvZJYXqC1n5Mk_KOdGcCFtDgu3I56SGSfsF7-tI7qG1ZO8RMuzqH0LkJVirujYzXrnMZ7WgbMPXmHU8i4z04zw",
-            "e": "AQAB",
-            "kid": "NTBGNTJEMDc3RUE3RUVEOTM4NDcyOEFDNzEyOTY5NDNGOUQ4OEU5OA",
-            "x5t": "NTBGNTJEMDc3RUE3RUVEOTM4NDcyOEFDNzEyOTY5NDNGOUQ4OEU5OA",
-            "x5c": [
-              "MIIDCzCCAfOgAwIBAgIJANPng0XRWwsdMA0GCSqGSIb3DQEBBQUAMBwxGjAYBgNVBAMMEWNvbnRvc28uYXV0aDAuY29tMB4XDTE0MDcxMTE2NTQyN1oXDTI4MDMxOTE2NTQyN1owHDEaMBgGA1UEAwwRY29udG9zby5hdXRoMC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDBb1ORJtyfkVXeJQn7zXaypO/BMYIWsObq8PZT6DbeCfqusF0VlBt/ZuASdKSiWmHoJqc5hNDWUpWEqMct3pDgwNUaJ1tUGERLGJvZgjMlVRL7ShCCLOQEQnHIcjhmXfFf+x0D/J6AtSL5iS3+Bow9LD++nF76kHG76N3XiL6MN/Cg8lR0XxkkZL2isI9GIcJgsOA6xwL1eJsf2tRtO8byrhsA/H07HqZqXHg4u9TeldWN7DosbeIGLZiGkJZ7q+gy9klheoLWfkyT8o50ZwIW0OC7cjnpIZJ+wXv60juobVk7xEy7OofQuQlWKu6NjNeucxntaBsw9eYdTyLjPTjPAgMBAAGjUDBOMB0GA1UdDgQWBBTLarHdkNa5CzPyiKJU51t8JWn9WTAfBgNVHSMEGDAWgBTLarHdkNa5CzPyiKJU51t8JWn9WTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBQUAA4IBAQA2FOjm+Bpbqk59rQBC0X6ops1wBcXH8clnXfG1G9qeRwLEwSef5HPz4TTh1f2lcf4Pcq2vF0HbVNJFnLVV+PjR9ACkto+v1n84i/U4BBezZyYuX2ZpEbv7hV/PWxg8tcVrtyPaj60UaA/pUA86CfYy+LckY4NRKmD7ZrcCzjxW2hFGNanfm2FEryxXA3RMNf6IiW7tbJ9ZGTEfA/DhVnZgh/e82KVX7EZnkB4MjCQrwj9QsWSMBtBiYp0/vRi9cxDFHlUwnYAUeZdHWTW+Rp2JX7Qwf0YycxgyjkGAUEZc4WpdNiQlwYf5G5epfOtHGiwiJS+u/nSYvqCFt57+g3R+"
-            ]
-          },
-          {
-            "alg": "RS256",
-            "kty": "RSA",
-            "use": "sig",
-            "n": "ylgVZbNR4nlsU_AbU8Zd7ZhVfmYuwq-RB1_YQWHY362pAed-qgSXV1QmKwCukQ2WDsPHWgpPuEf3O_acmJcCiSxhctpBr5WKkji5o50YX2FqC3xymGkYW5NilvFznKaKU45ulBVByrcb3Vt8BqqBAhaD4YywZZKo7mMudcq_M__f0_tB4fHsHHe7ehWobWtzAW7_NRP0_FjB4Kw4PiqJnChPvfbuxTCEUcIYrshRwD6GF4D_oLdeR44dwx4wtEgvPOtkQ5XIGrhQC_sgWcb2jh7YXauVUjuPezP-VkK7Wm9mZRe758q43SWxwT3afo5BLa3_YLWazqcpWRXn9QEDWw",
-            "e": "AQAB",
-            "kid": "aMIKy_brQk3nLd0PKd9ln",
-            "x5t": "-xcTyx47q3ddycG7LtE6QCcETbs",
-            "x5c": [
-              "MIIC/TCCAeWgAwIBAgIJH62yWyX7VxxQMA0GCSqGSIb3DQEBCwUAMBwxGjAYBgNVBAMTEWNvbnRvc28uYXV0aDAuY29tMB4XDTIwMDMxMTE5Mjk0N1oXDTMzMTExODE5Mjk0N1owHDEaMBgGA1UEAxMRY29udG9zby5hdXRoMC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDKWBVls1HieWxT8BtTxl3tmFV+Zi7Cr5EHX9hBYdjfrakB536qBJdXVCYrAK6RDZYOw8daCk+4R/c79pyYlwKJLGFy2kGvlYqSOLmjnRhfYWoLfHKYaRhbk2KW8XOcpopTjm6UFUHKtxvdW3wGqoECFoPhjLBlkqjuYy51yr8z/9/T+0Hh8ewcd7t6Fahta3MBbv81E/T8WMHgrDg+KomcKE+99u7FMIRRwhiuyFHAPoYXgP+gt15Hjh3DHjC0SC8862RDlcgauFAL+yBZxvaOHthdq5VSO497M/5WQrtab2ZlF7vnyrjdJbHBPdp+jkEtrf9gtZrOpylZFef1AQNbAgMBAAGjQjBAMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFPVdE4SPvuhlODV0GOcPE4QZ7xNuMA4GA1UdDwEB/wQEAwIChDANBgkqhkiG9w0BAQsFAAOCAQEAu2nhfiJk/Sp49LEsR1bliuVMP9nycbSz0zdp2ToAy0DZffTd0FKk/wyFtmbb0UFTD2aOg/WZJLDc+3dYjWQ15SSLDRh6LV45OHU8Dkrc2qLjiRdoh2RI+iQFakDn2OgPNgquL+3EEIpbBDA/uVoOYCbkqJNaNM/egN/s2vZ6Iq7O+BprWX/eM25xw8PMi+MU4K2sJpkcDRwoK9Wy8eeSSRIGYnpKO42g/3QI9+BRa5uD+9shG6n7xgzAPGeldUXajCThomwO8vInp6VqY8k3IeLEYoboJj5KMfJgOWUkmaoh6ZBJHnCogvSXI35jbxCxmHAbK+KdTka/Yg2MadFZdA=="
-            ]
-          }
-        ]
-      }
-                </pre>
-              </li>
-              <li>
-                <p>
-                  The <a data-cite="VC-DATA-MODEL#dfn-verifier">verifier</a> (or relying party)
-                  uses <code>kid</code> from the protected header of the JWT
-                  to identify the public key, controlled by the issuer, and uses it to verify
-                  the token.
-                </p>
-                <p>
-                  The <a data-cite="VC-DATA-MODEL#dfn-verifier">verifier</a> (or relying party)
-                  verifies the signature on the JWT.
-                  After verification, the claims the issuer has made about the subject can be reviewed or processed, 
-                  because the integrity of the claims has been protected by a digital signature verification.
-                </p>
-              </li>
-            </ol>
           </section>
         </section>
       </section>
+
     <section class="normative">
       <h2>Protected Header Parameters</h2>
       <p>

--- a/index.html
+++ b/index.html
@@ -346,14 +346,13 @@
           for the COSE "<code>typ</code>" (type) header parameter.
         </p>
         <p>When using this approach, the <code>content type (3)</code>
-          SHOULD be <code>application/vc+ld+json</code></p>
+          SHOULD be <code>application/vc+ld+json</code>.</p>
         <p>
           See <a data-cite="rfc9052#section-3.1">Common COSE Header
             Parameters</a> for additional details.
         </p>
-        <p>See <a href="https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml">Concise
-            Binary Object Representation (CBOR) Tags</a> for additional
-          details.</p>
+        <p>See the IANA <a href="https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml">Concise Binary Object Representation (CBOR) Tags</a> registry
+	  for additional details.</p>
       </section>
     </section>
   </section>
@@ -410,24 +409,24 @@
 
 
     <section>
-      <h2>Registered Claim Names</h2>
+      <h2>Registered Header Parameter and Claim Names</h2>
       <p>
-      When found in the <a data-cite="RFC7515#section-4.1">Protected Header</a>, or 
-      the <a data-cite="RFC7519#section-4.1.1">Protected Claimset</a>, members present in
-      <a href="https://www.iana.org/assignments/jwt/jwt.xhtml">IANA Assignments for JSON Web Token (JWT)</a> and 
-      <a href="https://www.iana.org/assignments/jose/jose.xhtml">IANA Assignments for JSON Object Signing and Encryption (JOSE)</a>
-      are to be interpreted according to the associated specifications referenced by IANA.
+      When present in
+      the <a data-cite="RFC7515#section-4">JOSE Header</a> or
+      the <a data-cite="RFC7519#section-4">JWT Claims Set</a>
+      members registered in
+      the IANA <a href="https://www.iana.org/assignments/jwt/jwt.xhtml">JSON Web Token Claims</a> registry or
+      the IANA <a href="https://www.iana.org/assignments/jose/jose.xhtml">JSON Web Signature and Encryption Header Parameters</a> registry
+      are to be interpreted as defined by the specifications referenced in the registries.
       </p>
       <p>
-      <a href="#registered-claim-names">Registered claims</a> that are present in either
-      the <a data-cite="RFC7515#section-4.1">Protected Header</a>
-      or the <a data-cite="RFC7519#section-4.1.1">Claimset</a> can be used to help
+      These parameters and claims can be used to help
       <a data-cite="VC-DATA-MODEL#dfn-verifier">verifiers</a> discover verification keys.
       </p>
       <section>
         <h2>kid</h2>
         <p>
-      If <code>kid</code> is present in the <a data-cite="RFC7515#section-4.1">Protected Header</a>,
+      If <code>kid</code> is present in the <a data-cite="RFC7515#section-4.1">JOSE Header</a>,
       a <a data-cite="VC-DATA-MODEL#dfn-verifier">verifier</a> can use this parameter
       to obtain a <a data-cite="RFC7517#section-4">JSON Web Key</a> to use in the 
       <a data-cite="VC-DATA-MODEL#dfn-verify">verification</a> process.
@@ -436,7 +435,7 @@
       <section>
         <h2>iss</h2>
         <p>
-      If <code>iss</code> is present in the <a data-cite="RFC7515#section-4.1">Protected Header</a>
+      If <code>iss</code> is present in the <a data-cite="RFC7515#section-4.1">JOSE Header</a>
       or the <a data-cite="RFC7519#section-4.1.1">JWT Claims </a>,
       a <a data-cite="VC-DATA-MODEL#dfn-verifier">verifier</a> can use this parameter
       to obtain a <a data-cite="RFC7517#section-4">JSON Web Key</a> to use in the 
@@ -450,7 +449,7 @@
         </p>
         <p>
       If <code>kid</code> is also present in the
-      <a data-cite="RFC7515#section-4.1">Protected Header</a>, it is expected to be useful to
+      <a data-cite="RFC7515#section-4.1">JOSE Header</a>, it is expected to be useful to
       distinguish the specific key used.
         </p>
       <p class="issue"  data-number="31">
@@ -462,7 +461,7 @@
       <section>
         <h2>cnf</h2>
         <p>
-      If <code>cnf</code> is present in the <a data-cite="RFC7515#section-4.1">Protected Header</a>
+      If <code>cnf</code> is present in the <a data-cite="RFC7515#section-4.1">JOSE Header</a>
       or the <a data-cite="RFC7519#section-4.1.1">JWT Claims </a>,
       a <a data-cite="VC-DATA-MODEL#dfn-verifier">verifier</a> can use this parameter
       to obtain a <a data-cite="RFC7517#section-4">JSON Web Key</a> to use in the 
@@ -470,7 +469,7 @@
         </p>
         <p>
       If <code>kid</code> is also present in the
-      <a data-cite="RFC7515#section-4.1">Protected Header</a>, it is expected to be
+      <a data-cite="RFC7515#section-4.1">JOSE Header</a>, it is expected to be
       useful to distinguish the specific key used.
         </p>
       </section>
@@ -498,7 +497,7 @@
       </section>
 
     <section class="normative">
-      <h2>Protected Header Parameters</h2>
+      <h2>JOSE Header Parameters</h2>
       <p>
         The normative statements in <a data-cite="RFC7515#section-4.1">Registered Header Parameter
           Names</a>
@@ -509,7 +508,7 @@
         apply to securing credentials and presentations.
       </p>
       <p>
-        The data model for the protected header is JSON
+        The data model for the JOSE Header is JSON
         (application/json), not JSON-LD (application/ld+json).
       </p>
       <p>
@@ -518,27 +517,25 @@
         apply to securing claims about a credential subject.
       </p>
       <p>
-        When replicating claims from the claimset to the header, it is
-        RECOMMENDED to use [[RFC7519]], <a href="https://www.iana.org/assignments/jose/jose.xhtml">IANA
-          Assignments for Header Parameters</a>, and <a href="https://www.iana.org/assignments/jwt/jwt.xhtml">IANA
-          Assignments for JSON Web Token (JWT)</a>
-        to identify any reserved claims that might be confused with
-        members of the [[VC-DATA-MODEL]. This includes but is not
+        When replicating claims from the JWT Claims Set to Header Parameters, it is
+        RECOMMENDED to use [[RFC7519]],
+	the IANA <a href="https://www.iana.org/assignments/jwt/jwt.xhtml">JSON Web Token Claims</a> registry, or
+	the IANA <a href="https://www.iana.org/assignments/jose/jose.xhtml">JSON Web Signature and Encryption Header Parameters</a> registry
+        to identify any claims that might be confused with
+        members defined by the [[VC-DATA-MODEL]. This includes but is not
         limited to: <code>iss</code>, <code>kid</code>,
         <code>alg</code>, <code>iat</code>,
-        <code>exp</code> and <code>cnf</code>.
+        <code>exp</code>, and <code>cnf</code>.
       </p>
       <p>
-        The <a href="#registered-claim-names">registered claim</a> names <code>vc</code> and <code>vp</code>
+        The JWT Claim Names <code>vc</code> and <code>vp</code>
         MUST NOT be present as header parameters.
       </p>
       <p>
         When present, members of the header are to be interpreted and
-        processed according to
-        <a href="https://www.iana.org/assignments/jwt/jwt.xhtml">IANA
-          Assignments for JSON Web Token (JWT)</a> and
-        <a href="https://www.iana.org/assignments/jose/jose.xhtml">IANA
-          Assignments for JSON Object Signing and Encryption (JOSE)</a>.
+        processed according to the definitions referenced from
+	the IANA <a href="https://www.iana.org/assignments/jose/jose.xhtml">JSON Web Signature and Encryption Header Parameters</a> registry and
+	the IANA <a href="https://www.iana.org/assignments/jwt/jwt.xhtml">JSON Web Token Claims</a> registry.
       </p>
       <p>
         Additional members may be present, if they are not understood,
@@ -551,7 +548,7 @@
     <section class="normative">
       <h2>Securing Verifiable Credentials</h2>
       <p>The <a data-cite="VC-DATA-MODEL#proof-formats"></a> describes the approach taken by JSON Web
-        Tokens to secure claimsets as <i>applying an
+        Tokens to secure JWT Claims Sets as <i>applying an
         <code>external proof</code></i>.
       </p>
       <p>The normative statements in <a data-cite="VC-DATA-MODEL#securing-verifiable-credentials">Securing
@@ -615,23 +612,23 @@
           Requirements</a>.
       </p>
       <p>
-        Accordingly, Issuers, Holders and Verifiers MUST understand the
+        Accordingly, Issuers, Holders, and Verifiers MUST understand the
         JSON Web Token header parameter
         <code>"alg": "none"</code> when securing the [[VC-DATA-MODEL]]
         with JSON Web Tokens.
       </p>
       <p>
         When content types from the [[VC-DATA-MODEL]] are secured using
-        JSON Web Tokens, the header parameter <code>"alg":
-        "none"</code>, MUST be used to communicate that a claimset (a
+        JSON Web Tokens, the header parameter <code>"alg": "none"</code>,
+	MUST be used to communicate that a JWT Claims Set (a
         Verifiable Credential or a Verifiable Presentation) has no
         integrity protection.
       </p>
       <p>
-        When a JSON Web Token claimset (a Verifiable Credential or a
+        When a JWT Claims Set (a Verifiable Credential or a
         Verifiable Presentation) contains
         <code>proof</code>, and the JSON Web Token header contains
-        <code>"alg": "none"</code>, the claimset MUST be considered to
+        <code>"alg": "none"</code>, the JWT Claims Set MUST be considered to
         have no integrity protection.
       </p>
       <p class="advisement">
@@ -639,7 +636,7 @@
         required to be secured or integrity protected or to contain a
         <code>proof</code> member.
       </p>
-      <p>Issuers, Holders and Verifiers MUST ignore all claimsets that
+      <p>Issuers, Holders, and Verifiers MUST ignore all JWT Claims Sets that
         have no integrity protection.</p>
     </section>
   
@@ -1243,7 +1240,7 @@ eyJhbGciOiJFUzM4NCIsInR5cCI6InZwK2xkK2p3dCIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19
       <p>The following examples are taken from <a data-cite="SD-JWT#name-example-4b-w3c-verifiable-c"></a>.</p>
       <p class="issue">These example are from a work in progress draft.</p>
       <p>
-        An issuer might start with a <code>vc+ld+json</code> claimset, for example:
+        An issuer might start with a <code>vc+ld+json</code> JWT Claims Set, for example:
       </p>
       <pre class="example">
 {
@@ -1286,7 +1283,7 @@ eyJhbGciOiJFUzM4NCIsInR5cCI6InZwK2xkK2p3dCIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19
 }
       </pre>
       <p>
-        The issuer converts this claimset into the SD-JWT payload, and encodes the token, for example:
+        The issuer converts this JWT Claims Set into the SD-JWT payload, and encodes the token, for example:
       </p>
       <pre class="example">
 eyJhbGciOiAiRVMyNTYifQ.eyJpc3MiOiAiaHR0cHM6Ly9leGFtcGxlLmNvbS9pc3N1Z
@@ -1336,7 +1333,7 @@ IsICI4ODMxMTAwMDAwMTUzNzYiXQ~
       </pre>
       <p>
         Notice that, in the case of sd-jwt, the decoded payload 
-        is different from the input claimset:
+        is different from the input JWT Claims Set:
       </p>
       <pre class="example">
 {


### PR DESCRIPTION
This replaces uses of non-standard names like "claimset" and inaccurate IANA registry names with the actual names from the specifications.  It also clarifies how many of the things named are used to align with the referenced specifications.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/vc-jose-cose/pull/156.html" title="Last updated on Sep 20, 2023, 10:17 PM UTC (f06fc20)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/156/bea8f07...selfissued:f06fc20.html" title="Last updated on Sep 20, 2023, 10:17 PM UTC (f06fc20)">Diff</a>