### PR TITLE
Update index.html: do not set the publish date in the editor's draft

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 
       // if you wish the publication date to be other than today, set
       // this 
-      publishDate: "2023-07-20",
+      // publishDate: "2023-07-20",
 
       // implementationReportURI:
       // "https://w3c.github.io/vc-test-suite/implementations/", errata:


### PR DESCRIPTION
This is an answer to #196 

What is "not being updated" is the editor's draft; the official draft on the W3C site is o.k. The reason is that the editor's draft includes an explicit publication date (and it should not, it should reflect the latest changes). This PR fixes that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/pull/197.html" title="Last updated on Dec 21, 2023, 5:47 PM UTC (38c716f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/197/a05dce7...38c716f.html" title="Last updated on Dec 21, 2023, 5:47 PM UTC (38c716f)">Diff</a>