### PR TITLE
Clarify semantics between jwt claims and vc properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,12 +414,21 @@ to ensure any addition JSON members are understood consistently.
         which represent the validity of the data that is being secured.
       </p>
       <p>
+        The claims and security provided by this specification are independent of the data 
+        secured and semantics provided by the [[VC-DATA-MODEL-2.0]]. This means that while the security
+        features of this specification ensure data integrity and authenticity, they do
+        not dictate the interpretation of claim data.
+        
+        Implementers are RECOMMENDED to avoid conflicting values, especially with claims such as
+        `issuer` with `iss`, `id` with `jti`, and `credentialSubject.id` with `sub`.
+      </p>
+      <p>
         The JWT Claim Names <code>vc</code> and <code>vp</code>
         MUST NOT be present.
       </p>
       <p>
         Additional members may be present as header parameters and claims.
-  If they are not understood, they MUST be ignored.
+        If they are not understood, they MUST be ignored.
       </p>
     </section>
   </section>

--- a/index.html
+++ b/index.html
@@ -418,9 +418,11 @@ to ensure any addition JSON members are understood consistently.
         secured and semantics provided by the [[VC-DATA-MODEL-2.0]]. This means that while the security
         features of this specification ensure data integrity and authenticity, they do
         not dictate the interpretation of claim data.
-        
-        Implementers are RECOMMENDED to avoid conflicting values, especially with claims such as
-        `issuer` with `iss`, `id` with `jti`, and `credentialSubject.id` with `sub`.
+      </p>
+      <p>
+        Implementers SHOULD avoid setting JWT claims to values that conflict with
+        verifiable credential properties, especially with pairs such as
+        `iss` and `issuer`, `jti` and `id`, and `sub` and `credentialSubject.id`.
       </p>
       <p>
         The JWT Claim Names <code>vc</code> and <code>vp</code>


### PR DESCRIPTION
fix #205 

open to feedback @msporny @selfissued


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 502 Bad Gateway :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 1, 2024, 8:58 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fvc-jose-cose%2F85b9bf10df7f79b8ea137b2d063a6d9825fabd5c%2Findex.html%3FisPreview%3Dtrue)

```
error code: 502
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/vc-jose-cose%23226.)._
</details>
