### PR TITLE
Renaming and updating the echidna action

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -17,4 +17,4 @@ jobs:
           W3C_WG_DECISION_URL: https://www.w3.org/2017/vc/WG/Meetings/Minutes/2023-04-12-vcwg#resolution1
           W3C_BUILD_OVERRIDE: |
              shortName: vc-jose-cose
-             specStatus: WD
+             specStatus: CRD


### PR DESCRIPTION
- the workflow file is again a .yml file, ready to go
- the spec status in the script is now set to CRD (for CR Draft)