### PR TITLE
Fix section numbering

### DIFF
--- a/index.html
+++ b/index.html
@@ -1679,6 +1679,7 @@ credential</a> by a verifier.
         </tr>
       </table>
     </section>
+    </section>
 
     <section>
     <h2>Structured Syntax Suffixes</h2>


### PR DESCRIPTION
https://w3c.github.io/vc-jose-cose/#structured-syntax-suffixes needs to be up a level.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/vc-jose-cose/pull/253.html" title="Last updated on Mar 4, 2024, 5:25 PM UTC (7c6e750)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/253/f4b0bc6...selfissued:7c6e750.html" title="Last updated on Mar 4, 2024, 5:25 PM UTC (7c6e750)">Diff</a>