### PR TITLE
Render section references

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@
     If implementations do not know which media type to use, media types defined in this specification MUST be used.
     </p>
 
-    <section>
+    <section id="secure-with-jose">
       <h2>With JOSE</h2>
       <section>
         <h2>Securing JSON-LD Verifiable Credentials with JOSE</h2>
@@ -343,7 +343,7 @@
       </section>
     </section>
 
-    <section>
+    <section id="secure-with-sd-jwt">
       <h2>With SD-JWT</h2>
       <section>
         <h2>Securing JSON-LD Verifiable Credentials with SD-JWT</h2>
@@ -452,7 +452,7 @@
       </section>
     </section>
 
-    <section>
+    <section id="secure-with-cose">
       <h2>With COSE</h2>
       <p>
         COSE [[RFC9052]] is a common approach to encoding and securing
@@ -1325,43 +1325,43 @@ credential</a> by a verifier.
       <h2>Conformance Classes</h2>
       <p>
       A <dfn>conforming JWS document</dfn> is one that conforms to all of the
-      "MUST" statements in Section <a href="with-jose"></a>.
+      "MUST" statements in Section <a href="#secure-with-jose"></a>.
       </p>
       <p>
       A <dfn>conforming JWS issuer implementation</dfn> produces
       [=conforming JWS documents=] and MUST secure them as described in Section
-      <a href="with-jose"></a>.
+      <a href="#secure-with-jose"></a>.
       <p>
       A <dfn>conforming JWS verifier implementation</dfn> verifies
       [=conforming JWS documents=] as described in Section
-      <a href="with-jose"></a>.
+      <a href="#secure-with-jose"></a>.
       </p>
       <p>
       A <dfn>conforming SD-JWT document</dfn> is one that conforms to all of the
-      "MUST" statements in Section <a href="with-sd-jwt"></a>.
+      "MUST" statements in Section <a href="#secure-with-sd-jwt"></a>.
       </p>
       <p>
       A <dfn>conforming SD-JWT issuer implementation</dfn> produces
       [=conforming SD-JWT documents=] and MUST secure them as described in Section
-      <a href="with-sd-jwt"></a>.
+      <a href="#secure-with-sd-jwt"></a>.
       <p>
       A <dfn>conforming SD-JWT verifier implementation</dfn> verifies
       [=conforming SD-JWT documents=] as described in Section
-      <a href="with-sd-jwt"></a>.
+      <a href="#secure-with-sd-jwt"></a>.
       </p>
       <p>
       A <dfn>conforming COSE document</dfn> is one that conforms to all of the
-      "MUST" statements in Section <a href="with-cose"></a>.
+      "MUST" statements in Section <a href="#secure-with-cose"></a>.
       </p>
       <p>
       A <dfn>conforming COSE issuer implementation</dfn> produces
       [=conforming COSE documents=] and MUST secure them as described in Section
-      <a href="with-cose"></a>.
+      <a href="#secure-with-cose"></a>.
       </p>
       <p>
       A <dfn>conforming COSE verifier implementation</dfn> verifies
       [=conforming COSE documents=] as described in Section
-      <a href="with-cose"></a>.
+      <a href="#secure-with-cose"></a>.
       </p>
     </section>
     <section class="normative">

--- a/index.html
+++ b/index.html
@@ -1326,43 +1326,43 @@ credential</a> by a verifier.
       <h2>Conformance Classes</h2>
       <p>
       A <dfn>conforming JWS document</dfn> is one that conforms to all of the
-      "MUST" statements in Section <a href="secure-with-jose"></a>.
+      "MUST" statements in Section <a href="with-jose"></a>.
       </p>
       <p>
       A <dfn>conforming JWS issuer implementation</dfn> produces
       [=conforming JWS documents=] and MUST secure them as described in Section
-      <a href="secure-with-jose"></a>.
+      <a href="with-jose"></a>.
       <p>
       A <dfn>conforming JWS verifier implementation</dfn> verifies
       [=conforming JWS documents=] as described in Section
-      <a href="secure-with-jose"></a>.
+      <a href="with-jose"></a>.
       </p>
       <p>
       A <dfn>conforming SD-JWT document</dfn> is one that conforms to all of the
-      "MUST" statements in Section <a href="secure-with-sd-jwt"></a>.
+      "MUST" statements in Section <a href="with-sd-jwt"></a>.
       </p>
       <p>
       A <dfn>conforming SD-JWT issuer implementation</dfn> produces
       [=conforming SD-JWT documents=] and MUST secure them as described in Section
-      <a href="secure-with-sd-jwt"></a>.
+      <a href="with-sd-jwt"></a>.
       <p>
       A <dfn>conforming SD-JWT verifier implementation</dfn> verifies
       [=conforming SD-JWT documents=] as described in Section
-      <a href="secure-with-sd-jwt"></a>.
+      <a href="with-sd-jwt"></a>.
       </p>
       <p>
       A <dfn>conforming COSE document</dfn> is one that conforms to all of the
-      "MUST" statements in Section <a href="secure-with-cose"></a>.
+      "MUST" statements in Section <a href="with-cose"></a>.
       </p>
       <p>
       A <dfn>conforming COSE issuer implementation</dfn> produces
       [=conforming COSE documents=] and MUST secure them as described in Section
-      <a href="secure-with-cose"></a>.
+      <a href="with-cose"></a>.
       </p>
       <p>
       A <dfn>conforming COSE verifier implementation</dfn> verifies
       [=conforming COSE documents=] as described in Section
-      <a href="secure-with-cose"></a>.
+      <a href="with-cose"></a>.
       </p>
     </section>
     <section class="normative">

--- a/index.html
+++ b/index.html
@@ -236,8 +236,7 @@
     If implementations do not know which media type to use, media types defined in this specification MUST be used.
     </p>
 
-    <section id="secure-with-jose">
-
+    <section>
       <h2>With JOSE</h2>
       <section>
         <h2>Securing JSON-LD Verifiable Credentials with JOSE</h2>
@@ -344,7 +343,7 @@
       </section>
     </section>
 
-    <section id="secure-with-sd-jwt">
+    <section>
       <h2>With SD-JWT</h2>
       <section>
         <h2>Securing JSON-LD Verifiable Credentials with SD-JWT</h2>
@@ -453,7 +452,7 @@
       </section>
     </section>
 
-    <section id="secure-with-cose">
+    <section>
       <h2>With COSE</h2>
       <p>
         COSE [[RFC9052]] is a common approach to encoding and securing


### PR DESCRIPTION
Fixes #262 

I'm guessing that we need the href values to point to fragment identifiers created from the section names in order for them to render correctly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/vc-jose-cose/pull/263.html" title="Last updated on Mar 29, 2024, 7:13 AM UTC (d29dde5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/263/e728aea...selfissued:d29dde5.html" title="Last updated on Mar 29, 2024, 7:13 AM UTC (d29dde5)">Diff</a>