### PR TITLE
Fix rendering; apply consistent html formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Securing Verifiable Credentials using JOSE and COSE</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
     <script class="remove"
-            src="https://cdn.jsdelivr.net/gh/w3c/vc-jose-cose@f90109dba46ef110cb7fce7b93821e0c43c48781/plugin/dist/main.js"></script>
+            src="https://cdn.jsdelivr.net/gh/w3c/vc-jose-cose@e7f73ef0060c2c8e4c1319ed6f3024eb8b622cf2/plugin/dist/main.js"></script>
     <script class="remove">
         // See https://github.com/w3c/respec/wiki/ for how to configure
         // ReSpec

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
   </section>
 
   <section id="introduction">
-    <h2>Introduction</h2>
+    <h2 id="section-introduction">Introduction</h2>
     <p>
       This specification defines how to secure media types
       expressing Verifiable Credentials and Verifiable Presentations
@@ -208,12 +208,12 @@
   </section>
 
   <section>
-    <h3>Terminology</h3>
+    <h3 id="terminology">Terminology</h3>
     <div data-include="./terms.html"></div>
   </section>
 
   <section>
-    <h2>Securing the VC Data Model</h2>
+    <h2 id="securing-the-vc-data-model">Securing the VC Data Model</h2>
     <p>
       This section outlines how to secure documents conforming
       to [[VC-DATA-MODEL-2.0]] using JOSE, SD-JWT, and COSE.
@@ -246,9 +246,9 @@
     </p>
 
     <section id="secure-with-jose">
-      <h2>With JOSE</h2>
+      <h2 id="with-jose">With JOSE</h2>
       <section>
-        <h2>Securing JSON-LD Verifiable Credentials with JOSE</h2>
+        <h2 id="securing-with-jose">Securing JSON-LD Verifiable Credentials with JOSE</h2>
         <p>
           This section details how to use JOSE to secure verifiable credentials conforming
           to [[VC-DATA-MODEL-2.0]].
@@ -299,7 +299,7 @@
       </section>
 
       <section>
-        <h2>Securing JSON-LD Verifiable Presentations with JOSE</h2>
+        <h2 id="securing-vps-with-jose">Securing JSON-LD Verifiable Presentations with JOSE</h2>
         <p>
           This section details how to use JOSE to secure verifiable presentations conforming
           to [[VC-DATA-MODEL-2.0]].
@@ -351,7 +351,7 @@
       </p>
       </section>
       <section class="normative">
-        <h2>JOSE Header Parameters and JWT Claims</h2>
+        <h2 id="jose-header-parameters-jwt-claims">JOSE Header Parameters and JWT Claims</h2>
 
         <p>
 When present in the <a data-cite="RFC7515#section-4">JOSE Header</a> or the
@@ -417,9 +417,9 @@ not understood, they MUST be ignored.
     </section>
 
     <section id="secure-with-sd-jwt">
-      <h2>With SD-JWT</h2>
+      <h2 id="with-sd-jwt">With SD-JWT</h2>
       <section>
-        <h2>Securing JSON-LD Verifiable Credentials with SD-JWT</h2>
+        <h2 id="securing-with-sd-jwt">Securing JSON-LD Verifiable Credentials with SD-JWT</h2>
         <p>
           This section details how to use JOSE to secure verifiable credentials conforming
           to [[VC-DATA-MODEL-2.0]].
@@ -474,7 +474,7 @@ unsecured [=verifiable credential=]) into an SD-JWT payload according to
       </section>
 
       <section>
-        <h2>Securing JSON-LD Verifiable Presentations with SD-JWT</h2>
+        <h2 id="securing-vps-sd-jwt">Securing JSON-LD Verifiable Presentations with SD-JWT</h2>
         <p>
           This section details how to use SD-JWT to secure verifiable presentations conforming
           to [[VC-DATA-MODEL-2.0]].
@@ -529,7 +529,7 @@ unsecured [=verifiable credential=]) into an SD-JWT payload according to
     </section>
 
     <section id="secure-with-cose">
-      <h2>With COSE</h2>
+      <h2 id="securing-with-cose">With COSE</h2>
       <p>
         COSE [[RFC9052]] is a common approach to encoding and securing
         information using CBOR [[RFC8949]]. Verifiable credentials MAY
@@ -538,7 +538,7 @@ unsecured [=verifiable credential=]) into an SD-JWT payload according to
       </p>
 
       <section>
-        <h2>Securing JSON-LD Verifiable Credentials with COSE</h2>
+        <h2 id="securing-vcs-with-cose">Securing JSON-LD Verifiable Credentials with COSE</h2>
         <p>
           This section details how to secure data with the type
           <code>application/vc+ld+json</code>
@@ -590,7 +590,7 @@ unsecured [=verifiable credential=]) into an SD-JWT payload according to
         </p>
       </section>
       <section>
-        <h2>Securing JSON-LD Verifiable Presentations with COSE</h2>
+        <h2 id="securing-vps-with-cose">Securing JSON-LD Verifiable Presentations with COSE</h2>
         <p>
           This section details how to use COSE to secure verifiable presentations conforming
           to [[VC-DATA-MODEL-2.0]].
@@ -634,7 +634,7 @@ unsecured [=verifiable credential=]) into an SD-JWT payload according to
         </p>
       </section>
       <section class="normative">
-        <h2>COSE Header Parameters and CWT Claims</h2>
+        <h2 id="cose-header-param-cwt-claims">COSE Header Parameters and CWT Claims</h2>
 
         <p>
 When present in the <a data-cite="RFC9052#section-3.1">COSE Header</a> or as
@@ -683,7 +683,7 @@ not understood, they MUST be ignored.
 
 
   <section id="key_discovery" class="normative">
-    <h2>Key Discovery</h2>
+    <h2 id="key-discovery">Key Discovery</h2>
       <p class="issue" data-number="160">
         The working group is still discussing how to close many related issues.
       </p>
@@ -792,13 +792,13 @@ not understood, they MUST be ignored.
 
 
     <section>
-      <h2>Using Header Parameters and Claims for Key Discovery</h2>
+      <h2 id="using-header-params-claims-key-discovery">Using Header Parameters and Claims for Key Discovery</h2>
       <p>
       These JOSE header parameters and JWT claims can be used by
       <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifiers</a> to discover verification keys.
       </p>
       <section>
-        <h2>kid</h2>
+        <h2 id="kid">kid</h2>
         <p>
       If <code>kid</code> is present in the <a data-cite="RFC7515#section-4.1">JOSE Header</a>
       or the <a data-cite="RFC9052#section-3">COSE Header</a>,
@@ -812,7 +812,7 @@ not understood, they MUST be ignored.
         </p>
       </section>
       <section>
-        <h2>iss</h2>
+        <h2 id="iss">iss</h2>
         <p>
       If <code>iss</code> is present in the <a data-cite="RFC7515#section-4.1">JOSE Header</a>,
       the <a data-cite="RFC7519#section-4.1.1">JWT Claims</a>,
@@ -835,7 +835,7 @@ not understood, they MUST be ignored.
       </section>
 
       <section>
-        <h2>cnf</h2>
+        <h2 id="cnf">cnf</h2>
         <p>
       If <code>cnf</code> is present in the <a data-cite="RFC7515#section-4.1">JOSE Header</a>,
       the <a data-cite="RFC7519#section-4.1.1">JWT Claims</a>,
@@ -854,7 +854,7 @@ not understood, they MUST be ignored.
       </section>
 
       <section>
-      <h2>Well-Known URIs</h2>
+      <h2 id="well-known-uris">Well-Known URIs</h2>
       <p class="issue" data-number="160">
       The working group is currently exploring how
       <a data-cite="RFC5785#section-3">Defining Well-Known Uniform Resource Identifiers (URIs)</a>
@@ -864,7 +864,7 @@ not understood, they MUST be ignored.
       </p>
 
       <section>
-        <h2>JWT Issuer</h2>
+        <h2 id="jwt-issuer">JWT Issuer</h2>
             <p>
               When the issuer value is a URL using the HTTPS scheme,
               issuer metadata including the issuer's public keys can be retrieved using the mechanism
@@ -879,7 +879,7 @@ not understood, they MUST be ignored.
           </section>
         </section>
         <section>
-        <h3>Controller Documents</h3>
+        <h3 id="controller-documents">Controller Documents</h3>
           <p>
 A <a>controller document</a> is a set of data that specifies one or more
 relationships between a <a>controller</a> and a set of data, such as a set of
@@ -890,7 +890,7 @@ certain <a>verification methods</a> for specific purposes.
 
 
         <section>
-          <h2>Verification Methods</h2>
+          <h2 id="verification-methods">Verification Methods</h2>
             <p>
 A <a>controller document</a> can express <a>verification methods</a>, such as
 cryptographic <a>public keys</a>, which can be used to <a>authenticate</a> or
@@ -985,7 +985,7 @@ using the `<a>controller</a>` property at the highest level of the
           </p>
 
           <section>
-            <h3>Verification Material</h3>
+            <h3 id="verification-material">Verification Material</h3>
 
             <p>
 Verification material MUST be expressed in the <code>publicKeyJwk</code> property
@@ -1044,7 +1044,7 @@ methods</a> using both properties above is shown below.
 
 
           <section>
-            <h3>JsonWebKey</h3>
+            <h3 id="json-web-key">JsonWebKey</h3>
             <p>
 The JSON Web Key (JWK) is a specific type of <a>verification method</a>
 that uses the JWK specification [[RFC7517]] to encode key types into a
@@ -1160,7 +1160,7 @@ the secp384r1 curve that is associated with the public key).
           </section>
 
           <section>
-            <h3>Referring to Verification Methods</h3>
+            <h3 id="referring-to-verification-methods">Referring to Verification Methods</h3>
             <p>
 <a>Verification methods</a> can be referenced from properties
 associated with various <a>verification relationships</a> as described in <a
@@ -1196,7 +1196,7 @@ is done by dereferencing the URL and searching the resulting <a>resource</a> for
         </section>
 
         <section>
-          <h2>Verification Relationships</h2>
+          <h2 id="verification-relationships">Verification Relationships</h2>
 
           <p>
 A <a>verification relationship</a> expresses the relationship between the
@@ -1231,7 +1231,7 @@ interoperability, any such properties used SHOULD be registered in the
 <a data-cite="VC-SPECS-DIR#securing-mechanisms">VC Specifications Directory</a>.
           </p>
           <section>
-            <h2>Authentication</h2>
+            <h2 id="authentication">Authentication</h2>
 
             <p>
 The `authentication` <a>verification relationship</a> is used to
@@ -1292,7 +1292,7 @@ the value of `controller` needs to <a>authenticate</a> with its
           </section>
 
           <section>
-            <h2>Assertion</h2>
+            <h2 id="assertion">Assertion</h2>
 
             <p>
 The `assertionMethod` <a>verification relationship</a> is used to
@@ -1336,7 +1336,7 @@ credential</a> by a verifier.
 
   <section id="conformance">
     <section class="normative">
-      <h2>Conformance Classes</h2>
+      <h2 id="conformance-classes">Conformance Classes</h2>
       <p>
       A <dfn>conforming JWS document</dfn> is one that conforms to all of the
       "MUST" statements in Section <a href="#secure-with-jose"></a>.
@@ -1379,7 +1379,7 @@ credential</a> by a verifier.
       </p>
     </section>
     <section class="normative">
-      <h2>Securing Verifiable Credentials</h2>
+      <h2 id="securing-verifiable-credentials">Securing Verifiable Credentials</h2>
       <p>The <a data-cite="VC-DATA-MODEL-2.0#securing-mechanism-specifications"></a> describes 
         the approach taken by JSON Web Tokens to secure JWT Claims Sets as <i>applying an
         <code>external proof</code></i>.
@@ -1432,13 +1432,13 @@ credential</a> by a verifier.
   </section>
 
   <section class="normative">
-    <h2>IANA Considerations</h2>
+    <h2 id="iana-considerations">IANA Considerations</h2>
 
     <section>
-    <h2>Media Types</h2>
+    <h2 id="media-types">Media Types</h2>
 
     <section id="vc-ld-jwt-media-type">
-      <h2><code>application/vc+ld+json+jwt</code></h2>
+      <h2 id="vcc-ld-json-jwt"><code>application/vc+ld+json+jwt</code></h2>
       <p>
         This specification registers the
         <code>application/vc+ld+json+jwt</code> Media Type specifically for
@@ -1484,7 +1484,7 @@ credential</a> by a verifier.
     </section>
 
     <section id="vp-ld-jwt-media-type">
-      <h2><code>application/vp+ld+json+jwt</code></h2>
+      <h2 id="vp-ld-json-jwt"><code>application/vp+ld+json+jwt</code></h2>
       <p>
         This specification registers the
         <code>application/vp+ld+json+jwt</code> Media Type specifically for
@@ -1530,7 +1530,7 @@ credential</a> by a verifier.
     </section>
 
     <section id="vc-ld-sd-jwt-media-type">
-      <h2><code>application/vc+ld+json+sd-jwt</code></h2>
+      <h2 id="vc-ld-json-sd-jwt"><code>application/vc+ld+json+sd-jwt</code></h2>
       <p>
         This specification registers the
         <code>application/vc+ld+json+sd-jwt</code> Media Type specifically for
@@ -1576,7 +1576,7 @@ credential</a> by a verifier.
     </section>
 
     <section id="vp-ld-sd-jwt-media-type">
-      <h2><code>application/vp+ld+json+sd-jwt</code></h2>
+      <h2 id="vp-ld-json-sd-jwt"><code>application/vp+ld+json+sd-jwt</code></h2>
       <p>
         This specification registers the
         <code>application/vp+ld+json+sd-jwt</code> Media Type specifically for
@@ -1622,7 +1622,7 @@ credential</a> by a verifier.
     </section>
 
     <section id="vc-ld-json-cose-media-type">
-      <h2><code>application/vc+ld+json+cose</code></h2>
+      <h2 id="vc-ld-json-cose"><code>application/vc+ld+json+cose</code></h2>
       <p>
         This specification registers the
         <code>application/vc+ld+json+cose</code> Media Type specifically for
@@ -1667,7 +1667,7 @@ credential</a> by a verifier.
     </section>
 
     <section id="vp-ld-json-cose-media-type">
-      <h2><code>application/vp+ld+json+cose</code></h2>
+      <h2 id="vp-ld-json-cose"><code>application/vp+ld+json+cose</code></h2>
       <p>
         This specification registers the
         <code>application/vp+ld+json+cose</code> Media Type specifically for
@@ -1713,10 +1713,10 @@ credential</a> by a verifier.
     </section>
 
     <section>
-    <h2>Structured Syntax Suffixes</h2>
+    <h2 id="structured-syntax-suffixes">Structured Syntax Suffixes</h2>
 
     <section id="ld-json-jwt-suffix">
-      <h2><code>+ld+json+jwt</code></h2>
+      <h2 id="ld-json-jwt"><code>+ld+json+jwt</code></h2>
       <p>
         This specification registers the
         <code>+ld+json+jwt</code> Structured Suffix
@@ -1770,7 +1770,7 @@ credential</a> by a verifier.
     </section>
 
     <section id="json-jwt-suffix">
-      <h2><code>+json+jwt</code></h2>
+      <h2 id="json-jwt"><code>+json+jwt</code></h2>
       <p>
         This specification registers the
         <code>+json+jwt</code> Structured Suffix
@@ -1824,7 +1824,7 @@ credential</a> by a verifier.
     </section>
 
     <section id="ld-json-sd-jwt-suffix">
-      <h2><code>+ld+json+sd-jwt</code></h2>
+      <h2 id="ld-json-sd-jwt"><code>+ld+json+sd-jwt</code></h2>
       <p>
         This specification registers the
         <code>+ld+json+sd-jwt</code> Structured Suffix
@@ -1878,7 +1878,7 @@ credential</a> by a verifier.
     </section>
 
     <section id="json-sd-jwt-suffix">
-      <h2><code>+json+sd-jwt</code></h2>
+      <h2 id="json-sd-jwt"><code>+json+sd-jwt</code></h2>
       <p>
         This specification registers the
         <code>+json+sd-jwt</code> Structured Suffix
@@ -1932,7 +1932,7 @@ credential</a> by a verifier.
     </section>
 
     <section id="ld-json-cose-suffix">
-      <h2><code>+ld+json+cose</code></h2>
+      <h2 id="ls-json-cose"><code>+ld+json+cose</code></h2>
       <p>
         This specification registers the
         <code>+ld+json+cose</code> Structured Suffix
@@ -1985,7 +1985,7 @@ credential</a> by a verifier.
     </section>
 
     <section id="json-cose-suffix">
-      <h2><code>+json+cose</code></h2>
+      <h2 id="json-cose"><code>+json+cose</code></h2>
       <p>
         This specification registers the
         <code>+json+cose</code> Structured Suffix
@@ -2041,10 +2041,10 @@ credential</a> by a verifier.
 
 </section>
   <section>
-    <h3>Other Considerations</h3>
+    <h3 id="other-considerations">Other Considerations</h3>
 
     <section>
-      <h2>Privacy Considerations</h2>
+      <h2 id="privacy-considerations">Privacy Considerations</h2>
       <p>
         Verifiable Credentials often contain sensitive information that
         needs to be protected to ensure the privacy and security of
@@ -2100,7 +2100,7 @@ credential</a> by a verifier.
       </p>
     </section>
     <section>
-      <h2>Security Considerations</h2>
+      <h2 id="security-considerations">Security Considerations</h2>
       <p>
         This section outlines security considerations for implementers
         and users of this specification. It is important to carefully
@@ -2148,7 +2148,7 @@ credential</a> by a verifier.
       </p>
     </section>
     <section class="informative">
-      <h2>Accessibility</h2>
+      <h2 id="accessibility">Accessibility</h2>
       <p>
         When implementing this specification, it is crucial for
         technical implementers to consider various accessibility
@@ -2170,9 +2170,9 @@ credential</a> by a verifier.
 
 
   <section class="informative">
-    <h3>Examples</h3>
+    <h3 id="examples">Examples</h3>
     <section>
-      <h2>Controllers</h2>
+      <h2 id="controllers">Controllers</h2>
 
       <pre class="example" title="A minimal controller document">
         {
@@ -2293,7 +2293,7 @@ credential</a> by a verifier.
 
     </section>
     <section>
-      <h3>Credentials</h3>
+      <h3 id="credentials">Credentials</h3>
       <pre class="example vc-jose-cose" title="A revocable credential with multiple subjects">
 {
   "@context": ["https://www.w3.org/ns/credentials/v2",
@@ -2346,9 +2346,7 @@ credential</a> by a verifier.
     </section>
 
     <section>
-      <h2>
-        Presentations
-      </h2>
+      <h2 id="presentations">Presentations</h2>
 
       <pre class="example vc-jose-cose" title="Presentation">
 {
@@ -2380,7 +2378,7 @@ credential</a> by a verifier.
     </section>
 
     <section>
-      <h3>Data URIs</h3>
+      <h3 id="date-uris">Data URIs</h3>
       <pre class="example" title="A simple URI-encoded Verifiable Credential">
 data:application/vc+ld+json+sd-jwt;eyJhbGciOiJFUzM4NCIsImtpZCI6IlNJM1JITm91aDhvODFOT09OUFFVQUw3RWdaLWtJNl94ajlvUkV2WDF4T3ciLCJ0eXAiOiJ2YytsZCtqc29uK3NkLWp3dCIsImN0eSI6InZjK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiX3NkIjpbIkU3dU1sSWFyS29iYXJTdEZGRjctZm5qaV9sQVdnM3BGMkV5dVc4dWFYakUiLCJYelRaSVgyNGdDSWxSQVFHclFoNU5FRm1XWkQtZ3Z3dkIybzB5Y0FwNFZzIl19LCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJfc2QiOlsiT3oxUEZIMG0tWk9TdEhwUVZyeGlmVlpKRzhvNmlQQmNnLVZ2SXQwd2plcyJdfSwiX3NkIjpbIkVZQ1daMTZZMHB5X1VNNzRHU3NVYU9zT19mdDExTlVSaFFUTS1TT1lFTVEiXX0sIl9zZCI6WyJqT055NnZUbGNvVlAzM25oSTdERGN3ekVka3d2R3VVRXlLUjdrWEVLd3VVIiwid21BdHpwc0dRbDJveS1PY2JrSEVZcE8xb3BoX3VYcWVWVTRKekF0aFFibyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vdW5pdmVyc2l0eS5leGFtcGxlL2lzc3VlcnMvNTY1MDQ5IiwiaWF0IjoxNjk3Mjg5OTk2LCJleHAiOjE3Mjg5MTIzOTYsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6InZFdV84WGxZT0ZFU2hTcVRpZ2JSYWduZ0ZGM1p5U0xrclNHekh3azFBT1loanhlazVhV21HY2UwZU05S0pWOEIiLCJ5IjoiRUpNY2czWXBzUTB3M2RLNHlVa25QczE1Z0lsY2Yyay03dzFKLTNlYlBiOERENmQtUkhBeGUwMDkzSWpfdTRCOSJ9fX0.rYzbxb6j1dwop8_s491iArVVJNm6A6C3b742gOm_qYO3zdkyQU4_VxxOSJ8ECcmWj2r5KyiCNC1ojfO4Yms-zBsjt7PoMYpYWBplsqXpiIvnehmM7D0eOLi40uHXki0X~WyJSWTg1YTZNMmEwX3VDWlFTVGZmTFdRIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJMeG5GYTBXVm8wRUluVy1QdS1fd1dRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJUQVdrakpCaVpxdC1rVU54X1EweUJBIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJTd2xuZFpPZzZEZ1ZERFp5X0RvYVFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJuSnJlU3E1Nzg3RGZMSDJCbU03cXFRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyIxMjNNd3hNcHRiek02YUk2aW03ME1RIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ
       </pre>
@@ -2391,9 +2389,7 @@ data:application/vp+ld+json+sd-jwt;eyJhbGciOiJFUzM4NCIsImtpZCI6IlNJM1JITm91aDhvO
     </section>
 
     <section>
-      <h2>
-        COSE Examples
-      </h2>
+      <h2 id="cose-examples">COSE Examples</h2>
       <p>
 These examples rely on <a data-cite="RFC7049#section-6">CBOR Diagnostic Notation</a>.
 Remember that all actual interchange always happens in the binary format.
@@ -2451,7 +2447,7 @@ The payload can be either a credential or presentation as described in
     </section>
   </section>
   <section>
-    <h2>Verification Algorithms</h2>
+    <h2 id="verification-algorithms">Verification Algorithms</h2>
     <p>
 This specification might be used with many different key discovery protocols.
 Therefore, discovery of verification keys is described in <a href="#key_discovery"></a>,
@@ -2482,7 +2478,7 @@ The outputs for the following algorithms are:
         </li>
     </ul>
     <section>
-      <h3>Algorithm for Verifying a Credential or Presentation Secured with JOSE</h3>
+      <h3 id="alg-jose">Algorithm for Verifying a Credential or Presentation Secured with JOSE</h3>
       <p>
       The inputs for this algorithm are:
       </p>
@@ -2541,7 +2537,7 @@ Return
       </ol>
     </section>
     <section>
-      <h3>Algorithm for Verifying a Credential or Presentation Secured with SD-JWT</h3>
+      <h3 id="alg-sd-jwt">Algorithm for Verifying a Credential or Presentation Secured with SD-JWT</h3>
       <p>
 The inputs for this algorithm are:
       </p>
@@ -2603,7 +2599,7 @@ If processing aborts for any reason or the SD-JWT is rejected:
       </ol>
     </section>
     <section>
-      <h3>Algorithm for Verifying a Credential or Presentation Secured with COSE</h3>
+      <h3 id="alg-cose">Algorithm for Verifying a Credential or Presentation Secured with COSE</h3>
       <p>
 The inputs for this algorithm are:
       </p>
@@ -2668,7 +2664,7 @@ Return
   </section>
 
   <section>
-    <h2>Validation Algorithm</h2>
+    <h2 id="validation-algorithms">Validation Algorithm</h2>
 
     <p>
 All claims expected for the <code>typ</code> MUST be present.

--- a/index.html
+++ b/index.html
@@ -2,272 +2,276 @@
 <html lang="en">
 
 <head>
-  <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
-  <title>Securing Verifiable Credentials using JOSE and COSE</title>
-  <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
-  <script class="remove" src="https://cdn.jsdelivr.net/gh/w3c/vc-jose-cose@357a6d2414985efadf6fa2f5cfb3ddf280de301c/plugin/dist/main.js"></script>
-  <script class="remove">
-    // See https://github.com/w3c/respec/wiki/ for how to configure
-    // ReSpec
-    var respecConfig = {
-      group: "vc",
+    <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
+    <title>Securing Verifiable Credentials using JOSE and COSE</title>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+    <script class="remove"
+            src="https://cdn.jsdelivr.net/gh/w3c/vc-jose-cose@f90109dba46ef110cb7fce7b93821e0c43c48781/plugin/dist/main.js"></script>
+    <script class="remove">
+        // See https://github.com/w3c/respec/wiki/ for how to configure
+        // ReSpec
+        var respecConfig = {
+            group: "vc",
 
-      // specification status (e.g., WD, NOTE, etc.). If in doubt use
-      // ED.
-      specStatus: "CR",
-      crEnd: "2024-05-25",
+            // specification status (e.g., WD, NOTE, etc.). If in doubt use
+            // ED.
+            specStatus: "CR",
+            crEnd: "2024-05-25",
 
-      // the specification's short name, as in
-      // http://www.w3.org/TR/short-name/
-      shortName: "vc-jose-cose",
+            // the specification's short name, as in
+            // http://www.w3.org/TR/short-name/
+            shortName: "vc-jose-cose",
 
-      // if you wish the publication date to be other than today, set
-      // this
-      // publishDate: "2024-04-25",
+            // if you wish the publication date to be other than today, set
+            // this
+            // publishDate: "2024-04-25",
 
-      implementationReportURI: "https://w3c.github.io/vc-jose-cose-test-suite/",
-      // errata:  "https://w3c.github.io/vc-data-model/errata.html",
+            implementationReportURI: "https://w3c.github.io/vc-jose-cose-test-suite/",
+            // errata:  "https://w3c.github.io/vc-data-model/errata.html",
 
-      // if there is a previously published draft, uncomment this and
-      // set its YYYY-MM-DD date and its maturity status
-      previousPublishDate:  "2023-07-10",
-      previousMaturity:  "WD",
+            // if there is a previously published draft, uncomment this and
+            // set its YYYY-MM-DD date and its maturity status
+            previousPublishDate: "2023-07-10",
+            previousMaturity: "WD",
 
-      // extend the bibliography entries localBiblio: vcwg.localBiblio,
-      doJsonLd: true,
+            // extend the bibliography entries localBiblio: vcwg.localBiblio,
+            doJsonLd: true,
 
-      // Uncomment these to use the respec extension that generates a
-      //   list of normative statements: preProcess: [], postProcess:
-      //   [],
+            // Uncomment these to use the respec extension that generates a
+            //   list of normative statements: preProcess: [], postProcess:
+            //   [],
 
-      github: "https://github.com/w3c/vc-jose-cose/",
-      includePermalinks: false,
+            github: "https://github.com/w3c/vc-jose-cose/",
+            includePermalinks: false,
 
-      // if there a publicly available Editor's Draft, this is the link
-      edDraftURI: "https://w3c.github.io/vc-jose-cose/",
+            // if there a publicly available Editor's Draft, this is the link
+            edDraftURI: "https://w3c.github.io/vc-jose-cose/",
 
-      // editors, add as many as you like only "name" is required
-      editors: [
-        {
-          name: "Michael Jones",
-          url: "https://self-issued.info/",
-          company: "Self-Issued Consulting",
-          w3cid: 38745,
-        },
-        {
-          name: "Michael Prorock",
-          company: "Mesur.io", companyURL: "https://mesur.io/",
-          w3cid: 130636
-        },
-        {
-          name: "Gabe Cohen",
-          url: "https://github.com/decentralgabe",
-          company: "Block",
-          companyURL: "https://www.tbd.website",
-          w3cid: 116851
-        }
-      ],
-      // authors, add as many as you like. This is optional, uncomment
-      // if you have authors as well as editors. only "name" is
-      // required. Same format as editors.
-      authors: [],
-      formerEditors: [{
-          name: "Orie Steele",
-          company: "Transmute",
-          companyURL: "https://transmute.industries",
-          w3cid: 109171,
-        }],
+            // editors, add as many as you like only "name" is required
+            editors: [
+                {
+                    name: "Michael Jones",
+                    url: "https://self-issued.info/",
+                    company: "Self-Issued Consulting",
+                    w3cid: 38745,
+                },
+                {
+                    name: "Michael Prorock",
+                    company: "Mesur.io", companyURL: "https://mesur.io/",
+                    w3cid: 130636
+                },
+                {
+                    name: "Gabe Cohen",
+                    url: "https://github.com/decentralgabe",
+                    company: "Block",
+                    companyURL: "https://www.tbd.website",
+                    w3cid: 116851
+                }
+            ],
+            // authors, add as many as you like. This is optional, uncomment
+            // if you have authors as well as editors. only "name" is
+            // required. Same format as editors.
+            authors: [],
+            formerEditors: [{
+                name: "Orie Steele",
+                company: "Transmute",
+                companyURL: "https://transmute.industries",
+                w3cid: 109171,
+            }],
 
-      maxTocLevel: 3,
-      inlineCSS: true,
-      postProcess: [window.respecVcJoseCose.processVcJoseCose],
-      license: "w3c-software-doc",
-      xref: true,
-      otherLinks: [{
-        key: "Related Documents",
-        data: [{
-          value: "VC Data Model",
-          href: "https://www.w3.org/TR/vc-data-model-2.0/"
-        }, {
-          value: "DID Core",
-          href: "https://www.w3.org/TR/did-core/"
-        }]
-      }],
-      localBiblio:  {
-        "SD-JWT": {
-          title:    "Selective Disclosure for JWTs (SD-JWT)",
-          href:     "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt",
-          authors:  [ "Daniel Fett" , "Kristina Yasuda" , "Brian Campbell"],
-          status:   "Internet-Draft",
-          publisher:  "IETF"
-        },
-        "SD-JWT-VC": {
-          title:    "SD-JWT-based Verifiable Credentials (SD-JWT VC)",
-          href:     "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc",
-          authors:  [ "Oliver Terbu", "Daniel Fett", "Brian Campbell" ],
-          status:   "Internet-Draft",
-          publisher:  "IETF"
-        },
-        "MULTIPLE-SUFFIXES": {
-          title:    "Media Types with Multiple Suffixes",
-          href:     "https://datatracker.ietf.org/doc/draft-ietf-mediaman-suffixes/",
-          authors:  [   "Manu Sporny" , "Amy Guy" ],
-          status:   "Internet-Draft",
-          publisher:  "IETF"
-        },
-        "JOSE-REGISTRIES": {
-          title:    "The JSON Object Signing and Encryption (JOSE) Registries",
-          href:     "https://www.iana.org/assignments/jose",
-          authors:  ["The Internet Assigned Numbers Authority"],
-          status:   "REC",
-          publisher:  "The Internet Assigned Numbers Authority"
-        },
-        "IANA-STRUCTURED-SUFFIX": {
-          title:    "Structured Syntax Suffixes",
-          href:     "https://www.iana.org/assignments/media-type-structured-suffix/",
-          authors:  ["The Internet Assigned Numbers Authority"],
-          status:   "REC",
-          publisher:  "The Internet Assigned Numbers Authority"
-        },
-      }
-    };
-  </script>
+            maxTocLevel: 3,
+            inlineCSS: true,
+            postProcess: [window.respecVcJoseCose.processVcJoseCose],
+            license: "w3c-software-doc",
+            xref: true,
+            otherLinks: [{
+                key: "Related Documents",
+                data: [{
+                    value: "VC Data Model",
+                    href: "https://www.w3.org/TR/vc-data-model-2.0/"
+                }, {
+                    value: "DID Core",
+                    href: "https://www.w3.org/TR/did-core/"
+                }]
+            }],
+            localBiblio: {
+                "SD-JWT": {
+                    title: "Selective Disclosure for JWTs (SD-JWT)",
+                    href: "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt",
+                    authors: ["Daniel Fett", "Kristina Yasuda", "Brian Campbell"],
+                    status: "Internet-Draft",
+                    publisher: "IETF"
+                },
+                "SD-JWT-VC": {
+                    title: "SD-JWT-based Verifiable Credentials (SD-JWT VC)",
+                    href: "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc",
+                    authors: ["Oliver Terbu", "Daniel Fett", "Brian Campbell"],
+                    status: "Internet-Draft",
+                    publisher: "IETF"
+                },
+                "MULTIPLE-SUFFIXES": {
+                    title: "Media Types with Multiple Suffixes",
+                    href: "https://datatracker.ietf.org/doc/draft-ietf-mediaman-suffixes/",
+                    authors: ["Manu Sporny", "Amy Guy"],
+                    status: "Internet-Draft",
+                    publisher: "IETF"
+                },
+                "JOSE-REGISTRIES": {
+                    title: "The JSON Object Signing and Encryption (JOSE) Registries",
+                    href: "https://www.iana.org/assignments/jose",
+                    authors: ["The Internet Assigned Numbers Authority"],
+                    status: "REC",
+                    publisher: "The Internet Assigned Numbers Authority"
+                },
+                "IANA-STRUCTURED-SUFFIX": {
+                    title: "Structured Syntax Suffixes",
+                    href: "https://www.iana.org/assignments/media-type-structured-suffix/",
+                    authors: ["The Internet Assigned Numbers Authority"],
+                    status: "REC",
+                    publisher: "The Internet Assigned Numbers Authority"
+                },
+            }
+        };
+    </script>
 </head>
 
 <body>
-  <section id="abstract">
+<section id="abstract">
     <p>
-      This specification defines how to secure credentials and presentations
-      conforming to the Verifiable Credential data model [[VC-DATA-MODEL-2.0]]
-      with JSON Object Signing and Encryption (<a href="https://datatracker.ietf.org/wg/jose/about/">JOSE</a>),
-      Selective Disclosure for JWTs [[SD-JWT]],
-      and CBOR Object Signing and Encryption (COSE) [[RFC9052]].
-      This enables the Verifiable Credential data model
-      [[VC-DATA-MODEL-2.0]] to be implemented with standards
-      for signing and encryption that are widely adopted.
+        This specification defines how to secure credentials and presentations
+        conforming to the Verifiable Credential data model [[VC-DATA-MODEL-2.0]]
+        with JSON Object Signing and Encryption (<a href="https://datatracker.ietf.org/wg/jose/about/">JOSE</a>),
+        Selective Disclosure for JWTs [[SD-JWT]],
+        and CBOR Object Signing and Encryption (COSE) [[RFC9052]].
+        This enables the Verifiable Credential data model
+        [[VC-DATA-MODEL-2.0]] to be implemented with standards
+        for signing and encryption that are widely adopted.
     </p>
-  </section>
-  <section id="sotd">
+</section>
+<section id="sotd">
     <p>
-      The Working Group is actively seeking implementation feedback for this
-      specification. In order to exit the Candidate Recommendation phase, the
-      Working Group has set the requirement of at least two independent
-      implementations for each mandatory feature in the specification. For details
-      on the conformance testing process, see the test suite listed in the
-      <a href="https://w3c.github.io/vc-jose-cose-test-suite/">
-      implementation report</a>.
+        The Working Group is actively seeking implementation feedback for this
+        specification. In order to exit the Candidate Recommendation phase, the
+        Working Group has set the requirement of at least two independent
+        implementations for each mandatory feature in the specification. For details
+        on the conformance testing process, see the test suite listed in the
+        <a href="https://w3c.github.io/vc-jose-cose-test-suite/">
+            implementation report</a>.
     </p>
-  </section>
+</section>
 
-  <section id="introduction">
+<section id="introduction">
     <h2 id="section-introduction">Introduction</h2>
     <p>
-      This specification defines how to secure media types
-      expressing Verifiable Credentials and Verifiable Presentations
-      as described in [[VC-DATA-MODEL-2.0]] using approaches
-      defined by the JOSE, OAuth, and COSE working groups at the IETF.
-      This includes JSON Web Signature (JWS) [[RFC7515]],
-      Selective Disclosure for JWTs [[SD-JWT]],
-      and CBOR Object Signing and Encryption (COSE) [[RFC9052]].
-      It uses content types [[RFC6838]] and structured suffixes [[MULTIPLE-SUFFIXES]]
-      to distinguish between the data types of unsecured documents
-      conforming to [[VC-DATA-MODEL-2.0]]
-      and the data types of secured documents conforming to [[VC-DATA-MODEL-2.0]].
+        This specification defines how to secure media types
+        expressing Verifiable Credentials and Verifiable Presentations
+        as described in [[VC-DATA-MODEL-2.0]] using approaches
+        defined by the JOSE, OAuth, and COSE working groups at the IETF.
+        This includes JSON Web Signature (JWS) [[RFC7515]],
+        Selective Disclosure for JWTs [[SD-JWT]],
+        and CBOR Object Signing and Encryption (COSE) [[RFC9052]].
+        It uses content types [[RFC6838]] and structured suffixes [[MULTIPLE-SUFFIXES]]
+        to distinguish between the data types of unsecured documents
+        conforming to [[VC-DATA-MODEL-2.0]]
+        and the data types of secured documents conforming to [[VC-DATA-MODEL-2.0]].
     </p>
     <p>
-      JSON Web Signature (JWS) [[RFC7515]] defines a standard means of
-      digitally signing documents, including JSON documents,
-      using JSON-based data structures.
-      It provides a means to ensure the integrity, authenticity,
-      and non-repudiation of the information contained in the document.
-      Selective Disclosure for JWTs (SD-JWT) [[SD-JWT]] builds on JWS by also
-      providing a mechanism enabling selective disclosure of document elements.
-      These properties make JWS and SD-JWT especially well suited to
-      securing documents conforming to [[VC-DATA-MODEL-2.0]].
+        JSON Web Signature (JWS) [[RFC7515]] defines a standard means of
+        digitally signing documents, including JSON documents,
+        using JSON-based data structures.
+        It provides a means to ensure the integrity, authenticity,
+        and non-repudiation of the information contained in the document.
+        Selective Disclosure for JWTs (SD-JWT) [[SD-JWT]] builds on JWS by also
+        providing a mechanism enabling selective disclosure of document elements.
+        These properties make JWS and SD-JWT especially well suited to
+        securing documents conforming to [[VC-DATA-MODEL-2.0]].
     </p>
     <p>
-      CBOR Object Signing and Encryption (COSE) [[RFC9052]] defines
-      a standard means of representing digitally signed data structures
-      using Concise Binary Object Representation (CBOR) [[RFC8949]].
-      Like JWS, COSE provides a standardized way to secure the
-      integrity, authenticity, and confidentiality of information.
-      It offers a flexible and extensible set of
-      cryptographic options, allowing for a wide range of algorithms
-      to be used for signing and encryption.
+        CBOR Object Signing and Encryption (COSE) [[RFC9052]] defines
+        a standard means of representing digitally signed data structures
+        using Concise Binary Object Representation (CBOR) [[RFC8949]].
+        Like JWS, COSE provides a standardized way to secure the
+        integrity, authenticity, and confidentiality of information.
+        It offers a flexible and extensible set of
+        cryptographic options, allowing for a wide range of algorithms
+        to be used for signing and encryption.
     </p>
     <p>
-      COSE supports two main operations: signing and encryption. For
-      signing, COSE allows the creation of digital signatures over
-      CBOR data using various algorithms such as RSA, ECDSA, and
-      EdDSA. These signatures provide assurance of data integrity and
-      authenticity. COSE also supports encryption, enabling the
-      confidentiality of CBOR data by encrypting it with symmetric or
-      asymmetric encryption algorithms.
+        COSE supports two main operations: signing and encryption. For
+        signing, COSE allows the creation of digital signatures over
+        CBOR data using various algorithms such as RSA, ECDSA, and
+        EdDSA. These signatures provide assurance of data integrity and
+        authenticity. COSE also supports encryption, enabling the
+        confidentiality of CBOR data by encrypting it with symmetric or
+        asymmetric encryption algorithms.
     </p>
 
-  </section>
+</section>
 
-  <section>
+<section>
     <h3 id="terminology">Terminology</h3>
     <div data-include="./terms.html"></div>
-  </section>
+</section>
 
-  <section>
+<section>
     <h2 id="securing-the-vc-data-model">Securing the VC Data Model</h2>
     <p>
-      This section outlines how to secure documents conforming
-      to [[VC-DATA-MODEL-2.0]] using JOSE, SD-JWT, and COSE.
+        This section outlines how to secure documents conforming
+        to [[VC-DATA-MODEL-2.0]] using JOSE, SD-JWT, and COSE.
     </p>
     <p>
-      Documents conforming to [[VC-DATA-MODEL-2.0]],
-      and their associated media types, rely on
-      JSON-LD, which is an extensible format for describing
-      linked data; see <a href="https://www.w3.org/TR/json-ld11/#relationship-to-rdf">JSON-LD Relationship to RDF</a>.
+        Documents conforming to [[VC-DATA-MODEL-2.0]],
+        and their associated media types, rely on
+        JSON-LD, which is an extensible format for describing
+        linked data; see <a href="https://www.w3.org/TR/json-ld11/#relationship-to-rdf">JSON-LD Relationship to RDF</a>.
     </p>
     <p>
-      A benefit to this approach is that payloads can be made to conform
-      directly to [[VC-DATA-MODEL-2.0]] without any mappings or
-      transformation, while at the same time supporting registered
-      header parameters and claims that are understood in the context of JOSE, SD-JWT, and COSE.
+        A benefit to this approach is that payloads can be made to conform
+        directly to [[VC-DATA-MODEL-2.0]] without any mappings or
+        transformation, while at the same time supporting registered
+        header parameters and claims that are understood in the context of JOSE, SD-JWT, and COSE.
     </p>
     <p>
-      It is RECOMMENDED that media types be used to distinguish <a data-cite="VC-DATA-MODEL-2.0#credentials">verifiable credentials</a>
-      and <a data-cite="VC-DATA-MODEL-2.0#presentations">verifiable presentations</a> from other kinds of secured JSON or CBOR.
+        It is RECOMMENDED that media types be used to distinguish <a data-cite="VC-DATA-MODEL-2.0#credentials">verifiable
+        credentials</a>
+        and <a data-cite="VC-DATA-MODEL-2.0#presentations">verifiable presentations</a> from other kinds of secured JSON
+        or CBOR.
     </p>
     <p>
-      The most specific media type (or subtype) available SHOULD be used, instead of
-      more generic media types (or supertypes). For example, rather than the general
-      <code>application/sd-jwt</code>, <code>application/vc+ld+json+sd-jwt</code>
-      SHOULD be used, unless there is a more specific media type that would even
-      better identify the secured envelope format.
+        The most specific media type (or subtype) available SHOULD be used, instead of
+        more generic media types (or supertypes). For example, rather than the general
+        <code>application/sd-jwt</code>, <code>application/vc+ld+json+sd-jwt</code>
+        SHOULD be used, unless there is a more specific media type that would even
+        better identify the secured envelope format.
     </p>
     <p>
-    If implementations do not know which media type to use, media types defined in this specification MUST be used.
+        If implementations do not know which media type to use, media types defined in this specification MUST be used.
     </p>
 
     <section id="secure-with-jose">
-      <h2 id="with-jose">With JOSE</h2>
-      <section>
-        <h2 id="securing-with-jose">Securing JSON-LD Verifiable Credentials with JOSE</h2>
-        <p>
-          This section details how to use JOSE to secure verifiable credentials conforming
-          to [[VC-DATA-MODEL-2.0]].
-        </p>
-        <p>
-          A [=conforming JWS issuer implementation=] MUST use [[RFC7515]] to secure this media type.
-	  The unsecured verifiable credential is the unencoded JWS payload.
-	</p>
-	<p>
-          The <code>typ</code> header parameter SHOULD be <code>vc+ld+json+jwt</code>.
-          When present, the <code>cty</code> header parameter SHOULD be <code>vc+ld+json</code>.
-          See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
-          for additional details regarding usage of <code>typ</code> and
-          <code>cty</code>.
-        </p>
-        <p>
-          A [=conforming JWS verifier implementation=] MUST use [[RFC7515]] to verify [=conforming JWS documents=] that use this media type.
-        </p>
-        <pre class="example vc-jose-cose-jwt" title="A simple example of a verifiable credential secured with JOSE">
+        <h2 id="with-jose">With JOSE</h2>
+        <section>
+            <h2 id="securing-with-jose">Securing JSON-LD Verifiable Credentials with JOSE</h2>
+            <p>
+                This section details how to use JOSE to secure verifiable credentials conforming
+                to [[VC-DATA-MODEL-2.0]].
+            </p>
+            <p>
+                A [=conforming JWS issuer implementation=] MUST use [[RFC7515]] to secure this media type.
+                The unsecured verifiable credential is the unencoded JWS payload.
+            </p>
+            <p>
+                The <code>typ</code> header parameter SHOULD be <code>vc+ld+json+jwt</code>.
+                When present, the <code>cty</code> header parameter SHOULD be <code>vc+ld+json</code>.
+                See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
+                for additional details regarding usage of <code>typ</code> and
+                <code>cty</code>.
+            </p>
+            <p>
+                A [=conforming JWS verifier implementation=] MUST use [[RFC7515]] to verify [=conforming JWS documents=]
+                that use this media type.
+            </p>
+            <pre class="example vc-jose-cose-jwt" title="A simple example of a verifiable credential secured with JOSE">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -293,41 +297,47 @@
   }
 }
         </pre>
-        <p>
-          See <a data-cite="VC-DATA-MODEL-2.0#example-a-simple-example-of-the-contents-of-a-verifiable-credential"></a> for more details regarding this example.
-        </p>
-      </section>
+            <p>
+                See <a
+                    data-cite="VC-DATA-MODEL-2.0#example-a-simple-example-of-the-contents-of-a-verifiable-credential"></a>
+                for more details regarding this example.
+            </p>
+        </section>
 
-      <section>
-        <h2 id="securing-vps-with-jose">Securing JSON-LD Verifiable Presentations with JOSE</h2>
-        <p>
-          This section details how to use JOSE to secure verifiable presentations conforming
-          to [[VC-DATA-MODEL-2.0]].
-        </p>
-        <p>
-	  A [=conforming JWS issuer implementation=] MUST use [[RFC7515]] to secure this media type.
-	  The unsecured verifiable presentation is the unencoded JWS payload.
-	</p>
-	<p>
-          The <code>typ</code> header parameter SHOULD be <code>vp+ld+json+jwt</code>.
-	  When present, the <code>cty</code> header parameter SHOULD be <code>vp+ld+json</code>.
-          See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
-          for additional details regarding usage of <code>typ</code> and
-          <code>cty</code>.
-        </p>
-        <p>
-          A [=conforming JWS verifier implementation=] MUST use [[RFC7515]] to verify [=conforming JWS documents=] that use this media type.
-        </p>
-        <p>
-          Credentials in verifiable presentations MUST use the <a data-cite="VC-DATA-MODEL-2.0/#defn-EnvelopedVerifiableCredential">Enveloped Verifiable Credential</a>
-          type defined by the [[VC-DATA-MODEL-2.0]].
-        </p>
-        <p>
-          Credentials in verifiable presentations MUST be secured.
-	  These credentials are secured using JWS in this case.
-        <p>
+        <section>
+            <h2 id="securing-vps-with-jose">Securing JSON-LD Verifiable Presentations with JOSE</h2>
+            <p>
+                This section details how to use JOSE to secure verifiable presentations conforming
+                to [[VC-DATA-MODEL-2.0]].
+            </p>
+            <p>
+                A [=conforming JWS issuer implementation=] MUST use [[RFC7515]] to secure this media type.
+                The unsecured verifiable presentation is the unencoded JWS payload.
+            </p>
+            <p>
+                The <code>typ</code> header parameter SHOULD be <code>vp+ld+json+jwt</code>.
+                When present, the <code>cty</code> header parameter SHOULD be <code>vp+ld+json</code>.
+                See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
+                for additional details regarding usage of <code>typ</code> and
+                <code>cty</code>.
+            </p>
+            <p>
+                A [=conforming JWS verifier implementation=] MUST use [[RFC7515]] to verify [=conforming JWS documents=]
+                that use this media type.
+            </p>
+            <p>
+                Credentials in verifiable presentations MUST use the <a
+                    data-cite="VC-DATA-MODEL-2.0/#defn-EnvelopedVerifiableCredential">Enveloped Verifiable
+                Credential</a>
+                type defined by the [[VC-DATA-MODEL-2.0]].
+            </p>
+            <p>
+                Credentials in verifiable presentations MUST be secured.
+                These credentials are secured using JWS in this case.
+            <p>
 
-    <pre class="example vc-jose-cose-jwt" title="A simple example of a verifiable presentation secured with JOSE">
+            <pre class="example vc-jose-cose-jwt"
+                 title="A simple example of a verifiable presentation secured with JOSE">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -341,108 +351,113 @@
   }]
 }
       </pre>
-      <p>
-        See <a data-cite="VC-DATA-MODEL-2.0#example-a-simple-example-of-a-verifiable-presentation"></a> for more details regarding this example.
-      </p>
+            <p>
+                See <a data-cite="VC-DATA-MODEL-2.0#example-a-simple-example-of-a-verifiable-presentation"></a> for more
+                details regarding this example.
+            </p>
 
-      <p>
-	Implementations MUST support the JWS compact serialization.
-	Use of the JWS JSON serialization is NOT RECOMMENDED.
-      </p>
-      </section>
-      <section class="normative">
-        <h2 id="jose-header-parameters-jwt-claims">JOSE Header Parameters and JWT Claims</h2>
+            <p>
+                Implementations MUST support the JWS compact serialization.
+                Use of the JWS JSON serialization is NOT RECOMMENDED.
+            </p>
+        </section>
+        <section class="normative">
+            <h2 id="jose-header-parameters-jwt-claims">JOSE Header Parameters and JWT Claims</h2>
 
-        <p>
-When present in the <a data-cite="RFC7515#section-4">JOSE Header</a> or the
-<a data-cite="RFC7519#section-4">JWT Claims Set</a>, members registered in the
-IANA
-<a href="https://www.iana.org/assignments/jwt/jwt.xhtml">JSON Web Token Claims</a>
-registry or the IANA
-<a href="https://www.iana.org/assignments/jose/jose.xhtml">JSON Web Signature and Encryption Header Parameters</a>
-registry are to be interpreted as defined by the specifications referenced in
-the registries.
-        </p>
-        <p>
-The normative statements in
-<a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>,
-<a data-cite="RFC7519#section-5">JOSE Header</a>, and
-<a data-cite="RFC7519#section-5.3">Replicating Claims as Header Parameters</a>
-apply to securing credentials and presentations.
-        </p>
-        <p>
-The unencoded JOSE Header is JSON (`application/json`), not JSON-LD
-(`application/ld+json`).
-        </p>
-        <p>
-It is RECOMMENDED to use the IANA
-<a href="https://www.iana.org/assignments/jwt/jwt.xhtml">JSON Web Token Claims</a>
-registry and the IANA
-<a href="https://www.iana.org/assignments/jose/jose.xhtml">JSON Web Signature and Encryption Header Parameters</a>
-registry to identify any claims and header parameters that might be confused
-with members defined by [[[VC-DATA-MODEL-2.0]]] [[VC-DATA-MODEL-2.0]]. These include but are not limited
-to: <code>iss</code>, <code>kid</code>, <code>alg</code>, <code>iat</code>,
-<code>exp</code>, and <code>cnf</code>.
-        </p>
-        <p>
-When the <code>iat</code> and/or <code>exp</code> JWT claims are present, they
-represent the issuance and expiration time of the signature, respectively. Note
-that these are different from the <code>validFrom</code> and
-<code>validUntil</code> properties defined in
-<a data-cite="VC-DATA-MODEL-2.0#validity-period">Validity Period</a>, which
-represent the validity of the data that is being secured.
-        </p>
-        <p>
-The claims and security provided by this specification are independent of the
-data secured and semantics provided by the [[[VC-DATA-MODEL-2.0]]] [[VC-DATA-MODEL-2.0]]. This means
-that while the security features of this specification ensure data integrity and
-authenticity, they do not dictate the interpretation of claim data.
-        </p>
-        <p>
-Implementers SHOULD avoid setting JWT claims to values that conflict with the
-values of verifiable credential properties when a claim and property pair refer
-to the same conceptual entity, especially with pairs such as `iss` and `issuer`,
-`jti` and `id`, and `sub` and `credentialSubject.id`. For example, JWK claim
-`iss` should not be set to a value which conflicts with the value of verifiable
-credential property `issuer`.
-        </p>
-        <p>
-The JWT Claim Names <code>vc</code> and <code>vp</code> MUST NOT be present.
-        </p>
-        <p>
-Additional members may be present as header parameters and claims. If they are
-not understood, they MUST be ignored.
-        </p>
-      </section>
+            <p>
+                When present in the <a data-cite="RFC7515#section-4">JOSE Header</a> or the
+                <a data-cite="RFC7519#section-4">JWT Claims Set</a>, members registered in the
+                IANA
+                <a href="https://www.iana.org/assignments/jwt/jwt.xhtml">JSON Web Token Claims</a>
+                registry or the IANA
+                <a href="https://www.iana.org/assignments/jose/jose.xhtml">JSON Web Signature and Encryption Header
+                    Parameters</a>
+                registry are to be interpreted as defined by the specifications referenced in
+                the registries.
+            </p>
+            <p>
+                The normative statements in
+                <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>,
+                <a data-cite="RFC7519#section-5">JOSE Header</a>, and
+                <a data-cite="RFC7519#section-5.3">Replicating Claims as Header Parameters</a>
+                apply to securing credentials and presentations.
+            </p>
+            <p>
+                The unencoded JOSE Header is JSON (`application/json`), not JSON-LD
+                (`application/ld+json`).
+            </p>
+            <p>
+                It is RECOMMENDED to use the IANA
+                <a href="https://www.iana.org/assignments/jwt/jwt.xhtml">JSON Web Token Claims</a>
+                registry and the IANA
+                <a href="https://www.iana.org/assignments/jose/jose.xhtml">JSON Web Signature and Encryption Header
+                    Parameters</a>
+                registry to identify any claims and header parameters that might be confused
+                with members defined by [[[VC-DATA-MODEL-2.0]]] [[VC-DATA-MODEL-2.0]]. These include but are not limited
+                to: <code>iss</code>, <code>kid</code>, <code>alg</code>, <code>iat</code>,
+                <code>exp</code>, and <code>cnf</code>.
+            </p>
+            <p>
+                When the <code>iat</code> and/or <code>exp</code> JWT claims are present, they
+                represent the issuance and expiration time of the signature, respectively. Note
+                that these are different from the <code>validFrom</code> and
+                <code>validUntil</code> properties defined in
+                <a data-cite="VC-DATA-MODEL-2.0#validity-period">Validity Period</a>, which
+                represent the validity of the data that is being secured.
+            </p>
+            <p>
+                The claims and security provided by this specification are independent of the
+                data secured and semantics provided by the [[[VC-DATA-MODEL-2.0]]] [[VC-DATA-MODEL-2.0]]. This means
+                that while the security features of this specification ensure data integrity and
+                authenticity, they do not dictate the interpretation of claim data.
+            </p>
+            <p>
+                Implementers SHOULD avoid setting JWT claims to values that conflict with the
+                values of verifiable credential properties when a claim and property pair refer
+                to the same conceptual entity, especially with pairs such as `iss` and `issuer`,
+                `jti` and `id`, and `sub` and `credentialSubject.id`. For example, JWK claim
+                `iss` should not be set to a value which conflicts with the value of verifiable
+                credential property `issuer`.
+            </p>
+            <p>
+                The JWT Claim Names <code>vc</code> and <code>vp</code> MUST NOT be present.
+            </p>
+            <p>
+                Additional members may be present as header parameters and claims. If they are
+                not understood, they MUST be ignored.
+            </p>
+        </section>
     </section>
 
     <section id="secure-with-sd-jwt">
-      <h2 id="with-sd-jwt">With SD-JWT</h2>
-      <section>
-        <h2 id="securing-with-sd-jwt">Securing JSON-LD Verifiable Credentials with SD-JWT</h2>
-        <p>
-          This section details how to use JOSE to secure verifiable credentials conforming
-          to [[VC-DATA-MODEL-2.0]].
-        </p>
-        <p>
-A [=conforming SD-JWT issuer implementation=] MUST use [[[SD-JWT]]] [[SD-JWT]] to secure
-this media type. The unsecured [=verifiable credential=] is the input JSON
-claim set. The Issuer then converts the input JSON claim set (i.e., the
-unsecured [=verifiable credential=]) into an SD-JWT payload according to
-<a data-cite="SD-JWT#section-6.1">SD-JWT issuance instructions</a>.
-	</p>
-	<p>
-          The <code>typ</code> header parameter SHOULD be <code>vc+ld+json+sd-jwt</code>.
-          When present, the <code>cty</code> header parameter SHOULD be <code>vc+ld+json</code>.
-          See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
-          for additional details regarding usage of <code>typ</code> and
-          <code>cty</code>.
-        </p>
-        <p>
-          A [=conforming SD-JWT verifier implementation=] MUST use [[SD-JWT]] to verify [=conforming JWS documents=] that use this media type.
-        </p>
+        <h2 id="with-sd-jwt">With SD-JWT</h2>
+        <section>
+            <h2 id="securing-with-sd-jwt">Securing JSON-LD Verifiable Credentials with SD-JWT</h2>
+            <p>
+                This section details how to use JOSE to secure verifiable credentials conforming
+                to [[VC-DATA-MODEL-2.0]].
+            </p>
+            <p>
+                A [=conforming SD-JWT issuer implementation=] MUST use [[[SD-JWT]]] [[SD-JWT]] to secure
+                this media type. The unsecured [=verifiable credential=] is the input JSON
+                claim set. The Issuer then converts the input JSON claim set (i.e., the
+                unsecured [=verifiable credential=]) into an SD-JWT payload according to
+                <a data-cite="SD-JWT#section-6.1">SD-JWT issuance instructions</a>.
+            </p>
+            <p>
+                The <code>typ</code> header parameter SHOULD be <code>vc+ld+json+sd-jwt</code>.
+                When present, the <code>cty</code> header parameter SHOULD be <code>vc+ld+json</code>.
+                See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
+                for additional details regarding usage of <code>typ</code> and
+                <code>cty</code>.
+            </p>
+            <p>
+                A [=conforming SD-JWT verifier implementation=] MUST use [[SD-JWT]] to verify [=conforming JWS
+                documents=] that use this media type.
+            </p>
 
-        <pre class="example vc-jose-cose-sd-jwt" title="A simple example of a verifiable credential secured with SD-JWT">
+            <pre class="example vc-jose-cose-sd-jwt"
+                 title="A simple example of a verifiable credential secured with SD-JWT">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -468,40 +483,46 @@ unsecured [=verifiable credential=]) into an SD-JWT payload according to
   }
 }
         </pre>
-        <p>
-          See <a data-cite="VC-DATA-MODEL-2.0#example-a-simple-example-of-the-contents-of-a-verifiable-credential"></a> for more details regarding this example.
-        </p>
-      </section>
+            <p>
+                See <a
+                    data-cite="VC-DATA-MODEL-2.0#example-a-simple-example-of-the-contents-of-a-verifiable-credential"></a>
+                for more details regarding this example.
+            </p>
+        </section>
 
-      <section>
-        <h2 id="securing-vps-sd-jwt">Securing JSON-LD Verifiable Presentations with SD-JWT</h2>
-        <p>
-          This section details how to use SD-JWT to secure verifiable presentations conforming
-          to [[VC-DATA-MODEL-2.0]].
-        </p>
-        <p>
-	  A [=conforming SD-JWT issuer implementation=] MUST use [[SD-JWT]] to secure this media type.
-	  The unsecured verifiable presentation is the unencoded SD-JWT payload.
-	</p>
-	<p>
-          The <code>typ</code> header parameter SHOULD be <code>vp+ld+json+sd-jwt</code>.
-    When present, the <code>cty</code> header parameter SHOULD be <code>vp+ld+json</code>.
-          See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
-          for additional details regarding usage of <code>typ</code> and
-          <code>cty</code>.
-        </p>
-        <p>
-          A [=conforming SD-JWT verifier implementation=] MUST use [[SD-JWT]] to verify [=conforming JWS documents=] that use this media type.
-        </p>
-        <p>
-          Credentials in verifiable presentations MUST use the <a data-cite="VC-DATA-MODEL-2.0/#defn-EnvelopedVerifiableCredential">Enveloped Verifiable Credential</a>
-          type defined by the [[VC-DATA-MODEL-2.0]].
-        </p>
-        <p>
-          Credentials in verifiable presentations MUST be secured.
-	  These credentials are secured using SD-JWT in this case.
-        <p>
-      <pre class="example vc-jose-cose-sd-jwt" title="A simple example of a verifiable presentation secured with SD-JWT">
+        <section>
+            <h2 id="securing-vps-sd-jwt">Securing JSON-LD Verifiable Presentations with SD-JWT</h2>
+            <p>
+                This section details how to use SD-JWT to secure verifiable presentations conforming
+                to [[VC-DATA-MODEL-2.0]].
+            </p>
+            <p>
+                A [=conforming SD-JWT issuer implementation=] MUST use [[SD-JWT]] to secure this media type.
+                The unsecured verifiable presentation is the unencoded SD-JWT payload.
+            </p>
+            <p>
+                The <code>typ</code> header parameter SHOULD be <code>vp+ld+json+sd-jwt</code>.
+                When present, the <code>cty</code> header parameter SHOULD be <code>vp+ld+json</code>.
+                See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
+                for additional details regarding usage of <code>typ</code> and
+                <code>cty</code>.
+            </p>
+            <p>
+                A [=conforming SD-JWT verifier implementation=] MUST use [[SD-JWT]] to verify [=conforming JWS
+                documents=] that use this media type.
+            </p>
+            <p>
+                Credentials in verifiable presentations MUST use the <a
+                    data-cite="VC-DATA-MODEL-2.0/#defn-EnvelopedVerifiableCredential">Enveloped Verifiable
+                Credential</a>
+                type defined by the [[VC-DATA-MODEL-2.0]].
+            </p>
+            <p>
+                Credentials in verifiable presentations MUST be secured.
+                These credentials are secured using SD-JWT in this case.
+            <p>
+            <pre class="example vc-jose-cose-sd-jwt"
+                 title="A simple example of a verifiable presentation secured with SD-JWT">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -515,51 +536,55 @@ unsecured [=verifiable credential=]) into an SD-JWT payload according to
   }]
 }
       </pre>
-      <p>
-        See <a data-cite="VC-DATA-MODEL-2.0#example-a-simple-example-of-a-verifiable-presentation"></a> for more details regarding this example.
-      </p>
+            <p>
+                See <a data-cite="VC-DATA-MODEL-2.0#example-a-simple-example-of-a-verifiable-presentation"></a> for more
+                details regarding this example.
+            </p>
 
-      <p>
-	Implementations MUST support the compact serialization (<code>application/sd-jwt</code>)
-	and MAY support the JSON serialization (<code>application/sd-jwt+json</code>).
-	If the JSON serialization is used, it is RECOMMENDED that a profile be defined
-	to ensure any additional JSON members are understood consistently.
-      </p>
-      </section>
+            <p>
+                Implementations MUST support the compact serialization (<code>application/sd-jwt</code>)
+                and MAY support the JSON serialization (<code>application/sd-jwt+json</code>).
+                If the JSON serialization is used, it is RECOMMENDED that a profile be defined
+                to ensure any additional JSON members are understood consistently.
+            </p>
+        </section>
     </section>
 
     <section id="secure-with-cose">
-      <h2 id="securing-with-cose">With COSE</h2>
-      <p>
-        COSE [[RFC9052]] is a common approach to encoding and securing
-        information using CBOR [[RFC8949]]. Verifiable credentials MAY
-        be secured using COSE [[RFC9052]] and SHOULD be identified through
-        use of content types as outlined in this section.
-      </p>
+        <h2 id="securing-with-cose">With COSE</h2>
+        <p>
+            COSE [[RFC9052]] is a common approach to encoding and securing
+            information using CBOR [[RFC8949]]. Verifiable credentials MAY
+            be secured using COSE [[RFC9052]] and SHOULD be identified through
+            use of content types as outlined in this section.
+        </p>
 
-      <section>
-        <h2 id="securing-vcs-with-cose">Securing JSON-LD Verifiable Credentials with COSE</h2>
-        <p>
-          This section details how to secure data with the type
-          <code>application/vc+ld+json</code>
-          with COSE.
-        </p>
-        <p>
-          A [=conforming COSE issuer implementation=] MUST use COSE_Sign1 as specified in [[RFC9052]] to secure this media type.
-	  The unsecured verifiable credential is the unencoded COSE_Sign1 payload.
-	</p>
-	<p>
-          The <code>typ</code> header parameter SHOULD be <code>application/vc+ld+json+cose</code>.
-          See <a href="https://www.ietf.org/archive/id/draft-ietf-cose-typ-header-parameter-03.html">I-D.ietf-cose-typ-header-parameter</a>
-          for the COSE "<code>typ</code>" (type) header parameter.
-          When present, the <code>content type (3)</code> header parameter
-          SHOULD be <code>application/vc+ld+json</code>.
-          See <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a> for additional details.
-        </p>
-        <p>
-        A [=conforming COSE verifier implementation=] MUST use COSE_Sign1 as specified in [[RFC9052]] to verify [=conforming COSE documents=] that use this media type.
-        </p>
-        <pre class="example vc-jose-cose-cose" title="A simple example of a verifiable credential secured with COSE">
+        <section>
+            <h2 id="securing-vcs-with-cose">Securing JSON-LD Verifiable Credentials with COSE</h2>
+            <p>
+                This section details how to secure data with the type
+                <code>application/vc+ld+json</code>
+                with COSE.
+            </p>
+            <p>
+                A [=conforming COSE issuer implementation=] MUST use COSE_Sign1 as specified in [[RFC9052]] to secure
+                this media type.
+                The unsecured verifiable credential is the unencoded COSE_Sign1 payload.
+            </p>
+            <p>
+                The <code>typ</code> header parameter SHOULD be <code>application/vc+ld+json+cose</code>.
+                See <a href="https://www.ietf.org/archive/id/draft-ietf-cose-typ-header-parameter-03.html">I-D.ietf-cose-typ-header-parameter</a>
+                for the COSE "<code>typ</code>" (type) header parameter.
+                When present, the <code>content type (3)</code> header parameter
+                SHOULD be <code>application/vc+ld+json</code>.
+                See <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a> for additional details.
+            </p>
+            <p>
+                A [=conforming COSE verifier implementation=] MUST use COSE_Sign1 as specified in [[RFC9052]] to verify
+                [=conforming COSE documents=] that use this media type.
+            </p>
+            <pre class="example vc-jose-cose-cose"
+                 title="A simple example of a verifiable credential secured with COSE">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -585,37 +610,44 @@ unsecured [=verifiable credential=]) into an SD-JWT payload according to
   }
 }
         </pre>
-        <p>
-          See <a data-cite="VC-DATA-MODEL-2.0#example-a-simple-example-of-the-contents-of-a-verifiable-credential"></a> for more details regarding this example.
-        </p>
-      </section>
-      <section>
-        <h2 id="securing-vps-with-cose">Securing JSON-LD Verifiable Presentations with COSE</h2>
-        <p>
-          This section details how to use COSE to secure verifiable presentations conforming
-          to [[VC-DATA-MODEL-2.0]].
-        </p>
-        <p>
-          A [=conforming COSE issuer implementation=] MUST use COSE_Sign1 as specified in [[RFC9052]] to secure this media type.
-	  The unsecured verifiable presentation is the unencoded COSE_Sign1 payload.
-	</p>
-	<p>
-          The <code>typ</code> header parameter SHOULD be <code>application/vp+ld+json+cose</code>.
-          When present, the <code>cty</code> header parameter SHOULD be <code>application/vp+ld+json</code>.
-          See <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a> for additional details.
-        </p>
-        <p>
-          A [=conforming COSE verifier implementation=] MUST use COSE_Sign1 as specified in [[RFC9052]] to verify [=conforming COSE documents=] that use this media type.
-        </p>
-        <p>
-          Credentials in verifiable presentations MUST use the <a data-cite="VC-DATA-MODEL-2.0/#defn-EnvelopedVerifiableCredential">Enveloped Verifiable Credential</a>
-          type defined by the [[VC-DATA-MODEL-2.0]].
-        </p>
-        <p>
-          Credentials in verifiable presentations MUST be secured.
-	  These credentials are secured using COSE in this case.
-        <p>
-        <pre class="example vc-jose-cose-cose" title="A simple example of a verifiable presentation secured with COSE">
+            <p>
+                See <a
+                    data-cite="VC-DATA-MODEL-2.0#example-a-simple-example-of-the-contents-of-a-verifiable-credential"></a>
+                for more details regarding this example.
+            </p>
+        </section>
+        <section>
+            <h2 id="securing-vps-with-cose">Securing JSON-LD Verifiable Presentations with COSE</h2>
+            <p>
+                This section details how to use COSE to secure verifiable presentations conforming
+                to [[VC-DATA-MODEL-2.0]].
+            </p>
+            <p>
+                A [=conforming COSE issuer implementation=] MUST use COSE_Sign1 as specified in [[RFC9052]] to secure
+                this media type.
+                The unsecured verifiable presentation is the unencoded COSE_Sign1 payload.
+            </p>
+            <p>
+                The <code>typ</code> header parameter SHOULD be <code>application/vp+ld+json+cose</code>.
+                When present, the <code>cty</code> header parameter SHOULD be <code>application/vp+ld+json</code>.
+                See <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a> for additional details.
+            </p>
+            <p>
+                A [=conforming COSE verifier implementation=] MUST use COSE_Sign1 as specified in [[RFC9052]] to verify
+                [=conforming COSE documents=] that use this media type.
+            </p>
+            <p>
+                Credentials in verifiable presentations MUST use the <a
+                    data-cite="VC-DATA-MODEL-2.0/#defn-EnvelopedVerifiableCredential">Enveloped Verifiable
+                Credential</a>
+                type defined by the [[VC-DATA-MODEL-2.0]].
+            </p>
+            <p>
+                Credentials in verifiable presentations MUST be secured.
+                These credentials are secured using COSE in this case.
+            <p>
+            <pre class="example vc-jose-cose-cose"
+                 title="A simple example of a verifiable presentation secured with COSE">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -629,108 +661,110 @@ unsecured [=verifiable credential=]) into an SD-JWT payload according to
   }]
 }
       </pre>
-        <p>
-          See <a data-cite="VC-DATA-MODEL-2.0#example-a-simple-example-of-a-verifiable-presentation"></a> for more details regarding this example.
-        </p>
-      </section>
-      <section class="normative">
-        <h2 id="cose-header-param-cwt-claims">COSE Header Parameters and CWT Claims</h2>
+            <p>
+                See <a data-cite="VC-DATA-MODEL-2.0#example-a-simple-example-of-a-verifiable-presentation"></a> for more
+                details regarding this example.
+            </p>
+        </section>
+        <section class="normative">
+            <h2 id="cose-header-param-cwt-claims">COSE Header Parameters and CWT Claims</h2>
 
-        <p>
-When present in the <a data-cite="RFC9052#section-3.1">COSE Header</a> or as
-<a data-cite="RFC8392#section-3">CWT Claims</a>, members registered in the IANA
-<a href="https://www.iana.org/assignments/cwt/cwt.xhtml">CBOR Web Token (CWT) Claims</a>
-registry or the IANA
-<a href="https://www.iana.org/assignments/cose/cose.xhtml">COSE Header Parameters</a>
-registry are to be interpreted as defined by the specifications referenced in
-those registries. CBOR Web Token (CWT) [[?RFC8392]] Claims MAY be included in a
-COSE header parameter, as specified in
-<a href="https://www.ietf.org/archive/id/draft-ietf-cose-cwt-claims-in-headers-10.html">I-D.ietf-cose-cwt-claims-in-headers</a>.
-        </p>
-        <p>
-The normative statements in
-<a data-cite="RFC9052#section-3.1">Header Parameters</a>,
-<a data-cite="RFC8392#section-3">Claims</a>, and
-<a href="https://www.ietf.org/archive/id/draft-ietf-cose-cwt-claims-in-headers-10.html">CBOR Web Token (CWT) Claims in COSE Headers</a>
-apply to securing credentials and presentations.
-        </p>
-        <p>
-It is RECOMMENDED to use the IANA
-<a href="https://www.iana.org/assignments/cwt/cwt.xhtml">CBOR Web Token Claims</a>
-registry and the IANA
-<a href="https://www.iana.org/assignments/cose/cose.xhtml">COSE Header Parameters</a>
-registry to identify any claims and header parameters that might be confused
-with members defined by [[[VC-DATA-MODEL-2.0]]] [[VC-DATA-MODEL-2.0]]. These include but are not limited
-to: <code>iss</code>, <code>kid</code>, <code>alg</code>, <code>iat</code>,
-<code>exp</code>, and <code>cnf</code>.
-        </p>
-        <p>
-When the <code>iat</code> and/or <code>exp</code> CWT claims are present, they
-represent the issuance and expiration time of the signature, respectively. Note
-that these are different from the <code>validFrom</code> and
-<code>validUntil</code> properties defined in
-<a data-cite="VC-DATA-MODEL-2.0#validity-period">Validity Period</a>, which
-represent the validity of the data that is being secured.
-        </p>
-        <p>
-Additional members may be present as header parameters and claims. If they are
-not understood, they MUST be ignored.
-        </p>
-      </section>
+            <p>
+                When present in the <a data-cite="RFC9052#section-3.1">COSE Header</a> or as
+                <a data-cite="RFC8392#section-3">CWT Claims</a>, members registered in the IANA
+                <a href="https://www.iana.org/assignments/cwt/cwt.xhtml">CBOR Web Token (CWT) Claims</a>
+                registry or the IANA
+                <a href="https://www.iana.org/assignments/cose/cose.xhtml">COSE Header Parameters</a>
+                registry are to be interpreted as defined by the specifications referenced in
+                those registries. CBOR Web Token (CWT) [[?RFC8392]] Claims MAY be included in a
+                COSE header parameter, as specified in
+                <a href="https://www.ietf.org/archive/id/draft-ietf-cose-cwt-claims-in-headers-10.html">I-D.ietf-cose-cwt-claims-in-headers</a>.
+            </p>
+            <p>
+                The normative statements in
+                <a data-cite="RFC9052#section-3.1">Header Parameters</a>,
+                <a data-cite="RFC8392#section-3">Claims</a>, and
+                <a href="https://www.ietf.org/archive/id/draft-ietf-cose-cwt-claims-in-headers-10.html">CBOR Web Token
+                    (CWT) Claims in COSE Headers</a>
+                apply to securing credentials and presentations.
+            </p>
+            <p>
+                It is RECOMMENDED to use the IANA
+                <a href="https://www.iana.org/assignments/cwt/cwt.xhtml">CBOR Web Token Claims</a>
+                registry and the IANA
+                <a href="https://www.iana.org/assignments/cose/cose.xhtml">COSE Header Parameters</a>
+                registry to identify any claims and header parameters that might be confused
+                with members defined by [[[VC-DATA-MODEL-2.0]]] [[VC-DATA-MODEL-2.0]]. These include but are not limited
+                to: <code>iss</code>, <code>kid</code>, <code>alg</code>, <code>iat</code>,
+                <code>exp</code>, and <code>cnf</code>.
+            </p>
+            <p>
+                When the <code>iat</code> and/or <code>exp</code> CWT claims are present, they
+                represent the issuance and expiration time of the signature, respectively. Note
+                that these are different from the <code>validFrom</code> and
+                <code>validUntil</code> properties defined in
+                <a data-cite="VC-DATA-MODEL-2.0#validity-period">Validity Period</a>, which
+                represent the validity of the data that is being secured.
+            </p>
+            <p>
+                Additional members may be present as header parameters and claims. If they are
+                not understood, they MUST be ignored.
+            </p>
+        </section>
     </section>
-  </section>
+</section>
 
 
-
-  <section id="key_discovery" class="normative">
+<section id="key_discovery" class="normative">
     <h2 id="key-discovery">Key Discovery</h2>
-      <p class="issue" data-number="160">
+    <p class="issue" data-number="160">
         The working group is still discussing how to close many related issues.
-      </p>
+    </p>
 
-      <!-- DID URLS via "issuer" and "holder" -->
-      <p>
+    <!-- DID URLS via "issuer" and "holder" -->
+    <p>
         When <a href="#iss">iss</a> is absent and the <a data-cite="VC-DATA-MODEL-2.0#dfn-issuers">issuer</a>
         is identified as a <a data-cite="DID-CORE#did-subject">DID Subject</a>,
         the <a href="#kid">kid</a> MUST be an absolute <a data-cite="DID-CORE#relative-did-urls">DID URL</a>.
-      </p>
-<pre class="example" title="An issuer identified by a DID">
+    </p>
+    <pre class="example" title="An issuer identified by a DID">
 {
   "issuer": "did:example:123"
   // ...
 }
 </pre>
-<pre class="example" title="An absolute DID URL as a kid">
+    <pre class="example" title="An absolute DID URL as a kid">
 {
   "alg": "ES384",
   "kid": "did:example:123#key-456
 }
 </pre>
-      <p>
+    <p>
         When <a href="#iss">iss</a> is absent, and the <a data-cite="VC-DATA-MODEL-2.0#dfn-holders">holder</a>
         is identified as a <a data-cite="DID-CORE#did-subject">DID Subject</a>,
         the <a href="#kid">kid</a> MUST be an absolute <a data-cite="DID-CORE#relative-did-urls">DID URL</a>.
-      </p>
-<pre class="example" title="A holder identified by a DID">
+    </p>
+    <pre class="example" title="A holder identified by a DID">
 {
   "holder": "did:example:abc"
   // ...
 }
 </pre>
-<pre class="example" title="A kid as an absolute DID URL">
+    <pre class="example" title="A kid as an absolute DID URL">
 {
   "alg": "ES384",
   "kid": "did:example:abc#key-456
 }
 </pre>
 
-      <!-- REGULAR URLS via "issuer" and "holder" -->
-      <p>
-        When <a href="#iss">iss</a> is absent, and the <a data-cite="VC-DATA-MODEL-2.0#dfn-issuers">issuer</a> is identified as a [[URL]],
+    <!-- REGULAR URLS via "issuer" and "holder" -->
+    <p>
+        When <a href="#iss">iss</a> is absent, and the <a data-cite="VC-DATA-MODEL-2.0#dfn-issuers">issuer</a> is
+        identified as a [[URL]],
         the <a href="#kid">kid</a> MUST be an absolute [[URL]] to a verification method listed in a controller document.
-      </p>
+    </p>
 
-<pre class="example" title="An issuer identified by a controller document identifier">
+    <pre class="example" title="An issuer identified by a controller document identifier">
 {
   "issuer": {
     "id": "https://university.example/issuers/565049"
@@ -738,19 +772,19 @@ not understood, they MUST be ignored.
   // ...
 }
 </pre>
-<pre class="example" title="A kid as a controller document verification method identifier">
+    <pre class="example" title="A kid as a controller document verification method identifier">
 {
   "alg": "ES384",
   "kid": "https://university.example/issuers/565049#key-123
 }
 </pre>
 
-      <p>
+    <p>
         When the <a data-cite="VC-DATA-MODEL-2.0#dfn-holders">holder</a> is identified as a [[URL]],
         and <a href="#iss">iss</a> is absent,
         the <a href="#kid">kid</a> MUST be an absolute [[URL]] to a verification method listed in a controller document.
-      </p>
-<pre class="example" title="A holder identified by a controller document identifier">
+    </p>
+    <pre class="example" title="A holder identified by a controller document identifier">
 {
   "holder": {
     "id": "https://university.example/issuers/565049"
@@ -758,201 +792,207 @@ not understood, they MUST be ignored.
   // ...
 }
 </pre>
-<pre class="example" title="A kid as a controller document verification method identifier">
+    <pre class="example" title="A kid as a controller document verification method identifier">
 {
   "alg": "ES384",
   "kid": "https://university.example/issuers/565049#key-123
 }
 </pre>
 
-      <!-- REGULAR URLS via "iss" -->
+    <!-- REGULAR URLS via "iss" -->
 
-      <p>
+    <p>
         When <a href="#iss">iss</a> is present and is a [[URL]],
         the <a href="#kid">kid</a> MUST match a key discovered via a JWT Issuer Metadata Request,
-  as described in [[SD-JWT-VC]].
-      </p>
+        as described in [[SD-JWT-VC]].
+    </p>
 
-      <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">
+    <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">
         This normative statement depends on the IETF OAuth working group draft [[SD-JWT-VC]].
         This feature is at risk and will be removed from the specification if at least
         two independent, interoperable implementations are not demonstrated.
-      </p>
+    </p>
 
-      <p>
-    To complete the <a data-cite="VC-DATA-MODEL-2.0#dfn-verify">verification</a> process,
-    a <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifier</a> needs to obtain the cryptographic keys used to secure the
-    <a data-cite="VC-DATA-MODEL-2.0#dfn-credential">credential</a>.
-      </p>
-      <p>
-    There are several different ways to discover the verification keys of
-    the <a data-cite="VC-DATA-MODEL-2.0#dfn-issuers">issuers</a>
-    and <a data-cite="VC-DATA-MODEL-2.0#dfn-holders">holders</a>.
-      </p>
+    <p>
+        To complete the <a data-cite="VC-DATA-MODEL-2.0#dfn-verify">verification</a> process,
+        a <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifier</a> needs to obtain the cryptographic keys used to
+        secure the
+        <a data-cite="VC-DATA-MODEL-2.0#dfn-credential">credential</a>.
+    </p>
+    <p>
+        There are several different ways to discover the verification keys of
+        the <a data-cite="VC-DATA-MODEL-2.0#dfn-issuers">issuers</a>
+        and <a data-cite="VC-DATA-MODEL-2.0#dfn-holders">holders</a>.
+    </p>
 
 
     <section>
-      <h2 id="using-header-params-claims-key-discovery">Using Header Parameters and Claims for Key Discovery</h2>
-      <p>
-      These JOSE header parameters and JWT claims can be used by
-      <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifiers</a> to discover verification keys.
-      </p>
-      <section>
-        <h2 id="kid">kid</h2>
+        <h2 id="using-header-params-claims-key-discovery">Using Header Parameters and Claims for Key Discovery</h2>
         <p>
-      If <code>kid</code> is present in the <a data-cite="RFC7515#section-4.1">JOSE Header</a>
-      or the <a data-cite="RFC9052#section-3">COSE Header</a>,
-      a <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifier</a> can use this parameter
-      as a hint indicating which key was used to secure the verifiable credential, when performing a
-      <a data-cite="VC-DATA-MODEL-2.0#dfn-verify">verification</a> process as defined in <a data-cite="RFC7515#section-4.1.4">RFC7515</a>.
+            These JOSE header parameters and JWT claims can be used by
+            <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifiers</a> to discover verification keys.
         </p>
-        <p>
-          <code>kid</code> MUST be present when the key of the <a data-cite="VC-DATA-MODEL-2.0#dfn-issuers">issuer</a>
-          or <a data-cite="VC-DATA-MODEL-2.0#dfn-subjects">subject</a> is expressed as a DID URL.
-        </p>
-      </section>
-      <section>
-        <h2 id="iss">iss</h2>
-        <p>
-      If <code>iss</code> is present in the <a data-cite="RFC7515#section-4.1">JOSE Header</a>,
-      the <a data-cite="RFC7519#section-4.1.1">JWT Claims</a>,
-      or the <a data-cite="RFC9052#section-3">COSE Header</a>,
-      a <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifier</a> can use this parameter
-      to obtain a <a data-cite="RFC7517#section-4">JSON Web Key</a> to use in the
-      <a data-cite="VC-DATA-MODEL-2.0#dfn-verify">verification</a> process.
-        </p>
-        <p>
-      The value of the <a data-cite="VC-DATA-MODEL-2.0#issuer">issuer</a> property can be either a string or an object.
-      When <code>issuer</code> value is a string, <code>iss</code> value, if present, MUST match <code>issuer</code> value.
-      When <code>issuer</code> value is an object with an <code>id</code> value,
-      <code>iss</code> value, if present, MUST match <code>issuer.id</code> value.
-        </p>
-        <p>
-      If <code>kid</code> is also present in the
-      <a data-cite="RFC7515#section-4.1">JOSE Header</a>, it is used to
-      distinguish the specific key used.
-        </p>
-      </section>
-
-      <section>
-        <h2 id="cnf">cnf</h2>
-        <p>
-      If <code>cnf</code> is present in the <a data-cite="RFC7515#section-4.1">JOSE Header</a>,
-      the <a data-cite="RFC7519#section-4.1.1">JWT Claims</a>,
-      or the <a data-cite="RFC9052#section-3">COSE Header</a>,
-      a <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifier</a> MAY use this parameter
-      to identify a proof-of-possession key in the manner described in [[RFC7800]]
-      or [[RFC8747]] for use in the
-      <a data-cite="VC-DATA-MODEL-2.0#dfn-verify">verification</a> process.
-        </p>
-	<p>
-	  Use of a proof-of-possession key provided by the Holder to the Issuer
-	  to establish a cryptographic binding to the Holder in the Verifiable Credential
-	  that is verifiable by the Verifier in the Verifiable Presentation is RECOMMENDED.
-	</p>
-      </section>
-      </section>
-
-      <section>
-      <h2 id="well-known-uris">Well-Known URIs</h2>
-      <p class="issue" data-number="160">
-      The working group is currently exploring how
-      <a data-cite="RFC5785#section-3">Defining Well-Known Uniform Resource Identifiers (URIs)</a>
-      could be leveraged to assist a <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifier</a> in discovering verification keys for
-      <a data-cite="VC-DATA-MODEL-2.0#dfn-issuers">issuers</a>
-      and <a data-cite="VC-DATA-MODEL-2.0#dfn-holders">holders</a>.
-      </p>
-
-      <section>
-        <h2 id="jwt-issuer">JWT Issuer</h2>
+        <section>
+            <h2 id="kid">kid</h2>
             <p>
-              When the issuer value is a URL using the HTTPS scheme,
-              issuer metadata including the issuer's public keys can be retrieved using the mechanism
-              defined in [[SD-JWT-VC]].
+                If <code>kid</code> is present in the <a data-cite="RFC7515#section-4.1">JOSE Header</a>
+                or the <a data-cite="RFC9052#section-3">COSE Header</a>,
+                a <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifier</a> can use this parameter
+                as a hint indicating which key was used to secure the verifiable credential, when performing a
+                <a data-cite="VC-DATA-MODEL-2.0#dfn-verify">verification</a> process as defined in <a
+                    data-cite="RFC7515#section-4.1.4">RFC7515</a>.
+            </p>
+            <p>
+                <code>kid</code> MUST be present when the key of the <a
+                    data-cite="VC-DATA-MODEL-2.0#dfn-issuers">issuer</a>
+                or <a data-cite="VC-DATA-MODEL-2.0#dfn-subjects">subject</a> is expressed as a DID URL.
+            </p>
+        </section>
+        <section>
+            <h2 id="iss">iss</h2>
+            <p>
+                If <code>iss</code> is present in the <a data-cite="RFC7515#section-4.1">JOSE Header</a>,
+                the <a data-cite="RFC7519#section-4.1.1">JWT Claims</a>,
+                or the <a data-cite="RFC9052#section-3">COSE Header</a>,
+                a <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifier</a> can use this parameter
+                to obtain a <a data-cite="RFC7517#section-4">JSON Web Key</a> to use in the
+                <a data-cite="VC-DATA-MODEL-2.0#dfn-verify">verification</a> process.
+            </p>
+            <p>
+                The value of the <a data-cite="VC-DATA-MODEL-2.0#issuer">issuer</a> property can be either a string or
+                an object.
+                When <code>issuer</code> value is a string, <code>iss</code> value, if present, MUST match
+                <code>issuer</code> value.
+                When <code>issuer</code> value is an object with an <code>id</code> value,
+                <code>iss</code> value, if present, MUST match <code>issuer.id</code> value.
+            </p>
+            <p>
+                If <code>kid</code> is also present in the
+                <a data-cite="RFC7515#section-4.1">JOSE Header</a>, it is used to
+                distinguish the specific key used.
+            </p>
+        </section>
+
+        <section>
+            <h2 id="cnf">cnf</h2>
+            <p>
+                If <code>cnf</code> is present in the <a data-cite="RFC7515#section-4.1">JOSE Header</a>,
+                the <a data-cite="RFC7519#section-4.1.1">JWT Claims</a>,
+                or the <a data-cite="RFC9052#section-3">COSE Header</a>,
+                a <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifier</a> MAY use this parameter
+                to identify a proof-of-possession key in the manner described in [[RFC7800]]
+                or [[RFC8747]] for use in the
+                <a data-cite="VC-DATA-MODEL-2.0#dfn-verify">verification</a> process.
+            </p>
+            <p>
+                Use of a proof-of-possession key provided by the Holder to the Issuer
+                to establish a cryptographic binding to the Holder in the Verifiable Credential
+                that is verifiable by the Verifier in the Verifiable Presentation is RECOMMENDED.
+            </p>
+        </section>
+    </section>
+
+    <section>
+        <h2 id="well-known-uris">Well-Known URIs</h2>
+        <p class="issue" data-number="160">
+            The working group is currently exploring how
+            <a data-cite="RFC5785#section-3">Defining Well-Known Uniform Resource Identifiers (URIs)</a>
+            could be leveraged to assist a <a data-cite="VC-DATA-MODEL-2.0#dfn-verifier">verifier</a> in discovering
+            verification keys for
+            <a data-cite="VC-DATA-MODEL-2.0#dfn-issuers">issuers</a>
+            and <a data-cite="VC-DATA-MODEL-2.0#dfn-holders">holders</a>.
+        </p>
+
+        <section>
+            <h2 id="jwt-issuer">JWT Issuer</h2>
+            <p>
+                When the issuer value is a URL using the HTTPS scheme,
+                issuer metadata including the issuer's public keys can be retrieved using the mechanism
+                defined in [[SD-JWT-VC]].
             </p>
 
             <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">
-              This normative statement depends on the IETF OAuth working group draft [[SD-JWT-VC]].
-              This feature is at risk and will be removed from the specification if at least
-              two independent, interoperable implementations are not demonstrated.
+                This normative statement depends on the IETF OAuth working group draft [[SD-JWT-VC]].
+                This feature is at risk and will be removed from the specification if at least
+                two independent, interoperable implementations are not demonstrated.
             </p>
-          </section>
         </section>
-        <section>
+    </section>
+    <section>
         <h3 id="controller-documents">Controller Documents</h3>
-          <p>
-A <a>controller document</a> is a set of data that specifies one or more
-relationships between a <a>controller</a> and a set of data, such as a set of
-public cryptographic keys. The <a>controller document</a> SHOULD
-contain <a>verification relationships</a> that explicitly permit the use of
-certain <a>verification methods</a> for specific purposes.
-          </p>
+        <p>
+            A <a>controller document</a> is a set of data that specifies one or more
+            relationships between a <a>controller</a> and a set of data, such as a set of
+            public cryptographic keys. The <a>controller document</a> SHOULD
+            contain <a>verification relationships</a> that explicitly permit the use of
+            certain <a>verification methods</a> for specific purposes.
+        </p>
 
 
         <section>
-          <h2 id="verification-methods">Verification Methods</h2>
+            <h2 id="verification-methods">Verification Methods</h2>
             <p>
-A <a>controller document</a> can express <a>verification methods</a>, such as
-cryptographic <a>public keys</a>, which can be used to <a>authenticate</a> or
-authorize interactions with the <a>controller</a> or associated parties. For
-example, a cryptographic <a>public key</a> can be used as a <a>verification
-method</a> with respect to a digital signature; in such usage, it verifies that
-the signer could use the associated cryptographic private key. <a>Verification
-methods</a> might take many parameters. An example of this is a set of five
-cryptographic keys from which any three are required to contribute to a
-cryptographic threshold signature.
+                A <a>controller document</a> can express <a>verification methods</a>, such as
+                cryptographic <a>public keys</a>, which can be used to <a>authenticate</a> or
+                authorize interactions with the <a>controller</a> or associated parties. For
+                example, a cryptographic <a>public key</a> can be used as a <a>verification
+                method</a> with respect to a digital signature; in such usage, it verifies that
+                the signer could use the associated cryptographic private key. <a>Verification
+                methods</a> might take many parameters. An example of this is a set of five
+                cryptographic keys from which any three are required to contribute to a
+                cryptographic threshold signature.
             </p>
 
-          <dl>
-            <dt><dfn class="lint-ignore">verificationMethod</dfn></dt>
-            <dd>
-              <p>
-The `verificationMethod` property is OPTIONAL. If present, its value
-MUST be a <a data-cite="INFRA#ordered-set">set</a> of <a>verification
-methods</a>, where each <a>verification method</a> is expressed using a <a
-data-cite="INFRA#ordered-map">map</a>. The <a>verification method</a> <a
-data-cite="INFRA#ordered-map">map</a> MUST include the `id`,
-`type`, `controller`, and specific verification material
-properties that are determined by the value of `type` and are defined
-in <a href="#verification-material"></a>. A <a>verification method</a> MAY
-include additional properties.
-              </p>
+            <dl>
+                <dt><dfn class="lint-ignore">verificationMethod</dfn></dt>
+                <dd>
+                    <p>
+                        The `verificationMethod` property is OPTIONAL. If present, its value
+                        MUST be a <a data-cite="INFRA#ordered-set">set</a> of <a>verification
+                        methods</a>, where each <a>verification method</a> is expressed using a <a
+                            data-cite="INFRA#ordered-map">map</a>. The <a>verification method</a> <a
+                            data-cite="INFRA#ordered-map">map</a> MUST include the `id`,
+                        `type`, `controller`, and specific verification material
+                        properties that are determined by the value of `type` and are defined
+                        in <a href="#verification-material"></a>. A <a>verification method</a> MAY
+                        include additional properties.
+                    </p>
 
-              <dl>
-                <dt>id</dt>
-                <dd>
-                  <p>
-The value of the `id` property for a <a>verification
-method</a> MUST be a <a data-cite="INFRA#string">string</a> that
-conforms to the [[URL]] syntax.
-                  </p>
+                    <dl>
+                        <dt>id</dt>
+                        <dd>
+                            <p>
+                                The value of the `id` property for a <a>verification
+                                method</a> MUST be a <a data-cite="INFRA#string">string</a> that
+                                conforms to the [[URL]] syntax.
+                            </p>
+                        </dd>
+                        <dt>type</dt>
+                        <dd>
+                            The value of the `type` property MUST be a <a
+                                data-cite="INFRA#string">string</a> that references exactly one <a>verification
+                            method</a> type. To maximize interoperability, the
+                            <a>verification method</a> type SHOULD be `JsonWebKey`.
+                        </dd>
+                        <dt><span id="defn-controller">controller</span></dt>
+                        <dd>
+                            The value of the `controller` property MUST be a <a
+                                data-cite="INFRA#string">string</a> that conforms to the [[URL]] syntax.
+                        </dd>
+                        <dt><dfn class="lint-ignore">revoked</dfn></dt>
+                        <dd>
+                            The `revoked` property is OPTIONAL. If present, its value MUST be an [[XMLSCHEMA11-2]]
+                            combined date and time string specifying when the <a>verification method</a>
+                            SHOULD cease to be used. Once the value is set, it is not expected to be updated, and
+                            systems depending on the value are expected to not verify any proofs associated
+                            with the <a>verification method</a> at or after the time of revocation.
+                        </dd>
+                    </dl>
                 </dd>
-                <dt>type</dt>
-                <dd>
-The value of the `type` property MUST be a <a
-data-cite="INFRA#string">string</a> that references exactly one <a>verification
-method</a> type. To maximize interoperability, the
-<a>verification method</a> type SHOULD be `JsonWebKey`.
-                </dd>
-                <dt><span id="defn-controller">controller</span></dt>
-                <dd>
-The value of the `controller` property MUST be a <a
-data-cite="INFRA#string">string</a> that conforms to the [[URL]] syntax.
-                </dd>
-                <dt><dfn class="lint-ignore">revoked</dfn></dt>
-                <dd>
-The `revoked` property is OPTIONAL. If present, its value MUST be an [[XMLSCHEMA11-2]]
-combined date and time string specifying when the <a>verification method</a>
-SHOULD cease to be used. Once the value is set, it is not expected to be updated, and
-systems depending on the value are expected to not verify any proofs associated
-with the <a>verification method</a> at or after the time of revocation.
-                </dd>
-              </dl>
-            </dd>
-          </dl>
+            </dl>
 
-          <pre class="example nohighlight"
-            title="Example verification method structure">
+            <pre class="example nohighlight"
+                 title="Example verification method structure">
     {
       "@context": [
         "https://www.w3.org/ns/did/v1",
@@ -970,52 +1010,52 @@ with the <a>verification method</a> at or after the time of revocation.
     }
           </pre>
 
-          <p class="note"
-            title="Verification method controller(s) and controller(s)">
-The semantics of the `controller` property are the same when the
-subject of the relationship is the <a>controller document</a> as when the subject of
-the relationship is a <a>verification method</a>, such as a cryptographic public
-key. Since a key can't control itself, and the key controller cannot be inferred
-from the <a>controller document</a>, it is necessary to explicitly express the identity
-of the controller of the key. The difference is that the value of
-`controller` for a <a>verification method</a> is <em>not</em>
-necessarily a <a>controller</a>. <a>Controllers</a> are expressed
-using the `<a>controller</a>` property at the highest level of the
-<a>controller document</a>.
-          </p>
-
-          <section>
-            <h3 id="verification-material">Verification Material</h3>
-
-            <p>
-Verification material MUST be expressed in the <code>publicKeyJwk</code> property
-of a <code>JsonWebKey</code>. This key material is retrieved based on hints in the
-JOSE or COSE message envelopes, such as <code>kid</code> or <code>iss</code>. At
-the time of writing, there is no standard way to retrieve a public key in JWK format
-from a DID URL or controller document.
+            <p class="note"
+               title="Verification method controller(s) and controller(s)">
+                The semantics of the `controller` property are the same when the
+                subject of the relationship is the <a>controller document</a> as when the subject of
+                the relationship is a <a>verification method</a>, such as a cryptographic public
+                key. Since a key can't control itself, and the key controller cannot be inferred
+                from the <a>controller document</a>, it is necessary to explicitly express the identity
+                of the controller of the key. The difference is that the value of
+                `controller` for a <a>verification method</a> is <em>not</em>
+                necessarily a <a>controller</a>. <a>Controllers</a> are expressed
+                using the `<a>controller</a>` property at the highest level of the
+                <a>controller document</a>.
             </p>
 
-            <p>
-A <a>verification method</a> MUST NOT contain multiple verification material
-properties for the same material. For example, expressing key material in a
-<a>verification method</a> using both `publicKeyJwk` and
-another representation is prohibited.
-            </p>
+            <section>
+                <h3 id="verification-material">Verification Material</h3>
 
-            <p>
-Implementations MAY convert keys between formats as desired for operational purposes or
-to interface with cryptographic libraries. As an internal implementation detail, such
-conversion MUST NOT affect the external representation of key material.
-            </p>
+                <p>
+                    Verification material MUST be expressed in the <code>publicKeyJwk</code> property
+                    of a <code>JsonWebKey</code>. This key material is retrieved based on hints in the
+                    JOSE or COSE message envelopes, such as <code>kid</code> or <code>iss</code>. At
+                    the time of writing, there is no standard way to retrieve a public key in JWK format
+                    from a DID URL or controller document.
+                </p>
 
-            <p>
-An example of a <a>controller document</a> containing <a>verification
-methods</a> using both properties above is shown below.
-            </p>
+                <p>
+                    A <a>verification method</a> MUST NOT contain multiple verification material
+                    properties for the same material. For example, expressing key material in a
+                    <a>verification method</a> using both `publicKeyJwk` and
+                    another representation is prohibited.
+                </p>
 
-        <pre id="example-various-verification-method-types"
-              class="example nohighlight"
-              title="Verification method using publicKeyJwk">
+                <p>
+                    Implementations MAY convert keys between formats as desired for operational purposes or
+                    to interface with cryptographic libraries. As an internal implementation detail, such
+                    conversion MUST NOT affect the external representation of key material.
+                </p>
+
+                <p>
+                    An example of a <a>controller document</a> containing <a>verification
+                    methods</a> using both properties above is shown below.
+                </p>
+
+                <pre id="example-various-verification-method-types"
+                     class="example nohighlight"
+                     title="Verification method using publicKeyJwk">
     {
       "@context": [
         "https://www.w3.org/ns/did/v1",
@@ -1033,71 +1073,75 @@ methods</a> using both properties above is shown below.
             "crv": "Ed25519", <span class="comment">// external (property name)</span>
             "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ", <span class="comment">// external (property name)</span>
             "kty": "OKP", <span class="comment">// external (property name)</span>
-            "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A" <span class="comment">// external (property name)</span>
+            "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A" <span
+                        class="comment">// external (property name)</span>
           }
         }
       ],
       <span class="comment">...</span>
     }
             </pre>
-          </section>
+            </section>
 
 
-          <section>
-            <h3 id="json-web-key">JsonWebKey</h3>
-            <p>
-The JSON Web Key (JWK) is a specific type of <a>verification method</a>
-that uses the JWK specification [[RFC7517]] to encode key types into a
-set of parameters.
-            </p>
-
-            <p>
-When specifying a `JsonWebKey`, the object takes the following form:
-            </p>
-
-            <dl>
-              <dt>type</dt>
-              <dd>
-The value of the `type` property MUST contain the string `JsonWebKey`.
-              </dd>
-              <dt><dfn class="lint-ignore">publicKeyJwk</dfn></dt>
-              <dd>
+            <section>
+                <h3 id="json-web-key">JsonWebKey</h3>
                 <p>
-The `publicKeyJwk` property is REQUIRED, and its value MUST
-be a JSON Web Key that conforms to [[RFC7517]].
-It is RECOMMENDED that verification methods that use
-JWKs [[RFC7517]] to represent their <a>public keys</a> use the value of `kid` as
-their fragment identifier. It is RECOMMENDED that JWK `kid` values be set to
-the public key fingerprint [[RFC7638]]. See the first key in the example below
-for an instance of a public key with a compound key identifier.
+                    The JSON Web Key (JWK) is a specific type of <a>verification method</a>
+                    that uses the JWK specification [[RFC7517]] to encode key types into a
+                    set of parameters.
                 </p>
+
                 <p>
-As specified in <a data-cite="RFC7517#section-4.4">Section 4.4 of the JWK specification</a>,
-the OPTIONAL `alg` property identifies the algorithm intended for use with the public key,
-and SHOULD be included to prevent security issues that can arise when using the same
-key with multiple algorithms. As specified in <a data-cite="RFC7518#section-6.2.1.1">
-Section 6.2.1.1 of the JWA specification</a>, describing a key using an elliptic curve,
-the REQUIRED `crv` property is used to identify the particular curve type of the public key.
-As specified in <a data-cite="RFC7515#section-4.1.4">Section 4.1.4 of the JWS specification</a>,
-the OPTIONAL `kid` property is a hint used to help discover the key; if present, the `kid` value SHOULD
-match, or be included in, the `id` property of the encapsulating `JsonWebKey` object,
-as part of the path, query, or fragment of the URL.
+                    When specifying a `JsonWebKey`, the object takes the following form:
                 </p>
-              </dd>
-              <dt><dfn class="lint-ignore">secretKeyJwk</dfn></dt>
-              <dd>
-The `secretKeyJwk` property is OPTIONAL. If present, its value MUST be a <a
-data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that conforms
-to [[RFC7517]].
-It MUST NOT be used if the data structure containing it is public or may be revealed to parties other than the legitimate holders of the secret key.
-              </dd>
-            </dl>
 
-            <p>
-An example of an object that conforms to `JsonWebKey` is provided below:
-            </p>
+                <dl>
+                    <dt>type</dt>
+                    <dd>
+                        The value of the `type` property MUST contain the string `JsonWebKey`.
+                    </dd>
+                    <dt><dfn class="lint-ignore">publicKeyJwk</dfn></dt>
+                    <dd>
+                        <p>
+                            The `publicKeyJwk` property is REQUIRED, and its value MUST
+                            be a JSON Web Key that conforms to [[RFC7517]].
+                            It is RECOMMENDED that verification methods that use
+                            JWKs [[RFC7517]] to represent their <a>public keys</a> use the value of `kid` as
+                            their fragment identifier. It is RECOMMENDED that JWK `kid` values be set to
+                            the public key fingerprint [[RFC7638]]. See the first key in the example below
+                            for an instance of a public key with a compound key identifier.
+                        </p>
+                        <p>
+                            As specified in <a data-cite="RFC7517#section-4.4">Section 4.4 of the JWK specification</a>,
+                            the OPTIONAL `alg` property identifies the algorithm intended for use with the public key,
+                            and SHOULD be included to prevent security issues that can arise when using the same
+                            key with multiple algorithms. As specified in <a data-cite="RFC7518#section-6.2.1.1">
+                            Section 6.2.1.1 of the JWA specification</a>, describing a key using an elliptic curve,
+                            the REQUIRED `crv` property is used to identify the particular curve type of the public key.
+                            As specified in <a data-cite="RFC7515#section-4.1.4">Section 4.1.4 of the JWS
+                            specification</a>,
+                            the OPTIONAL `kid` property is a hint used to help discover the key; if present, the `kid`
+                            value SHOULD
+                            match, or be included in, the `id` property of the encapsulating `JsonWebKey` object,
+                            as part of the path, query, or fragment of the URL.
+                        </p>
+                    </dd>
+                    <dt><dfn class="lint-ignore">secretKeyJwk</dfn></dt>
+                    <dd>
+                        The `secretKeyJwk` property is OPTIONAL. If present, its value MUST be a <a
+                            data-cite="INFRA#ordered-map">map</a> representing a JSON Web Key that conforms
+                        to [[RFC7517]].
+                        It MUST NOT be used if the data structure containing it is public or may be revealed to parties
+                        other than the legitimate holders of the secret key.
+                    </dd>
+                </dl>
 
-            <pre class="example nohighlight" title="JSON Web Key encoding of a secp384r1 (P-384) public key">
+                <p>
+                    An example of an object that conforms to `JsonWebKey` is provided below:
+                </p>
+
+                <pre class="example nohighlight" title="JSON Web Key encoding of a secp384r1 (P-384) public key">
 {
   "id": "did:example:123456789abcdefghi#key-1",
   "type": "JsonWebKey",
@@ -1113,27 +1157,28 @@ An example of an object that conforms to `JsonWebKey` is provided below:
 }
             </pre>
 
-            <p>
-In the example above, the `publicKeyJwk` value contains the JSON Web Key.
-The `kty` property encodes the key type of "OKP", which means
-"Octet string key pairs". The `alg` property identifies the algorithm intended
-for use with the public key, which in this case is `ES384`. The `crv` property identifies
-the particular curve type of the public key, `P-384`. The `x` property specifies
-the point on the P-384 curve that is associated with the public key.
-            </p>
+                <p>
+                    In the example above, the `publicKeyJwk` value contains the JSON Web Key.
+                    The `kty` property encodes the key type of "OKP", which means
+                    "Octet string key pairs". The `alg` property identifies the algorithm intended
+                    for use with the public key, which in this case is `ES384`. The `crv` property identifies
+                    the particular curve type of the public key, `P-384`. The `x` property specifies
+                    the point on the P-384 curve that is associated with the public key.
+                </p>
 
-            <p>
-The `publicKeyJwk` property MUST NOT contain any property marked as
-"Private" or "Secret" in any registry contained in the JOSE Registries [[JOSE-REGISTRIES]], including "d".
-            </p>
+                <p>
+                    The `publicKeyJwk` property MUST NOT contain any property marked as
+                    "Private" or "Secret" in any registry contained in the JOSE Registries [[JOSE-REGISTRIES]],
+                    including "d".
+                </p>
 
-            <p>
-JSON Web Key is also capable of encoding <em>secret keys</em>, sometimes
-referred to as <em>private keys</em>.
-            </p>
+                <p>
+                    JSON Web Key is also capable of encoding <em>secret keys</em>, sometimes
+                    referred to as <em>private keys</em>.
+                </p>
 
-            <pre class="example nohighlight"
-              title="JSON Web Key encoding of a secp384r1 (P-384) secret key">
+                <pre class="example nohighlight"
+                     title="JSON Web Key encoding of a secp384r1 (P-384) secret key">
 {
   "id": "did:example:123456789abcdefghi#key-1",
   "type": "JsonWebKey",
@@ -1149,37 +1194,37 @@ referred to as <em>private keys</em>.
 }
             </pre>
 
-            <p>
-The private key example above is almost identical to the previous example of the
-public key, except that the information is stored in the `secretKeyJwk` property
-(rather than the `publicKeyJwk`), and the private key value is encoded in the `d`
-property thereof (alongside the `x` property, which still specifies the point on
-the secp384r1 curve that is associated with the public key).
-            </p>
+                <p>
+                    The private key example above is almost identical to the previous example of the
+                    public key, except that the information is stored in the `secretKeyJwk` property
+                    (rather than the `publicKeyJwk`), and the private key value is encoded in the `d`
+                    property thereof (alongside the `x` property, which still specifies the point on
+                    the secp384r1 curve that is associated with the public key).
+                </p>
 
-          </section>
+            </section>
 
-          <section>
-            <h3 id="referring-to-verification-methods">Referring to Verification Methods</h3>
-            <p>
-<a>Verification methods</a> can be referenced from properties
-associated with various <a>verification relationships</a> as described in <a
-href="#verification-relationships"></a>. Referencing <a>verification methods</a>
-allows them to be used by more than one <a>verification relationship</a>.
-            </p>
+            <section>
+                <h3 id="referring-to-verification-methods">Referring to Verification Methods</h3>
+                <p>
+                    <a>Verification methods</a> can be referenced from properties
+                    associated with various <a>verification relationships</a> as described in <a
+                        href="#verification-relationships"></a>. Referencing <a>verification methods</a>
+                    allows them to be used by more than one <a>verification relationship</a>.
+                </p>
 
-            <p>
-If the value of a <a>verification method</a> property is a
-URL <a data-cite="INFRA#string">string</a>, the <a>verification method</a> has
-been included by reference and its properties will need to be retrieved from
-elsewhere in the <a>controller document</a> or from another <a>controller document</a>. This
-is done by dereferencing the URL and searching the resulting <a>resource</a> for a
-<a>verification method</a> <a data-cite="INFRA#ordered-map">map</a> with an
-`id` property whose value matches the URL.
-            </p>
+                <p>
+                    If the value of a <a>verification method</a> property is a
+                    URL <a data-cite="INFRA#string">string</a>, the <a>verification method</a> has
+                    been included by reference and its properties will need to be retrieved from
+                    elsewhere in the <a>controller document</a> or from another <a>controller document</a>. This
+                    is done by dereferencing the URL and searching the resulting <a>resource</a> for a
+                    <a>verification method</a> <a data-cite="INFRA#ordered-map">map</a> with an
+                    `id` property whose value matches the URL.
+                </p>
 
-            <pre class="example nohighlight"
-            title="Referencing verification methods">
+                <pre class="example nohighlight"
+                     title="Referencing verification methods">
     {
 <span class="comment">...</span>
 
@@ -1192,65 +1237,65 @@ is done by dereferencing the URL and searching the resulting <a>resource</a> for
 <span class="comment">...</span>
     }
             </pre>
-          </section>
+            </section>
         </section>
 
         <section>
-          <h2 id="verification-relationships">Verification Relationships</h2>
-
-          <p>
-A <a>verification relationship</a> expresses the relationship between the
-<a>controller</a> and a <a>verification method</a>.
-          </p>
-          <p>
-Different <a>verification relationships</a> enable the associated
-<a>verification methods</a> to be used for different purposes. It is up to a
-<em>verifier</em> to ascertain the validity of a verification attempt by
-checking that the <a>verification method</a> used is contained in the
-appropriate <a>verification relationship</a> property of the
-<a>controller document</a>.
-          </p>
-          <p>
-The <a>verification relationship</a> between the <a>controller</a> and the
-<a>verification method</a> is explicit in the <a>controller document</a>.
-<a>Verification methods</a> that are not associated with a particular
-<a>verification relationship</a> cannot be used for that <a>verification
-relationship</a>.
-          </p>
-          <p>
-The <a>controller document</a> does not express revoked keys using a <a>verification
-relationship</a>. If a referenced verification method is not in the latest
-<a>controller document</a> used to dereference it, then that verification method is
-considered invalid or revoked.
-          </p>
-          <p>
-The following sections define several useful <a>verification relationships</a>.
-A <a>controller document</a> MAY include any of these, or other properties, to
-express a specific <a>verification relationship</a>. To maximize global
-interoperability, any such properties used SHOULD be registered in the
-<a data-cite="VC-SPECS-DIR#securing-mechanisms">VC Specifications Directory</a>.
-          </p>
-          <section>
-            <h2 id="authentication">Authentication</h2>
+            <h2 id="verification-relationships">Verification Relationships</h2>
 
             <p>
-The `authentication` <a>verification relationship</a> is used to
-specify how the <a>controller</a> is expected to be <a>authenticated</a>, for
-purposes such as logging into a website or engaging in any sort of
-challenge-response protocol.
+                A <a>verification relationship</a> expresses the relationship between the
+                <a>controller</a> and a <a>verification method</a>.
             </p>
+            <p>
+                Different <a>verification relationships</a> enable the associated
+                <a>verification methods</a> to be used for different purposes. It is up to a
+                <em>verifier</em> to ascertain the validity of a verification attempt by
+                checking that the <a>verification method</a> used is contained in the
+                appropriate <a>verification relationship</a> property of the
+                <a>controller document</a>.
+            </p>
+            <p>
+                The <a>verification relationship</a> between the <a>controller</a> and the
+                <a>verification method</a> is explicit in the <a>controller document</a>.
+                <a>Verification methods</a> that are not associated with a particular
+                <a>verification relationship</a> cannot be used for that <a>verification
+                relationship</a>.
+            </p>
+            <p>
+                The <a>controller document</a> does not express revoked keys using a <a>verification
+                relationship</a>. If a referenced verification method is not in the latest
+                <a>controller document</a> used to dereference it, then that verification method is
+                considered invalid or revoked.
+            </p>
+            <p>
+                The following sections define several useful <a>verification relationships</a>.
+                A <a>controller document</a> MAY include any of these, or other properties, to
+                express a specific <a>verification relationship</a>. To maximize global
+                interoperability, any such properties used SHOULD be registered in the
+                <a data-cite="VC-SPECS-DIR#securing-mechanisms">VC Specifications Directory</a>.
+            </p>
+            <section>
+                <h2 id="authentication">Authentication</h2>
 
-            <dl>
-              <dt id="defn-authentication">authentication</dt>
-              <dd>
-The `authentication` property is OPTIONAL. If present, its
-value MUST be a <a data-cite="INFRA#ordered-set">set</a> of one or more
-<a>verification methods</a>. Each <a>verification method</a> MAY be embedded or
-referenced.
-              </dd>
-            </dl>
+                <p>
+                    The `authentication` <a>verification relationship</a> is used to
+                    specify how the <a>controller</a> is expected to be <a>authenticated</a>, for
+                    purposes such as logging into a website or engaging in any sort of
+                    challenge-response protocol.
+                </p>
 
-            <pre class="example nohighlight" title="Authentication property
+                <dl>
+                    <dt id="defn-authentication">authentication</dt>
+                    <dd>
+                        The `authentication` property is OPTIONAL. If present, its
+                        value MUST be a <a data-cite="INFRA#ordered-set">set</a> of one or more
+                        <a>verification methods</a>. Each <a>verification method</a> MAY be embedded or
+                        referenced.
+                    </dd>
+                </dl>
+
+                <pre class="example nohighlight" title="Authentication property
                           containing three verification methods">
     {
       "@context": [
@@ -1266,56 +1311,56 @@ referenced.
     }
             </pre>
 
-            <p>
-If authentication is established, it is up to the application to decide what to
-do with that information.
-            </p>
-            <p>
-This is useful to any <em>authentication verifier</em> that needs to check to
-see whether an entity that is attempting to <a>authenticate</a> is, in fact,
-presenting a valid proof of authentication. When a <em>verifier</em> receives
-some data (in some protocol-specific format) that contains a proof that was made
-for the purpose of "authentication", and that says that an entity is identified
-by the `id`, then that <em>verifier</em> checks to ensure that the proof can be
-verified using a <a>verification method</a> (e.g., <a>public key</a>) listed
-under `<a>authentication</a>` in the <a>controller document</a>.
-            </p>
-            <p>
-Note that the <a>verification method</a> indicated by the
-`<a>authentication</a>` property of a <a>controller document</a> can
-only be used to <a>authenticate</a> the <a>controller</a>. To
-<a>authenticate</a> a different <a>controller</a>, the entity associated with
-the value of `controller` needs to <a>authenticate</a> with its
-<em>own</em> <a>controller document</a> and associated
-`<a>authentication</a>` <a>verification relationship</a>.
-            </p>
-          </section>
+                <p>
+                    If authentication is established, it is up to the application to decide what to
+                    do with that information.
+                </p>
+                <p>
+                    This is useful to any <em>authentication verifier</em> that needs to check to
+                    see whether an entity that is attempting to <a>authenticate</a> is, in fact,
+                    presenting a valid proof of authentication. When a <em>verifier</em> receives
+                    some data (in some protocol-specific format) that contains a proof that was made
+                    for the purpose of "authentication", and that says that an entity is identified
+                    by the `id`, then that <em>verifier</em> checks to ensure that the proof can be
+                    verified using a <a>verification method</a> (e.g., <a>public key</a>) listed
+                    under `<a>authentication</a>` in the <a>controller document</a>.
+                </p>
+                <p>
+                    Note that the <a>verification method</a> indicated by the
+                    `<a>authentication</a>` property of a <a>controller document</a> can
+                    only be used to <a>authenticate</a> the <a>controller</a>. To
+                    <a>authenticate</a> a different <a>controller</a>, the entity associated with
+                    the value of `controller` needs to <a>authenticate</a> with its
+                    <em>own</em> <a>controller document</a> and associated
+                    `<a>authentication</a>` <a>verification relationship</a>.
+                </p>
+            </section>
 
-          <section>
-            <h2 id="assertion">Assertion</h2>
+            <section>
+                <h2 id="assertion">Assertion</h2>
 
-            <p>
-The `assertionMethod` <a>verification relationship</a> is used to
-specify how the <a>controller</a> is expected to express claims, such as for
-the purposes of issuing a Verifiable Credential [[?VC-DATA-MODEL-2.0]].
-            </p>
+                <p>
+                    The `assertionMethod` <a>verification relationship</a> is used to
+                    specify how the <a>controller</a> is expected to express claims, such as for
+                    the purposes of issuing a Verifiable Credential [[?VC-DATA-MODEL-2.0]].
+                </p>
 
-            <dl>
-              <dt>assertionMethod</dt>
-              <dd>
-The `assertionMethod` property is OPTIONAL. If present, its
-value MUST be a <a data-cite="INFRA#ordered-set">set</a> of
-one or more <a>verification methods</a>. Each <a>verification method</a> MAY be
-embedded or referenced.
-              </dd>
-            </dl>
+                <dl>
+                    <dt>assertionMethod</dt>
+                    <dd>
+                        The `assertionMethod` property is OPTIONAL. If present, its
+                        value MUST be a <a data-cite="INFRA#ordered-set">set</a> of
+                        one or more <a>verification methods</a>. Each <a>verification method</a> MAY be
+                        embedded or referenced.
+                    </dd>
+                </dl>
 
-            <p>
-This property is useful, for example, during the processing of a <a>verifiable
-credential</a> by a verifier.
-            </p>
+                <p>
+                    This property is useful, for example, during the processing of a <a>verifiable
+                    credential</a> by a verifier.
+                </p>
 
-            <pre class="example nohighlight" title="Assertion method property">
+                <pre class="example nohighlight" title="Assertion method property">
     {
       "@context": [
         "https://www.w3.org/ns/did/v1",
@@ -1329,858 +1374,858 @@ credential</a> by a verifier.
       <span class="comment">...</span>
     }
             </pre>
-          </section>
+            </section>
         </section>
-      </section>
-      </section>
+    </section>
+</section>
 
-  <section id="conformance">
+<section id="conformance">
     <section class="normative">
-      <h2 id="conformance-classes">Conformance Classes</h2>
-      <p>
-      A <dfn>conforming JWS document</dfn> is one that conforms to all of the
-      "MUST" statements in Section <a href="#secure-with-jose"></a>.
-      </p>
-      <p>
-      A <dfn>conforming JWS issuer implementation</dfn> produces
-      [=conforming JWS documents=] and MUST secure them as described in Section
-      <a href="#secure-with-jose"></a>.
-      <p>
-      A <dfn>conforming JWS verifier implementation</dfn> verifies
-      [=conforming JWS documents=] as described in Section
-      <a href="#secure-with-jose"></a>.
-      </p>
-      <p>
-      A <dfn>conforming SD-JWT document</dfn> is one that conforms to all of the
-      "MUST" statements in Section <a href="#secure-with-sd-jwt"></a>.
-      </p>
-      <p>
-      A <dfn>conforming SD-JWT issuer implementation</dfn> produces
-      [=conforming SD-JWT documents=] and MUST secure them as described in Section
-      <a href="#secure-with-sd-jwt"></a>.
-      <p>
-      A <dfn>conforming SD-JWT verifier implementation</dfn> verifies
-      [=conforming SD-JWT documents=] as described in Section
-      <a href="#secure-with-sd-jwt"></a>.
-      </p>
-      <p>
-      A <dfn>conforming COSE document</dfn> is one that conforms to all of the
-      "MUST" statements in Section <a href="#secure-with-cose"></a>.
-      </p>
-      <p>
-      A <dfn>conforming COSE issuer implementation</dfn> produces
-      [=conforming COSE documents=] and MUST secure them as described in Section
-      <a href="#secure-with-cose"></a>.
-      </p>
-      <p>
-      A <dfn>conforming COSE verifier implementation</dfn> verifies
-      [=conforming COSE documents=] as described in Section
-      <a href="#secure-with-cose"></a>.
-      </p>
+        <h2 id="conformance-classes">Conformance Classes</h2>
+        <p>
+            A <dfn>conforming JWS document</dfn> is one that conforms to all of the
+            "MUST" statements in Section <a href="#secure-with-jose"></a>.
+        </p>
+        <p>
+            A <dfn>conforming JWS issuer implementation</dfn> produces
+            [=conforming JWS documents=] and MUST secure them as described in Section
+            <a href="#secure-with-jose"></a>.
+        <p>
+            A <dfn>conforming JWS verifier implementation</dfn> verifies
+            [=conforming JWS documents=] as described in Section
+            <a href="#secure-with-jose"></a>.
+        </p>
+        <p>
+            A <dfn>conforming SD-JWT document</dfn> is one that conforms to all of the
+            "MUST" statements in Section <a href="#secure-with-sd-jwt"></a>.
+        </p>
+        <p>
+            A <dfn>conforming SD-JWT issuer implementation</dfn> produces
+            [=conforming SD-JWT documents=] and MUST secure them as described in Section
+            <a href="#secure-with-sd-jwt"></a>.
+        <p>
+            A <dfn>conforming SD-JWT verifier implementation</dfn> verifies
+            [=conforming SD-JWT documents=] as described in Section
+            <a href="#secure-with-sd-jwt"></a>.
+        </p>
+        <p>
+            A <dfn>conforming COSE document</dfn> is one that conforms to all of the
+            "MUST" statements in Section <a href="#secure-with-cose"></a>.
+        </p>
+        <p>
+            A <dfn>conforming COSE issuer implementation</dfn> produces
+            [=conforming COSE documents=] and MUST secure them as described in Section
+            <a href="#secure-with-cose"></a>.
+        </p>
+        <p>
+            A <dfn>conforming COSE verifier implementation</dfn> verifies
+            [=conforming COSE documents=] as described in Section
+            <a href="#secure-with-cose"></a>.
+        </p>
     </section>
     <section class="normative">
-      <h2 id="securing-verifiable-credentials">Securing Verifiable Credentials</h2>
-      <p>The <a data-cite="VC-DATA-MODEL-2.0#securing-mechanism-specifications"></a> describes 
-        the approach taken by JSON Web Tokens to secure JWT Claims Sets as <i>applying an
-        <code>external proof</code></i>.
-      </p>
-      <p>The normative statements in <a data-cite="VC-DATA-MODEL-2.0#securing-mechanisms">Securing
-          Mechanisms</a> apply to securing
-        <code>application/vc+ld+json</code> and
-        <code>application/vp+ld+json</code>,
-        <code>application/vc+ld+json+sd-jwt</code> and
-        <code>application/vp+ld+json+sd-jwt</code>,
-        as well as
-        <code>application/vc+ld+json+cose</code> and
-        <code>application/vp+ld+json+cose</code>.
-      </p>
-      <p>
-        JSON Web Token implementers are advised to review <a data-cite="RFC7519#section-8">Implementation
-          Requirements</a>.
-      </p>
-      <p>
-        Accordingly, Issuers, Holders, and Verifiers MUST understand the
-        JSON Web Token header parameter
-        <code>"alg": "none"</code> when securing [[VC-DATA-MODEL-2.0]]
-        with JSON Web Tokens.
-        When content types from [[VC-DATA-MODEL-2.0]] are secured using
-        JSON Web Tokens, the header parameter <code>"alg": "none"</code>,
-  MUST be used to communicate that a JWT Claims Set (a
-        Verifiable Credential or a Verifiable Presentation) has no
-        integrity protection.
-        When a JWT Claims Set (a Verifiable Credential or a
-        Verifiable Presentation) contains
-        <code>proof</code>, and the JSON Web Token header contains
-        <code>"alg": "none"</code>, the JWT Claims Set MUST be considered to
-        have no integrity protection.
-      </p>
-      <p class="advisement">
-        Verifiable Credentials and Verifiable Presentations are not
-        required to be secured or integrity protected or to contain a
-        <code>proof</code> member.
-      </p>
-      <p>
-        Issuers, Holders, and Verifiers MUST ignore all JWT Claims Sets that
-        have no integrity protection.
-      </p>
-      <p>
-        The JWT Claim Names <code>vc</code> and <code>vp</code>
-        MUST NOT be present in any JWT Claims Set.
-      </p>
+        <h2 id="securing-verifiable-credentials">Securing Verifiable Credentials</h2>
+        <p>The <a data-cite="VC-DATA-MODEL-2.0#securing-mechanism-specifications"></a> describes
+            the approach taken by JSON Web Tokens to secure JWT Claims Sets as <i>applying an
+                <code>external proof</code></i>.
+        </p>
+        <p>The normative statements in <a data-cite="VC-DATA-MODEL-2.0#securing-mechanisms">Securing
+            Mechanisms</a> apply to securing
+            <code>application/vc+ld+json</code> and
+            <code>application/vp+ld+json</code>,
+            <code>application/vc+ld+json+sd-jwt</code> and
+            <code>application/vp+ld+json+sd-jwt</code>,
+            as well as
+            <code>application/vc+ld+json+cose</code> and
+            <code>application/vp+ld+json+cose</code>.
+        </p>
+        <p>
+            JSON Web Token implementers are advised to review <a data-cite="RFC7519#section-8">Implementation
+            Requirements</a>.
+        </p>
+        <p>
+            Accordingly, Issuers, Holders, and Verifiers MUST understand the
+            JSON Web Token header parameter
+            <code>"alg": "none"</code> when securing [[VC-DATA-MODEL-2.0]]
+            with JSON Web Tokens.
+            When content types from [[VC-DATA-MODEL-2.0]] are secured using
+            JSON Web Tokens, the header parameter <code>"alg": "none"</code>,
+            MUST be used to communicate that a JWT Claims Set (a
+            Verifiable Credential or a Verifiable Presentation) has no
+            integrity protection.
+            When a JWT Claims Set (a Verifiable Credential or a
+            Verifiable Presentation) contains
+            <code>proof</code>, and the JSON Web Token header contains
+            <code>"alg": "none"</code>, the JWT Claims Set MUST be considered to
+            have no integrity protection.
+        </p>
+        <p class="advisement">
+            Verifiable Credentials and Verifiable Presentations are not
+            required to be secured or integrity protected or to contain a
+            <code>proof</code> member.
+        </p>
+        <p>
+            Issuers, Holders, and Verifiers MUST ignore all JWT Claims Sets that
+            have no integrity protection.
+        </p>
+        <p>
+            The JWT Claim Names <code>vc</code> and <code>vp</code>
+            MUST NOT be present in any JWT Claims Set.
+        </p>
     </section>
 
-  </section>
+</section>
 
-  <section class="normative">
+<section class="normative">
     <h2 id="iana-considerations">IANA Considerations</h2>
 
     <section>
-    <h2 id="media-types">Media Types</h2>
+        <h2 id="media-types">Media Types</h2>
 
-    <section id="vc-ld-jwt-media-type">
-      <h2 id="vcc-ld-json-jwt"><code>application/vc+ld+json+jwt</code></h2>
-      <p>
-        This specification registers the
-        <code>application/vc+ld+json+jwt</code> Media Type specifically for
-        identifying a <a data-cite="JWT"></a>
-	with a payload
-        conforming to the Verifiable Credential Data Model.
-      </p>
-      <table>
-        <tr>
-          <td>Type name: </td>
-          <td>`application`</td>
-        </tr>
-        <tr>
-          <td>Subtype name: </td>
-          <td>`vc+ld+json+jwt`</td>
-        </tr>
-        <tr>
-          <td>Required parameters: </td>
-          <td>None</td>
-        </tr>
-        <tr>
-          <td>Encoding considerations: </td>
-          <td>
-            binary; `application/jwt` values are a series of base64url-encoded values
-            (some of which may be the empty string) separated by period ('.').
-          </td>
-        </tr>
-        <tr>
-          <td>Security considerations: </td>
-          <td>
-            <p>As defined in this specification. See also the security
-            considerations in <a data-cite="JWT"></a>.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>Contact: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-      </table>
-    </section>
+        <section id="vc-ld-jwt-media-type">
+            <h2 id="vcc-ld-json-jwt"><code>application/vc+ld+json+jwt</code></h2>
+            <p>
+                This specification registers the
+                <code>application/vc+ld+json+jwt</code> Media Type specifically for
+                identifying a <a data-cite="JWT"></a>
+                with a payload
+                conforming to the Verifiable Credential Data Model.
+            </p>
+            <table>
+                <tr>
+                    <td>Type name:</td>
+                    <td>`application`</td>
+                </tr>
+                <tr>
+                    <td>Subtype name:</td>
+                    <td>`vc+ld+json+jwt`</td>
+                </tr>
+                <tr>
+                    <td>Required parameters:</td>
+                    <td>None</td>
+                </tr>
+                <tr>
+                    <td>Encoding considerations:</td>
+                    <td>
+                        binary; `application/jwt` values are a series of base64url-encoded values
+                        (some of which may be the empty string) separated by period ('.').
+                    </td>
+                </tr>
+                <tr>
+                    <td>Security considerations:</td>
+                    <td>
+                        <p>As defined in this specification. See also the security
+                            considerations in <a data-cite="JWT"></a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Contact:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+            </table>
+        </section>
 
-    <section id="vp-ld-jwt-media-type">
-      <h2 id="vp-ld-json-jwt"><code>application/vp+ld+json+jwt</code></h2>
-      <p>
-        This specification registers the
-        <code>application/vp+ld+json+jwt</code> Media Type specifically for
-        identifying a <a data-cite="JWT"></a>
-	with a payload
-        conforming to Verifiable Presentations.
-      </p>
-      <table>
-        <tr>
-          <td>Type name: </td>
-          <td>application</td>
-        </tr>
-        <tr>
-          <td>Subtype name: </td>
-          <td>vp+ld+json+jwt</td>
-        </tr>
-        <tr>
-          <td>Required parameters: </td>
-          <td>None</td>
-        </tr>
-        <tr>
-          <td>Encoding considerations: </td>
-          <td>
-            binary; `application/jwt` values are a series of base64url-encoded values
-            (some of which may be the empty string) separated by period ('.').
-          </td>
-        </tr>
-        <tr>
-          <td>Security considerations: </td>
-          <td>
-            <p>As defined in this specification. See also the security
-            considerations in <a data-cite="JWT"></a>.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>Contact: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-      </table>
-    </section>
+        <section id="vp-ld-jwt-media-type">
+            <h2 id="vp-ld-json-jwt"><code>application/vp+ld+json+jwt</code></h2>
+            <p>
+                This specification registers the
+                <code>application/vp+ld+json+jwt</code> Media Type specifically for
+                identifying a <a data-cite="JWT"></a>
+                with a payload
+                conforming to Verifiable Presentations.
+            </p>
+            <table>
+                <tr>
+                    <td>Type name:</td>
+                    <td>application</td>
+                </tr>
+                <tr>
+                    <td>Subtype name:</td>
+                    <td>vp+ld+json+jwt</td>
+                </tr>
+                <tr>
+                    <td>Required parameters:</td>
+                    <td>None</td>
+                </tr>
+                <tr>
+                    <td>Encoding considerations:</td>
+                    <td>
+                        binary; `application/jwt` values are a series of base64url-encoded values
+                        (some of which may be the empty string) separated by period ('.').
+                    </td>
+                </tr>
+                <tr>
+                    <td>Security considerations:</td>
+                    <td>
+                        <p>As defined in this specification. See also the security
+                            considerations in <a data-cite="JWT"></a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Contact:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+            </table>
+        </section>
 
-    <section id="vc-ld-sd-jwt-media-type">
-      <h2 id="vc-ld-json-sd-jwt"><code>application/vc+ld+json+sd-jwt</code></h2>
-      <p>
-        This specification registers the
-        <code>application/vc+ld+json+sd-jwt</code> Media Type specifically for
-        identifying a <a data-cite="SD-JWT"></a>
-	with a payload
-        conforming to the Verifiable Credential Data Model.
-      </p>
-      <table>
-        <tr>
-          <td>Type name: </td>
-          <td>`application`</td>
-        </tr>
-        <tr>
-          <td>Subtype name: </td>
-          <td>`vc+ld+json+sd-jwt`</td>
-        </tr>
-        <tr>
-          <td>Required parameters: </td>
-          <td>None</td>
-        </tr>
-        <tr>
-          <td>Encoding considerations: </td>
-          <td>
-            binary; `application/sd-jwt` values are a series of base64url-encoded values
-            (some of which may be the empty string) separated by period ('.') or tilde ('~') characters.
-          </td>
-        </tr>
-        <tr>
-          <td>Security considerations: </td>
-          <td>
-            <p>As defined in this specification. See also the security
-            considerations in <a data-cite="SD-JWT"></a>.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>Contact: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-      </table>
-    </section>
+        <section id="vc-ld-sd-jwt-media-type">
+            <h2 id="vc-ld-json-sd-jwt"><code>application/vc+ld+json+sd-jwt</code></h2>
+            <p>
+                This specification registers the
+                <code>application/vc+ld+json+sd-jwt</code> Media Type specifically for
+                identifying a <a data-cite="SD-JWT"></a>
+                with a payload
+                conforming to the Verifiable Credential Data Model.
+            </p>
+            <table>
+                <tr>
+                    <td>Type name:</td>
+                    <td>`application`</td>
+                </tr>
+                <tr>
+                    <td>Subtype name:</td>
+                    <td>`vc+ld+json+sd-jwt`</td>
+                </tr>
+                <tr>
+                    <td>Required parameters:</td>
+                    <td>None</td>
+                </tr>
+                <tr>
+                    <td>Encoding considerations:</td>
+                    <td>
+                        binary; `application/sd-jwt` values are a series of base64url-encoded values
+                        (some of which may be the empty string) separated by period ('.') or tilde ('~') characters.
+                    </td>
+                </tr>
+                <tr>
+                    <td>Security considerations:</td>
+                    <td>
+                        <p>As defined in this specification. See also the security
+                            considerations in <a data-cite="SD-JWT"></a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Contact:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+            </table>
+        </section>
 
-    <section id="vp-ld-sd-jwt-media-type">
-      <h2 id="vp-ld-json-sd-jwt"><code>application/vp+ld+json+sd-jwt</code></h2>
-      <p>
-        This specification registers the
-        <code>application/vp+ld+json+sd-jwt</code> Media Type specifically for
-        identifying a <a data-cite="SD-JWT"></a>
-	with a payload
-        conforming to Verifiable Presentations.
-      </p>
-      <table>
-        <tr>
-          <td>Type name: </td>
-          <td>application</td>
-        </tr>
-        <tr>
-          <td>Subtype name: </td>
-          <td>vp+ld+json+sd-jwt</td>
-        </tr>
-        <tr>
-          <td>Required parameters: </td>
-          <td>None</td>
-        </tr>
-        <tr>
-          <td>Encoding considerations: </td>
-          <td>
-            binary; `application/sd-jwt` values are a series of base64url-encoded values
-            (some of which may be the empty string) separated by period ('.') or tilde ('~') characters.
-          </td>
-        </tr>
-        <tr>
-          <td>Security considerations: </td>
-          <td>
-            <p>As defined in this specification. See also the security
-            considerations in <a data-cite="SD-JWT"></a>.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>Contact: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-      </table>
-    </section>
+        <section id="vp-ld-sd-jwt-media-type">
+            <h2 id="vp-ld-json-sd-jwt"><code>application/vp+ld+json+sd-jwt</code></h2>
+            <p>
+                This specification registers the
+                <code>application/vp+ld+json+sd-jwt</code> Media Type specifically for
+                identifying a <a data-cite="SD-JWT"></a>
+                with a payload
+                conforming to Verifiable Presentations.
+            </p>
+            <table>
+                <tr>
+                    <td>Type name:</td>
+                    <td>application</td>
+                </tr>
+                <tr>
+                    <td>Subtype name:</td>
+                    <td>vp+ld+json+sd-jwt</td>
+                </tr>
+                <tr>
+                    <td>Required parameters:</td>
+                    <td>None</td>
+                </tr>
+                <tr>
+                    <td>Encoding considerations:</td>
+                    <td>
+                        binary; `application/sd-jwt` values are a series of base64url-encoded values
+                        (some of which may be the empty string) separated by period ('.') or tilde ('~') characters.
+                    </td>
+                </tr>
+                <tr>
+                    <td>Security considerations:</td>
+                    <td>
+                        <p>As defined in this specification. See also the security
+                            considerations in <a data-cite="SD-JWT"></a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Contact:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+            </table>
+        </section>
 
-    <section id="vc-ld-json-cose-media-type">
-      <h2 id="vc-ld-json-cose"><code>application/vc+ld+json+cose</code></h2>
-      <p>
-        This specification registers the
-        <code>application/vc+ld+json+cose</code> Media Type specifically for
-        identifying a COSE object [[RFC9052]]
-	with a payload
-        conforming to the Verifiable Credential Data Model.
-      </p>
-      <table>
-        <tr>
-          <td>Type name: </td>
-          <td>`application`</td>
-        </tr>
-        <tr>
-          <td>Subtype name: </td>
-          <td>`vc+ld+json+cose`</td>
-        </tr>
-        <tr>
-          <td>Required parameters: </td>
-          <td>None</td>
-        </tr>
-        <tr>
-          <td>Encoding considerations: </td>
-          <td>
-            binary (CBOR)
-          </td>
-        </tr>
-        <tr>
-          <td>Security considerations: </td>
-          <td>
-            <p>As defined in this specification. See also the security
-            considerations in [[RFC9052]]</a>.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>Contact: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-      </table>
-    </section>
+        <section id="vc-ld-json-cose-media-type">
+            <h2 id="vc-ld-json-cose"><code>application/vc+ld+json+cose</code></h2>
+            <p>
+                This specification registers the
+                <code>application/vc+ld+json+cose</code> Media Type specifically for
+                identifying a COSE object [[RFC9052]]
+                with a payload
+                conforming to the Verifiable Credential Data Model.
+            </p>
+            <table>
+                <tr>
+                    <td>Type name:</td>
+                    <td>`application`</td>
+                </tr>
+                <tr>
+                    <td>Subtype name:</td>
+                    <td>`vc+ld+json+cose`</td>
+                </tr>
+                <tr>
+                    <td>Required parameters:</td>
+                    <td>None</td>
+                </tr>
+                <tr>
+                    <td>Encoding considerations:</td>
+                    <td>
+                        binary (CBOR)
+                    </td>
+                </tr>
+                <tr>
+                    <td>Security considerations:</td>
+                    <td>
+                        <p>As defined in this specification. See also the security
+                            considerations in [[RFC9052]]</a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Contact:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+            </table>
+        </section>
 
-    <section id="vp-ld-json-cose-media-type">
-      <h2 id="vp-ld-json-cose"><code>application/vp+ld+json+cose</code></h2>
-      <p>
-        This specification registers the
-        <code>application/vp+ld+json+cose</code> Media Type specifically for
-        identifying a COSE object [[RFC9052]]
-	with a payload
-        conforming to Verifiable Presentations.
-      </p>
-      <table>
-        <tr>
-          <td>Type name: </td>
-          <td>`application`</td>
-        </tr>
-        <tr>
-          <td>Subtype name: </td>
-          <td>`vp+ld+json+cose`</td>
-        </tr>
-        <tr>
-          <td>Required parameters: </td>
-          <td>None</td>
-        </tr>
-        <tr>
-          <td>Encoding considerations: </td>
-          <td>
-            binary (CBOR)
-          </td>
-        </tr>
-        <tr>
-          <td>Security considerations: </td>
-          <td>
-            <p>As defined in this specification. See also the security
-            considerations in [[RFC9052]]</a>.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>Contact: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-      </table>
-    </section>
+        <section id="vp-ld-json-cose-media-type">
+            <h2 id="vp-ld-json-cose"><code>application/vp+ld+json+cose</code></h2>
+            <p>
+                This specification registers the
+                <code>application/vp+ld+json+cose</code> Media Type specifically for
+                identifying a COSE object [[RFC9052]]
+                with a payload
+                conforming to Verifiable Presentations.
+            </p>
+            <table>
+                <tr>
+                    <td>Type name:</td>
+                    <td>`application`</td>
+                </tr>
+                <tr>
+                    <td>Subtype name:</td>
+                    <td>`vp+ld+json+cose`</td>
+                </tr>
+                <tr>
+                    <td>Required parameters:</td>
+                    <td>None</td>
+                </tr>
+                <tr>
+                    <td>Encoding considerations:</td>
+                    <td>
+                        binary (CBOR)
+                    </td>
+                </tr>
+                <tr>
+                    <td>Security considerations:</td>
+                    <td>
+                        <p>As defined in this specification. See also the security
+                            considerations in [[RFC9052]]</a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Contact:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+            </table>
+        </section>
     </section>
 
     <section>
-    <h2 id="structured-syntax-suffixes">Structured Syntax Suffixes</h2>
+        <h2 id="structured-syntax-suffixes">Structured Syntax Suffixes</h2>
 
-    <section id="ld-json-jwt-suffix">
-      <h2 id="ld-json-jwt"><code>+ld+json+jwt</code></h2>
-      <p>
-        This specification registers the
-        <code>+ld+json+jwt</code> Structured Suffix
-	in the IANA "Structured Syntax Suffixes" registry [[IANA-STRUCTURED-SUFFIX]]
-	for indicating that the media type is encoded as
-	a <a data-cite="JWT"></a>
-        with a JSON-LD payload.
-      </p>
-      <table>
-        <tr>
-          <td>Name: </td>
-          <td>`ld+json+jwt`</td>
-        </tr>
-        <tr>
-          <td>+suffix: </td>
-          <td>`+ld+json+jwt`</td>
-        </tr>
-        <tr>
-          <td>References: </td>
-          <td>this specification</td>
-        </tr>
-        <tr>
-          <td>Encoding considerations: </td>
-          <td>
-            binary; `jwt` values are a series of base64url-encoded values
-            (some of which may be the empty string) separated by period ('.').
-          </td>
-        </tr>
-        <tr>
-          <td>Security considerations: </td>
-          <td>
-            <p>As defined in this specification. See also the security
-            considerations in <a data-cite="JWT"></a> and [[json-ld11]].</p>
-          </td>
-        </tr>
-        <tr>
-          <td>Contact: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-        <tr>
-          <td>Author/Change Controller: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-      </table>
+        <section id="ld-json-jwt-suffix">
+            <h2 id="ld-json-jwt"><code>+ld+json+jwt</code></h2>
+            <p>
+                This specification registers the
+                <code>+ld+json+jwt</code> Structured Suffix
+                in the IANA "Structured Syntax Suffixes" registry [[IANA-STRUCTURED-SUFFIX]]
+                for indicating that the media type is encoded as
+                a <a data-cite="JWT"></a>
+                with a JSON-LD payload.
+            </p>
+            <table>
+                <tr>
+                    <td>Name:</td>
+                    <td>`ld+json+jwt`</td>
+                </tr>
+                <tr>
+                    <td>+suffix:</td>
+                    <td>`+ld+json+jwt`</td>
+                </tr>
+                <tr>
+                    <td>References:</td>
+                    <td>this specification</td>
+                </tr>
+                <tr>
+                    <td>Encoding considerations:</td>
+                    <td>
+                        binary; `jwt` values are a series of base64url-encoded values
+                        (some of which may be the empty string) separated by period ('.').
+                    </td>
+                </tr>
+                <tr>
+                    <td>Security considerations:</td>
+                    <td>
+                        <p>As defined in this specification. See also the security
+                            considerations in <a data-cite="JWT"></a> and [[json-ld11]].</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Contact:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Author/Change Controller:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+            </table>
+        </section>
+
+        <section id="json-jwt-suffix">
+            <h2 id="json-jwt"><code>+json+jwt</code></h2>
+            <p>
+                This specification registers the
+                <code>+json+jwt</code> Structured Suffix
+                in the IANA "Structured Syntax Suffixes" registry [[IANA-STRUCTURED-SUFFIX]]
+                for indicating that the media type is encoded as
+                a <a data-cite="JWT"></a>
+                with a JSON payload.
+            </p>
+            <table>
+                <tr>
+                    <td>Name:</td>
+                    <td>json+jwt</td>
+                </tr>
+                <tr>
+                    <td>+suffix:</td>
+                    <td>`+json+jwt`</td>
+                </tr>
+                <tr>
+                    <td>References:</td>
+                    <td>this specification</td>
+                </tr>
+                <tr>
+                    <td>Encoding considerations:</td>
+                    <td>
+                        binary; `jwt` values are a series of base64url-encoded values
+                        (some of which may be the empty string) separated by period ('.').
+                    </td>
+                </tr>
+                <tr>
+                    <td>Security considerations:</td>
+                    <td>
+                        <p>As defined in this specification. See also the security
+                            considerations in <a data-cite="JWT"></a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Contact:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Author/Change Controller:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+            </table>
+        </section>
+
+        <section id="ld-json-sd-jwt-suffix">
+            <h2 id="ld-json-sd-jwt"><code>+ld+json+sd-jwt</code></h2>
+            <p>
+                This specification registers the
+                <code>+ld+json+sd-jwt</code> Structured Suffix
+                in the IANA "Structured Syntax Suffixes" registry [[IANA-STRUCTURED-SUFFIX]]
+                for indicating that the media type is encoded as
+                an <a data-cite="SD-JWT"></a>
+                with a JSON-LD payload.
+            </p>
+            <table>
+                <tr>
+                    <td>Name:</td>
+                    <td>`ld+json+sd-jwt`</td>
+                </tr>
+                <tr>
+                    <td>+suffix:</td>
+                    <td>`+ld+json+sd-jwt`</td>
+                </tr>
+                <tr>
+                    <td>References:</td>
+                    <td>this specification</td>
+                </tr>
+                <tr>
+                    <td>Encoding considerations:</td>
+                    <td>
+                        binary; `sd-jwt` values are a series of base64url-encoded values
+                        (some of which may be the empty string) separated by period ('.') or tilde ('~') characters.
+                    </td>
+                </tr>
+                <tr>
+                    <td>Security considerations:</td>
+                    <td>
+                        <p>As defined in this specification. See also the security
+                            considerations in <a data-cite="SD-JWT"></a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Contact:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Author/Change Controller:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+            </table>
+        </section>
+
+        <section id="json-sd-jwt-suffix">
+            <h2 id="json-sd-jwt"><code>+json+sd-jwt</code></h2>
+            <p>
+                This specification registers the
+                <code>+json+sd-jwt</code> Structured Suffix
+                in the IANA "Structured Syntax Suffixes" registry [[IANA-STRUCTURED-SUFFIX]]
+                for indicating that the media type is encoded as
+                an <a data-cite="SD-JWT"></a>
+                with a JSON payload.
+            </p>
+            <table>
+                <tr>
+                    <td>Name:</td>
+                    <td>json+sd-jwt</td>
+                </tr>
+                <tr>
+                    <td>+suffix:</td>
+                    <td>`+json+sd-jwt`</td>
+                </tr>
+                <tr>
+                    <td>References:</td>
+                    <td>this specification</td>
+                </tr>
+                <tr>
+                    <td>Encoding considerations:</td>
+                    <td>
+                        binary; `sd-jwt` values are a series of base64url-encoded values
+                        (some of which may be the empty string) separated by period ('.') or tilde ('~') characters.
+                    </td>
+                </tr>
+                <tr>
+                    <td>Security considerations:</td>
+                    <td>
+                        <p>As defined in this specification. See also the security
+                            considerations in <a data-cite="SD-JWT"></a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Contact:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Author/Change Controller:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+            </table>
+        </section>
+
+        <section id="ld-json-cose-suffix">
+            <h2 id="ls-json-cose"><code>+ld+json+cose</code></h2>
+            <p>
+                This specification registers the
+                <code>+ld+json+cose</code> Structured Suffix
+                in the IANA "Structured Syntax Suffixes" registry [[IANA-STRUCTURED-SUFFIX]]
+                for indicating that the media type is encoded as
+                a COSE object [[RFC9052]]
+                with a JSON-LD payload.
+            </p>
+            <table>
+                <tr>
+                    <td>Name:</td>
+                    <td>`ld+json+cose`</td>
+                </tr>
+                <tr>
+                    <td>+suffix:</td>
+                    <td>`+ld+json+cose`</td>
+                </tr>
+                <tr>
+                    <td>References:</td>
+                    <td>this specification</td>
+                </tr>
+                <tr>
+                    <td>Encoding considerations:</td>
+                    <td>
+                        binary (CBOR)
+                    </td>
+                </tr>
+                <tr>
+                    <td>Security considerations:</td>
+                    <td>
+                        <p>As defined in this specification. See also the security
+                            considerations in [[RFC9052]] and [[json-ld11]]</a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Contact:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Author/Change Controller:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+            </table>
+        </section>
+
+        <section id="json-cose-suffix">
+            <h2 id="json-cose"><code>+json+cose</code></h2>
+            <p>
+                This specification registers the
+                <code>+json+cose</code> Structured Suffix
+                in the IANA "Structured Syntax Suffixes" registry [[IANA-STRUCTURED-SUFFIX]]
+                for indicating that the media type is encoded as
+                a COSE object [[RFC9052]]
+                with a JSON payload.
+            </p>
+            <table>
+                <tr>
+                    <td>Name:</td>
+                    <td>json+cose</td>
+                </tr>
+                <tr>
+                    <td>+suffix:</td>
+                    <td>`+json+cose`</td>
+                </tr>
+                <tr>
+                    <td>References:</td>
+                    <td>this specification</td>
+                </tr>
+                <tr>
+                    <td>Encoding considerations:</td>
+                    <td>
+                        binary (CBOR)
+                    </td>
+                </tr>
+                <tr>
+                    <td>Security considerations:</td>
+                    <td>
+                        <p>As defined in this specification. See also the security
+                            considerations in [[RFC9052]]</a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Contact:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Author/Change Controller:</td>
+                    <td>
+                        W3C Verifiable Credentials Working Group <a
+                            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+                    </td>
+                </tr>
+            </table>
+        </section>
+
     </section>
-
-    <section id="json-jwt-suffix">
-      <h2 id="json-jwt"><code>+json+jwt</code></h2>
-      <p>
-        This specification registers the
-        <code>+json+jwt</code> Structured Suffix
-	in the IANA "Structured Syntax Suffixes" registry [[IANA-STRUCTURED-SUFFIX]]
-	for indicating that the media type is encoded as
-	a <a data-cite="JWT"></a>
-        with a JSON payload.
-      </p>
-      <table>
-        <tr>
-          <td>Name: </td>
-          <td>json+jwt</td>
-        </tr>
-        <tr>
-          <td>+suffix: </td>
-          <td>`+json+jwt`</td>
-        </tr>
-        <tr>
-          <td>References: </td>
-          <td>this specification</td>
-        </tr>
-        <tr>
-          <td>Encoding considerations: </td>
-          <td>
-            binary; `jwt` values are a series of base64url-encoded values
-            (some of which may be the empty string) separated by period ('.').
-          </td>
-        </tr>
-        <tr>
-          <td>Security considerations: </td>
-          <td>
-            <p>As defined in this specification. See also the security
-            considerations in <a data-cite="JWT"></a>.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>Contact: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-        <tr>
-          <td>Author/Change Controller: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-      </table>
-    </section>
-
-    <section id="ld-json-sd-jwt-suffix">
-      <h2 id="ld-json-sd-jwt"><code>+ld+json+sd-jwt</code></h2>
-      <p>
-        This specification registers the
-        <code>+ld+json+sd-jwt</code> Structured Suffix
-	in the IANA "Structured Syntax Suffixes" registry [[IANA-STRUCTURED-SUFFIX]]
-	for indicating that the media type is encoded as
-	an <a data-cite="SD-JWT"></a>
-        with a JSON-LD payload.
-      </p>
-      <table>
-        <tr>
-          <td>Name: </td>
-          <td>`ld+json+sd-jwt`</td>
-        </tr>
-        <tr>
-          <td>+suffix: </td>
-          <td>`+ld+json+sd-jwt`</td>
-        </tr>
-        <tr>
-          <td>References: </td>
-          <td>this specification</td>
-        </tr>
-        <tr>
-          <td>Encoding considerations: </td>
-          <td>
-            binary; `sd-jwt` values are a series of base64url-encoded values
-            (some of which may be the empty string) separated by period ('.') or tilde ('~') characters.
-          </td>
-        </tr>
-        <tr>
-          <td>Security considerations: </td>
-          <td>
-            <p>As defined in this specification. See also the security
-            considerations in <a data-cite="SD-JWT"></a>.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>Contact: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-        <tr>
-          <td>Author/Change Controller: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-      </table>
-    </section>
-
-    <section id="json-sd-jwt-suffix">
-      <h2 id="json-sd-jwt"><code>+json+sd-jwt</code></h2>
-      <p>
-        This specification registers the
-        <code>+json+sd-jwt</code> Structured Suffix
-	in the IANA "Structured Syntax Suffixes" registry [[IANA-STRUCTURED-SUFFIX]]
-	for indicating that the media type is encoded as
-	an <a data-cite="SD-JWT"></a>
-        with a JSON payload.
-      </p>
-      <table>
-        <tr>
-          <td>Name: </td>
-          <td>json+sd-jwt</td>
-        </tr>
-        <tr>
-          <td>+suffix: </td>
-          <td>`+json+sd-jwt`</td>
-        </tr>
-        <tr>
-          <td>References: </td>
-          <td>this specification</td>
-        </tr>
-        <tr>
-          <td>Encoding considerations: </td>
-          <td>
-            binary; `sd-jwt` values are a series of base64url-encoded values
-            (some of which may be the empty string) separated by period ('.') or tilde ('~') characters.
-          </td>
-        </tr>
-        <tr>
-          <td>Security considerations: </td>
-          <td>
-            <p>As defined in this specification. See also the security
-            considerations in <a data-cite="SD-JWT"></a>.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>Contact: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-        <tr>
-          <td>Author/Change Controller: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-      </table>
-    </section>
-
-    <section id="ld-json-cose-suffix">
-      <h2 id="ls-json-cose"><code>+ld+json+cose</code></h2>
-      <p>
-        This specification registers the
-        <code>+ld+json+cose</code> Structured Suffix
-	in the IANA "Structured Syntax Suffixes" registry [[IANA-STRUCTURED-SUFFIX]]
-	for indicating that the media type is encoded as
-	a COSE object [[RFC9052]]
-        with a JSON-LD payload.
-      </p>
-      <table>
-        <tr>
-          <td>Name: </td>
-          <td>`ld+json+cose`</td>
-        </tr>
-        <tr>
-          <td>+suffix: </td>
-          <td>`+ld+json+cose`</td>
-        </tr>
-        <tr>
-          <td>References: </td>
-          <td>this specification</td>
-        </tr>
-        <tr>
-          <td>Encoding considerations: </td>
-          <td>
-            binary (CBOR)
-          </td>
-        </tr>
-        <tr>
-          <td>Security considerations: </td>
-          <td>
-            <p>As defined in this specification. See also the security
-            considerations in [[RFC9052]] and [[json-ld11]]</a>.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>Contact: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-        <tr>
-          <td>Author/Change Controller: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-      </table>
-    </section>
-
-    <section id="json-cose-suffix">
-      <h2 id="json-cose"><code>+json+cose</code></h2>
-      <p>
-        This specification registers the
-        <code>+json+cose</code> Structured Suffix
-	in the IANA "Structured Syntax Suffixes" registry [[IANA-STRUCTURED-SUFFIX]]
-	for indicating that the media type is encoded as
-	a COSE object [[RFC9052]]
-        with a JSON payload.
-      </p>
-      <table>
-        <tr>
-          <td>Name: </td>
-          <td>json+cose</td>
-        </tr>
-        <tr>
-          <td>+suffix: </td>
-          <td>`+json+cose`</td>
-        </tr>
-        <tr>
-          <td>References: </td>
-          <td>this specification</td>
-        </tr>
-        <tr>
-          <td>Encoding considerations: </td>
-          <td>
-            binary (CBOR)
-          </td>
-        </tr>
-        <tr>
-          <td>Security considerations: </td>
-          <td>
-            <p>As defined in this specification. See also the security
-            considerations in [[RFC9052]]</a>.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>Contact: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-        <tr>
-          <td>Author/Change Controller: </td>
-          <td>
-            W3C Verifiable Credentials Working Group <a
-            href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
-          </td>
-        </tr>
-      </table>
-    </section>
-
-  </section>
 
 </section>
-  <section>
+<section>
     <h3 id="other-considerations">Other Considerations</h3>
 
     <section>
-      <h2 id="privacy-considerations">Privacy Considerations</h2>
-      <p>
-        Verifiable Credentials often contain sensitive information that
-        needs to be protected to ensure the privacy and security of
-        organizations and individuals. This section outlines some
-        privacy considerations relevant to implementers and users.
-      </p>
-      <p>
-        Implementers are advised to note and abide by all privacy
-        considerations called out in [[VC-DATA-MODEL-2.0]].
-      </p>
-      <p>
-        Implementers are additionally advised to reference the
-        <a href="https://www.rfc-editor.org/rfc/rfc7519#section-12">Privacy
-          Consideration</a>
-        section of the JWT specification for privacy guidance.
-      </p>
-      <p>
-        In addition to the privacy recommendations in the
-        [[VC-DATA-MODEL-2.0]], the following considerations are given:
-      <ul>
-        <li>
-          <p>
-            Minimization of data: It is considered best practice for
-            Verifiable Credentials to only contain the minimum amount of
-            data necessary to achieve their intended purpose. This helps
-            to limit the amount of sensitive information that is shared
-            or stored unnecessarily.
-          </p>
-        </li>
-        <li>
-          <p>
-            Informed consent: It is considered best practice that
-            individuals be fully informed about how their data will be
-            used and provide the ability to consent to or decline the
-            use of their data. This helps to ensure that individuals
-            maintain control over their own personal information.
-          </p>
-        </li>
-        <li>
-          <p>
-            Data protection: It is considered best practice to protect
-            Verifiable Credentials using strong encryption and other
-            security measures to prevent unauthorized access,
-            modification, or disclosure.
-          </p>
-        </li>
-      </ul>
-      <p>
-        These considerations are not exhaustive, and implementers and
-        users are advised to consult additional privacy resources and
-        best practices to ensure the privacy and security of Verifiable
-        Credentials implemented using this specification.
-      </p>
+        <h2 id="privacy-considerations">Privacy Considerations</h2>
+        <p>
+            Verifiable Credentials often contain sensitive information that
+            needs to be protected to ensure the privacy and security of
+            organizations and individuals. This section outlines some
+            privacy considerations relevant to implementers and users.
+        </p>
+        <p>
+            Implementers are advised to note and abide by all privacy
+            considerations called out in [[VC-DATA-MODEL-2.0]].
+        </p>
+        <p>
+            Implementers are additionally advised to reference the
+            <a href="https://www.rfc-editor.org/rfc/rfc7519#section-12">Privacy
+                Consideration</a>
+            section of the JWT specification for privacy guidance.
+        </p>
+        <p>
+            In addition to the privacy recommendations in the
+            [[VC-DATA-MODEL-2.0]], the following considerations are given:
+        <ul>
+            <li>
+                <p>
+                    Minimization of data: It is considered best practice for
+                    Verifiable Credentials to only contain the minimum amount of
+                    data necessary to achieve their intended purpose. This helps
+                    to limit the amount of sensitive information that is shared
+                    or stored unnecessarily.
+                </p>
+            </li>
+            <li>
+                <p>
+                    Informed consent: It is considered best practice that
+                    individuals be fully informed about how their data will be
+                    used and provide the ability to consent to or decline the
+                    use of their data. This helps to ensure that individuals
+                    maintain control over their own personal information.
+                </p>
+            </li>
+            <li>
+                <p>
+                    Data protection: It is considered best practice to protect
+                    Verifiable Credentials using strong encryption and other
+                    security measures to prevent unauthorized access,
+                    modification, or disclosure.
+                </p>
+            </li>
+        </ul>
+        <p>
+            These considerations are not exhaustive, and implementers and
+            users are advised to consult additional privacy resources and
+            best practices to ensure the privacy and security of Verifiable
+            Credentials implemented using this specification.
+        </p>
     </section>
     <section>
-      <h2 id="security-considerations">Security Considerations</h2>
-      <p>
-        This section outlines security considerations for implementers
-        and users of this specification. It is important to carefully
-        consider these factors to ensure the security and integrity of
-        Verifiable Credentials when implemented using JOSE or COSE.
-      </p>
-      <p>
-        When implementing this specification, it is essential to address all
-        security issues relevant to broad cryptographic applications.
-        This especially includes protecting the user's asymmetric
-        private and symmetric secret keys, as well as employing
-        countermeasures against various attacks. Failure to adequately
-        address these issues could compromise the security and integrity
-        of Verifiable Credentials, potentially leading to unauthorized
-        access, modification, or disclosure of sensitive information.
-      </p>
-      <p>
-        Implementers are advised to follow best practices and
-        established cryptographic standards to ensure the secure
-        handling of keys and other sensitive data. Additionally, conduct
-        regular security assessments and audits to identify and address
-        any vulnerabilities or threats.
-      </p>
-      <p>
-        Follow all security considerations outlined in [[RFC7515]] and
-        [[RFC7519]].
-      </p>
-      <p>
-        When utilizing JSON-LD, take special care around remote
-        retrieval of contexts and follow the additional security
-        considerations noted in [[json-ld11]].
-      </p>
-      <p>
-        As noted in [[RFC7515]] when utilizing JSON [[RFC7159]], strict
-        validation is a security requirement. If malformed JSON is
-        received, it may be impossible to reliably interpret the
-        producer's intent, potentially leading to ambiguous or
-        exploitable situations. To prevent these risks, it is essential
-        to use a JSON parser that strictly validates the syntax of all
-        input data. It is essential that any JSON inputs that do not
-        conform to the JSON-text syntax defined in [[RFC7159]] be
-        rejected in their entirety by JSON parsers. Failure to reject
-        invalid input could compromise the security and integrity of
-        Verifiable Credentials.
-      </p>
+        <h2 id="security-considerations">Security Considerations</h2>
+        <p>
+            This section outlines security considerations for implementers
+            and users of this specification. It is important to carefully
+            consider these factors to ensure the security and integrity of
+            Verifiable Credentials when implemented using JOSE or COSE.
+        </p>
+        <p>
+            When implementing this specification, it is essential to address all
+            security issues relevant to broad cryptographic applications.
+            This especially includes protecting the user's asymmetric
+            private and symmetric secret keys, as well as employing
+            countermeasures against various attacks. Failure to adequately
+            address these issues could compromise the security and integrity
+            of Verifiable Credentials, potentially leading to unauthorized
+            access, modification, or disclosure of sensitive information.
+        </p>
+        <p>
+            Implementers are advised to follow best practices and
+            established cryptographic standards to ensure the secure
+            handling of keys and other sensitive data. Additionally, conduct
+            regular security assessments and audits to identify and address
+            any vulnerabilities or threats.
+        </p>
+        <p>
+            Follow all security considerations outlined in [[RFC7515]] and
+            [[RFC7519]].
+        </p>
+        <p>
+            When utilizing JSON-LD, take special care around remote
+            retrieval of contexts and follow the additional security
+            considerations noted in [[json-ld11]].
+        </p>
+        <p>
+            As noted in [[RFC7515]] when utilizing JSON [[RFC7159]], strict
+            validation is a security requirement. If malformed JSON is
+            received, it may be impossible to reliably interpret the
+            producer's intent, potentially leading to ambiguous or
+            exploitable situations. To prevent these risks, it is essential
+            to use a JSON parser that strictly validates the syntax of all
+            input data. It is essential that any JSON inputs that do not
+            conform to the JSON-text syntax defined in [[RFC7159]] be
+            rejected in their entirety by JSON parsers. Failure to reject
+            invalid input could compromise the security and integrity of
+            Verifiable Credentials.
+        </p>
     </section>
     <section class="informative">
-      <h2 id="accessibility">Accessibility</h2>
-      <p>
-        When implementing this specification, it is crucial for
-        technical implementers to consider various accessibility
-        factors. Ignoring accessibility concerns renders the information
-        unusable for a significant portion of the population. To ensure
-        equal access for all individuals, regardless of their abilities,
-        it is vital to adhere to accessibility guidelines and standards,
-        such as the Web Content Accessibility Guidelines (WCAG 2.1)
-        [[WCAG21]]. This becomes even more critical when establishing
-        systems that involve cryptography, as they have historically
-        posed challenges for assistive technologies.
-      </p>
-      <p>
-        Implementers are advised to note and abide by all accessibility
-        considerations called out in [[VC-DATA-MODEL-2.0]].
-      </p>
+        <h2 id="accessibility">Accessibility</h2>
+        <p>
+            When implementing this specification, it is crucial for
+            technical implementers to consider various accessibility
+            factors. Ignoring accessibility concerns renders the information
+            unusable for a significant portion of the population. To ensure
+            equal access for all individuals, regardless of their abilities,
+            it is vital to adhere to accessibility guidelines and standards,
+            such as the Web Content Accessibility Guidelines (WCAG 2.1)
+            [[WCAG21]]. This becomes even more critical when establishing
+            systems that involve cryptography, as they have historically
+            posed challenges for assistive technologies.
+        </p>
+        <p>
+            Implementers are advised to note and abide by all accessibility
+            considerations called out in [[VC-DATA-MODEL-2.0]].
+        </p>
     </section>
-  </section>
+</section>
 
 
-  <section class="informative">
+<section class="informative">
     <h3 id="examples">Examples</h3>
     <section>
-      <h2 id="controllers">Controllers</h2>
+        <h2 id="controllers">Controllers</h2>
 
-      <pre class="example" title="A minimal controller document">
+        <pre class="example" title="A minimal controller document">
         {
           "id": "https://vendor.example",
         }
       </pre>
 
-      <pre class="example" title="A controller document with verification method">
+        <pre class="example" title="A controller document with verification method">
         {
           "id": "https://university.example/issuers/565049",
           "verificationMethod": [{
@@ -2198,7 +2243,7 @@ credential</a> by a verifier.
         }
       </pre>
 
-      <pre class="example" title="A controller document with verification relationships">
+        <pre class="example" title="A controller document with verification relationships">
         {
           "id": "https://university.example/issuers/565049",
           "verificationMethod": [{
@@ -2218,7 +2263,7 @@ credential</a> by a verifier.
         }
       </pre>
 
-      <pre class="example" title="A verifiable credential controller document">
+        <pre class="example" title="A verifiable credential controller document">
 {
   "@context": [
         "https://www.w3.org/ns/did/v1",
@@ -2293,8 +2338,8 @@ credential</a> by a verifier.
 
     </section>
     <section>
-      <h3 id="credentials">Credentials</h3>
-      <pre class="example vc-jose-cose" title="A revocable credential with multiple subjects">
+        <h3 id="credentials">Credentials</h3>
+        <pre class="example vc-jose-cose" title="A revocable credential with multiple subjects">
 {
   "@context": ["https://www.w3.org/ns/credentials/v2",
     "https://www.w3.org/ns/credentials/examples/v2"
@@ -2322,7 +2367,7 @@ credential</a> by a verifier.
 }
       </pre>
 
-      <pre class="example vc-jose-cose" title="A credential with a schema">
+        <pre class="example vc-jose-cose" title="A credential with a schema">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -2346,9 +2391,9 @@ credential</a> by a verifier.
     </section>
 
     <section>
-      <h2 id="presentations">Presentations</h2>
+        <h2 id="presentations">Presentations</h2>
 
-      <pre class="example vc-jose-cose" title="Presentation">
+        <pre class="example vc-jose-cose" title="Presentation">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -2378,24 +2423,24 @@ credential</a> by a verifier.
     </section>
 
     <section>
-      <h3 id="date-uris">Data URIs</h3>
-      <pre class="example" title="A simple URI-encoded Verifiable Credential">
+        <h3 id="date-uris">Data URIs</h3>
+        <pre class="example" title="A simple URI-encoded Verifiable Credential">
 data:application/vc+ld+json+sd-jwt;eyJhbGciOiJFUzM4NCIsImtpZCI6IlNJM1JITm91aDhvODFOT09OUFFVQUw3RWdaLWtJNl94ajlvUkV2WDF4T3ciLCJ0eXAiOiJ2YytsZCtqc29uK3NkLWp3dCIsImN0eSI6InZjK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiX3NkIjpbIkU3dU1sSWFyS29iYXJTdEZGRjctZm5qaV9sQVdnM3BGMkV5dVc4dWFYakUiLCJYelRaSVgyNGdDSWxSQVFHclFoNU5FRm1XWkQtZ3Z3dkIybzB5Y0FwNFZzIl19LCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJfc2QiOlsiT3oxUEZIMG0tWk9TdEhwUVZyeGlmVlpKRzhvNmlQQmNnLVZ2SXQwd2plcyJdfSwiX3NkIjpbIkVZQ1daMTZZMHB5X1VNNzRHU3NVYU9zT19mdDExTlVSaFFUTS1TT1lFTVEiXX0sIl9zZCI6WyJqT055NnZUbGNvVlAzM25oSTdERGN3ekVka3d2R3VVRXlLUjdrWEVLd3VVIiwid21BdHpwc0dRbDJveS1PY2JrSEVZcE8xb3BoX3VYcWVWVTRKekF0aFFibyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vdW5pdmVyc2l0eS5leGFtcGxlL2lzc3VlcnMvNTY1MDQ5IiwiaWF0IjoxNjk3Mjg5OTk2LCJleHAiOjE3Mjg5MTIzOTYsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6InZFdV84WGxZT0ZFU2hTcVRpZ2JSYWduZ0ZGM1p5U0xrclNHekh3azFBT1loanhlazVhV21HY2UwZU05S0pWOEIiLCJ5IjoiRUpNY2czWXBzUTB3M2RLNHlVa25QczE1Z0lsY2Yyay03dzFKLTNlYlBiOERENmQtUkhBeGUwMDkzSWpfdTRCOSJ9fX0.rYzbxb6j1dwop8_s491iArVVJNm6A6C3b742gOm_qYO3zdkyQU4_VxxOSJ8ECcmWj2r5KyiCNC1ojfO4Yms-zBsjt7PoMYpYWBplsqXpiIvnehmM7D0eOLi40uHXki0X~WyJSWTg1YTZNMmEwX3VDWlFTVGZmTFdRIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJMeG5GYTBXVm8wRUluVy1QdS1fd1dRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJUQVdrakpCaVpxdC1rVU54X1EweUJBIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJTd2xuZFpPZzZEZ1ZERFp5X0RvYVFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJuSnJlU3E1Nzg3RGZMSDJCbU03cXFRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyIxMjNNd3hNcHRiek02YUk2aW03ME1RIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ
       </pre>
 
-      <pre class="example" title="A simple URI-encoded Verifiable Presentation">
+        <pre class="example" title="A simple URI-encoded Verifiable Presentation">
 data:application/vp+ld+json+sd-jwt;eyJhbGciOiJFUzM4NCIsImtpZCI6IlNJM1JITm91aDhvODFOT09OUFFVQUw3RWdaLWtJNl94ajlvUkV2WDF4T3ciLCJ0eXAiOiJ2YytsZCtqc29uK3NkLWp3dCIsImN0eSI6InZjK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiX3NkIjpbIkU3dU1sSWFyS29iYXJTdEZGRjctZm5qaV9sQVdnM3BGMkV5dVc4dWFYakUiLCJYelRaSVgyNGdDSWxSQVFHclFoNU5FRm1XWkQtZ3Z3dkIybzB5Y0FwNFZzIl19LCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJfc2QiOlsiT3oxUEZIMG0tWk9TdEhwUVZyeGlmVlpKRzhvNmlQQmNnLVZ2SXQwd2plcyJdfSwiX3NkIjpbIkVZQ1daMTZZMHB5X1VNNzRHU3NVYU9zT19mdDExTlVSaFFUTS1TT1lFTVEiXX0sIl9zZCI6WyJqT055NnZUbGNvVlAzM25oSTdERGN3ekVka3d2R3VVRXlLUjdrWEVLd3VVIiwid21BdHpwc0dRbDJveS1PY2JrSEVZcE8xb3BoX3VYcWVWVTRKekF0aFFibyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vdW5pdmVyc2l0eS5leGFtcGxlL2lzc3VlcnMvNTY1MDQ5IiwiaWF0IjoxNjk3Mjg5OTk2LCJleHAiOjE3Mjg5MTIzOTYsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6InZFdV84WGxZT0ZFU2hTcVRpZ2JSYWduZ0ZGM1p5U0xrclNHekh3azFBT1loanhlazVhV21HY2UwZU05S0pWOEIiLCJ5IjoiRUpNY2czWXBzUTB3M2RLNHlVa25QczE1Z0lsY2Yyay03dzFKLTNlYlBiOERENmQtUkhBeGUwMDkzSWpfdTRCOSJ9fX0.rYzbxb6j1dwop8_s491iArVVJNm6A6C3b742gOm_qYO3zdkyQU4_VxxOSJ8ECcmWj2r5KyiCNC1ojfO4Yms-zBsjt7PoMYpYWBplsqXpiIvnehmM7D0eOLi40uHXki0X~WyJTd2xuZFpPZzZEZ1ZERFp5X0RvYVFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyIxMjNNd3hNcHRiek02YUk2aW03ME1RIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~WyJMeG5GYTBXVm8wRUluVy1QdS1fd1dRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJSWTg1YTZNMmEwX3VDWlFTVGZmTFdRIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~eyJhbGciOiJFUzM4NCIsInR5cCI6ImtiK2p3dCJ9.eyJub25jZSI6IkVmeTROTFJPX3ZvSkszdDIzcUNfQlEiLCJhdWQiOiJodHRwczovL3ZlcmlmaWVyLmV4YW1wbGUiLCJpYXQiOjE2OTcyODk5OTZ9.6G-1nVcrDKFzR6BdbcFHcbtassEb8NZ7ZavTYz3SJ-e4pXleXs0tNcCkUCwMI70gsuOY0AXzeDPbHjp5GKyLDVuNWgWCt3Wo2VSaCwUkyfLyvhkCsmkF9kvFhMIOhp1i
       </pre>
     </section>
 
     <section>
-      <h2 id="cose-examples">COSE Examples</h2>
-      <p>
-These examples rely on <a data-cite="RFC7049#section-6">CBOR Diagnostic Notation</a>.
-Remember that all actual interchange always happens in the binary format.
-      </p>
+        <h2 id="cose-examples">COSE Examples</h2>
+        <p>
+            These examples rely on <a data-cite="RFC7049#section-6">CBOR Diagnostic Notation</a>.
+            Remember that all actual interchange always happens in the binary format.
+        </p>
 
-      <pre class="example" title="A COSE Sign 1 Protected Header for a Verifiable Credential">
+        <pre class="example" title="A COSE Sign 1 Protected Header for a Verifiable Credential">
 {                                   / Protected                     /
   1: -35,                           / Algorithm                     /
   3: application/vc+ld+json,        / Content type                  /
@@ -2430,7 +2475,7 @@ Remember that all actual interchange always happens in the binary format.
 )
       </pre>
 
-      <pre class="example" title="A COSE Sign 1 with a detached payload">
+        <pre class="example" title="A COSE Sign 1 with a detached payload">
 18(                                 / COSE Sign 1                   /
     [
       h'a4013822...3a343536',       / Protected Header              /
@@ -2440,265 +2485,263 @@ Remember that all actual interchange always happens in the binary format.
     ]
 )
       </pre>
-      <p>
-The payload can be either a credential or presentation as described in
-<a data-cite="VC-DATA-MODEL-2.0#securing-mechanisms">Securing Mechanisms</a>.
-      </p>
+        <p>
+            The payload can be either a credential or presentation as described in
+            <a data-cite="VC-DATA-MODEL-2.0#securing-mechanisms">Securing Mechanisms</a>.
+        </p>
     </section>
-  </section>
-  <section>
+</section>
+<section>
     <h2 id="verification-algorithms">Verification Algorithms</h2>
     <p>
-This specification might be used with many different key discovery protocols.
-Therefore, discovery of verification keys is described in <a href="#key_discovery"></a>,
-and is assumed to have succeeded prior to beginning the verification process.
+        This specification might be used with many different key discovery protocols.
+        Therefore, discovery of verification keys is described in <a href="#key_discovery"></a>,
+        and is assumed to have succeeded prior to beginning the verification process.
     </p>
     <p>
-As a general rule, verifiers SHOULD strive to minimize the processing of
-untrusted data. This includes minimizing any processing of the protected header,
-unprotected header, or payload as part of the key discovery procedures.
+        As a general rule, verifiers SHOULD strive to minimize the processing of
+        untrusted data. This includes minimizing any processing of the protected header,
+        unprotected header, or payload as part of the key discovery procedures.
     </p>
     <p>
-After verification has succeeded, additional validation checks SHOULD be
-performed as described in Section <a href="#validation-algorithm"></a>
+        After verification has succeeded, additional validation checks SHOULD be
+        performed as described in Section <a href="#validation-algorithm"></a>
     </p>
     <p>
-The outputs for the following algorithms are:
+        The outputs for the following algorithms are:
     </p>
     <ul>
-      <li>
-<code>status</code>: a boolean indicating the result of verification,
-<code>true</code> for success and <code>false</code> for failure.
+        <li>
+            <code>status</code>: a boolean indicating the result of verification,
+            <code>true</code> for success and <code>false</code> for failure.
         </li>
-      <li>
-<code>document</code>: a document conforming to the [[[VC-DATA-MODEL-2.0]]] [[VC-DATA-MODEL-2.0]]
+        <li>
+            <code>document</code>: a document conforming to the [[[VC-DATA-MODEL-2.0]]] [[VC-DATA-MODEL-2.0]]
         </li>
-      <li>
-<code>mediaType</code>: <code>vc+ld+json</code> or <code>vp+ld+json</code>
+        <li>
+            <code>mediaType</code>: <code>vc+ld+json</code> or <code>vp+ld+json</code>
         </li>
     </ul>
     <section>
-      <h3 id="alg-jose">Algorithm for Verifying a Credential or Presentation Secured with JOSE</h3>
-      <p>
-      The inputs for this algorithm are:
-      </p>
-      <ul>
-        <li>
-<code>inputMediaType</code>: <code>vc+ld+json+jwt</code> or
-<code>vp+ld+json+jwt</code>
-        </li>
-        <li>
-<code>inputDocument</code>: the verifiable credential secured as a JWT [[RFC7519]]
-        </li>
-      </ul>
-      <p>
-Upon receipt of the verifiable credential or presentation secured as a JWT
-[[RFC7519]], the holder or verifier follows this algorithm:
-      </p>
-      <ol>
-        <li>
-Follow the algorithm defined in <a data-cite="RFC7519#section-7.2"> Validating a JWT</a> [[RFC7519]].
-        </li>
-        <li>
-If processing completes successfully:
+        <h3 id="alg-jose">Algorithm for Verifying a Credential or Presentation Secured with JOSE</h3>
+        <p>
+            The inputs for this algorithm are:
+        </p>
+        <ul>
+            <li>
+                <code>inputMediaType</code>: <code>vc+ld+json+jwt</code> or
+                <code>vp+ld+json+jwt</code>
+            </li>
+            <li>
+                <code>inputDocument</code>: the verifiable credential secured as a JWT [[RFC7519]]
+            </li>
+        </ul>
+        <p>
+            Upon receipt of the verifiable credential or presentation secured as a JWT
+            [[RFC7519]], the holder or verifier follows this algorithm:
+        </p>
         <ol>
-          <li>
-Set <code>status</code> to <code>true</code>
-          </li>
-          <li>
-Set <code>mediaType</code> to <code>vc+ld+json</code> or <code>vp+json+ld</code>
-          </li>
-          <li>
-Set <code>document</code> to the decoded JWS payload.
-          </li>
-          <li>
-Return
-          </li>
+            <li>
+                Follow the algorithm defined in <a data-cite="RFC7519#section-7.2"> Validating a JWT</a> [[RFC7519]].
+            </li>
+            <li>
+                If processing completes successfully:
+                <ol>
+                    <li>
+                        Set <code>status</code> to <code>true</code>
+                    </li>
+                    <li>
+                        Set <code>mediaType</code> to <code>vc+ld+json</code> or <code>vp+json+ld</code>
+                    </li>
+                    <li>
+                        Set <code>document</code> to the decoded JWS payload.
+                    </li>
+                    <li>
+                        Return
+                    </li>
+                </ol>
+            </li>
+            <li>
+                If processing aborts for any reason or the JWT is rejected:
+                <ol>
+                    <li>
+                        Set <code>status</code> to <code>false</code>
+                    </li>
+                    <li>
+                        Set <code>document</code> to <code>null</code>
+                    </li>
+                    <li>
+                        Set <code>mediaType</code> to <code>null</code>
+                    </li>
+                    <li>
+                        Return
+                    </li>
+                </ol>
+            </li>
         </ol>
-        </li>
-        <li>
-If processing aborts for any reason or the JWT is rejected:
-        <ol>
-          <li>
-Set <code>status</code> to <code>false</code>
-          </li>
-          <li>
-Set <code>document</code> to <code>null</code>
-          </li>
-          <li>
-Set <code>mediaType</code> to <code>null</code>
-          </li>
-          <li>
-Return
-          </li>
-        </ol>
-        </li>
-        </li>
-      </ol>
     </section>
     <section>
-      <h3 id="alg-sd-jwt">Algorithm for Verifying a Credential or Presentation Secured with SD-JWT</h3>
-      <p>
-The inputs for this algorithm are:
-      </p>
-      <ul>
-        <li>
-<code>inputMediaType</code>: <code>vc+ld+json+sd-jwt</code>
-          </li>
-        <li>
-<code>inputDocument</code>: the verifiable credential secured with [[SD-JWT]]
-          </li>
-      </ul>
-      <p>
-Upon receipt of the verifiable credential or presentation secured with
-[[SD-JWT]], the holder or verifier follows this algorithm:
-      </p>
+        <h3 id="alg-sd-jwt">Algorithm for Verifying a Credential or Presentation Secured with SD-JWT</h3>
+        <p>
+            The inputs for this algorithm are:
+        </p>
+        <ul>
+            <li>
+                <code>inputMediaType</code>: <code>vc+ld+json+sd-jwt</code>
+            </li>
+            <li>
+                <code>inputDocument</code>: the verifiable credential secured with [[SD-JWT]]
+            </li>
+        </ul>
+        <p>
+            Upon receipt of the verifiable credential or presentation secured with
+            [[SD-JWT]], the holder or verifier follows this algorithm:
+        </p>
         <ol>
-          <li>
-Follow the algorithms defined in <a data-cite="SD-JWT#section-8">SD-JWT</a> for
-verification of the SD-JWT.
-          </li>
-          <li>
-If processing completes successfully:
-            <ol>
-              <li>
-Set <code>status</code> to <code>true</code>
-              </li>
-              <li>
-Set <code>mediaType</code> to <code>vc+ld+json</code>
-              </li>
-              <li>
-Convert the SD-JWT payload back into the JSON claim set by reversing the process
-in [[[SD-JWT]]] [[SD-JWT]]. Set <code>document</code> to the JSON claim set.
-(For examples of the transition from JSON claim set to SD-JWT payload, please
-see <a data-cite="SD-JWT#appendix-A">SD-JWT examples</a>).
-              </li>
-              <li>
-Return
-              </li>
-            </ol>
-          </li>
-          <li>
-If processing aborts for any reason or the SD-JWT is rejected:
-          <ol>
             <li>
-            Set <code>status</code> to <code>false</code>
+                Follow the algorithms defined in <a data-cite="SD-JWT#section-8">SD-JWT</a> for
+                verification of the SD-JWT.
             </li>
             <li>
-            Set <code>document</code> to <code>null</code>
+                If processing completes successfully:
+                <ol>
+                    <li>
+                        Set <code>status</code> to <code>true</code>
+                    </li>
+                    <li>
+                        Set <code>mediaType</code> to <code>vc+ld+json</code>
+                    </li>
+                    <li>
+                        Convert the SD-JWT payload back into the JSON claim set by reversing the process
+                        in [[[SD-JWT]]] [[SD-JWT]]. Set <code>document</code> to the JSON claim set.
+                        (For examples of the transition from JSON claim set to SD-JWT payload, please
+                        see <a data-cite="SD-JWT#appendix-A">SD-JWT examples</a>).
+                    </li>
+                    <li>
+                        Return
+                    </li>
+                </ol>
             </li>
             <li>
-            Set <code>mediaType</code> to <code>null</code>
+                If processing aborts for any reason or the SD-JWT is rejected:
+                <ol>
+                    <li>
+                        Set <code>status</code> to <code>false</code>
+                    </li>
+                    <li>
+                        Set <code>document</code> to <code>null</code>
+                    </li>
+                    <li>
+                        Set <code>mediaType</code> to <code>null</code>
+                    </li>
+                    <li>
+                        Return
+                    </li>
+                </ol>
             </li>
-            <li>
-            Return
-            </li>
-          </ol>
-          </li>
-        </li>
-      </ol>
+        </ol>
     </section>
     <section>
-      <h3 id="alg-cose">Algorithm for Verifying a Credential or Presentation Secured with COSE</h3>
-      <p>
-The inputs for this algorithm are:
-      </p>
-      <ul>
-        <li>
-<code>inputMediaType</code>: <code>vc+ld+json+cose</code> or
-<code>vp+ld+json+cose</code>
-        </li>
-        <li>
-<code>inputDocument</code>: the verifiable credential or verifiable presentation
-secured with [[[RFC9052]]]
-        </li>
-      </ul>
-      <p>
-Upon receipt of the verifiable credential or presentation secured with
-[[RFC9052]], the holder or verifier follows this algorithm:
-      </p>
-      <ol>
-        <li>
-Follow the algorithm defined in [[[RFC9052]]] [[RFC9052]] under the Signing and
-Verification Process for COSE_Sign1.
-        </li>
-        <li>
-If processing completes successfully:
+        <h3 id="alg-cose">Algorithm for Verifying a Credential or Presentation Secured with COSE</h3>
+        <p>
+            The inputs for this algorithm are:
+        </p>
+        <ul>
+            <li>
+                <code>inputMediaType</code>: <code>vc+ld+json+cose</code> or
+                <code>vp+ld+json+cose</code>
+            </li>
+            <li>
+                <code>inputDocument</code>: the verifiable credential or verifiable presentation
+                secured with [[[RFC9052]]]
+            </li>
+        </ul>
+        <p>
+            Upon receipt of the verifiable credential or presentation secured with
+            [[RFC9052]], the holder or verifier follows this algorithm:
+        </p>
         <ol>
-          <li>
-Set <code>status</code> to <code>true</code>
-          </li>
-          <li>
-Set <code>mediaType</code> to <code>vc+ld+json</code> or <code>vp+ld+json</code>
-          </li>
-          <li>
-Set <code>document</code> to the decoded COSE_Sign1 payload.
-          </li>
-          <li>
-Return
-          </li>
+            <li>
+                Follow the algorithm defined in [[[RFC9052]]] [[RFC9052]] under the Signing and
+                Verification Process for COSE_Sign1.
+            </li>
+            <li>
+                If processing completes successfully:
+                <ol>
+                    <li>
+                        Set <code>status</code> to <code>true</code>
+                    </li>
+                    <li>
+                        Set <code>mediaType</code> to <code>vc+ld+json</code> or <code>vp+ld+json</code>
+                    </li>
+                    <li>
+                        Set <code>document</code> to the decoded COSE_Sign1 payload.
+                    </li>
+                    <li>
+                        Return
+                    </li>
+                </ol>
+            </li>
+            <li>
+                If processing aborts for any reason:
+                <ol>
+                    <li>
+                        Set <code>status</code> to <code>false</code>
+                    </li>
+                    <li>
+                        Set <code>document</code> to <code>null</code>
+                    </li>
+                    <li>
+                        Set <code>mediaType</code> to <code>null</code>
+                    </li>
+                    <li>
+                        Return
+                    </li>
+                </ol>
+            </li>
+            </li>
         </ol>
-        </li>
-        <li>
-If processing aborts for any reason:
-        <ol>
-          <li>
-Set <code>status</code> to <code>false</code>
-          </li>
-          <li>
-Set <code>document</code> to <code>null</code>
-          </li>
-          <li>
-Set <code>mediaType</code> to <code>null</code>
-          </li>
-          <li>
-Return
-          </li>
-        </ol>
-        </li>
-        </li>
-      </ol>
     </section>
 
 
-  </section>
+</section>
 
-  <section>
+<section>
     <h2 id="validation-algorithms">Validation Algorithm</h2>
 
     <p>
-All claims expected for the <code>typ</code> MUST be present.
-All claims that are understood MUST be evaluated according the verifier's validation policies.
-All claims that are not understood MUST be ignored.
+        All claims expected for the <code>typ</code> MUST be present.
+        All claims that are understood MUST be evaluated according the verifier's validation policies.
+        All claims that are not understood MUST be ignored.
     </p>
 
     <p>
-The verified <code>document</code> returned from verification MUST be a
-well-formed compact JSON-LD document, as described in
-<a data-cite="VC-DATA-MODEL-2.0/#conformance">Verifiable Credentials Data Model v2.0</a>.
+        The verified <code>document</code> returned from verification MUST be a
+        well-formed compact JSON-LD document, as described in
+        <a data-cite="VC-DATA-MODEL-2.0/#conformance">Verifiable Credentials Data Model v2.0</a>.
     </p>
 
     <p>
-Schema extension mechanisms such as <code>credentialSchema</code> SHOULD be checked.
-If the extension mechanism <code>type</code> is not understood, this property
-MUST be ignored.
+        Schema extension mechanisms such as <code>credentialSchema</code> SHOULD be checked.
+        If the extension mechanism <code>type</code> is not understood, this property
+        MUST be ignored.
     </p>
 
     <p>
-Status extension mechanisms such as <code>credentialStatus</code> SHOULD be checked.
-If the extension mechanism <code>type</code> is not understood, this property
-MUST be ignored.
+        Status extension mechanisms such as <code>credentialStatus</code> SHOULD be checked.
+        If the extension mechanism <code>type</code> is not understood, this property
+        MUST be ignored.
     </p>
 
     <p>
-Based on the validation policy of the verifier, the type of credentials, and
-the type of securing mechanism, additional validation checks MAY be applied.
-For example, dependencies between multiple credentials, ordering or timing
-information associated with multiple credentials, and/or multiple presentations
-could cause an otherwise valid credential or presentation to be considered
-invalid.
+        Based on the validation policy of the verifier, the type of credentials, and
+        the type of securing mechanism, additional validation checks MAY be applied.
+        For example, dependencies between multiple credentials, ordering or timing
+        information associated with multiple credentials, and/or multiple presentations
+        could cause an otherwise valid credential or presentation to be considered
+        invalid.
     </p>
-  </section>
+</section>
 </body>
 
 </html>

--- a/plugin/src/exampleSdJwt.js
+++ b/plugin/src/exampleSdJwt.js
@@ -51,10 +51,9 @@ const getDisclosuresHtml = async (vc) => {
     const disclosureHtml = disclosures.map((disclosure) => {
         const decodedDisclosure = JSON.parse(new TextDecoder().decode(base64url.decode(disclosure)));
         const [, ...claimPath] = decodedDisclosure;
-        const claimName = claimPath.pop();
+        claimPath.pop();
         const hash = calculateHash(disclosure);
-
-        return generateDisclosureHtml(JSON.stringify(claimName), hash, disclosure, decodedDisclosure);
+        return generateDisclosureHtml(claimPath, hash, disclosure, decodedDisclosure);
     });
 
     return `<div class="disclosures">${disclosureHtml.join('\n')}</div>`;

--- a/plugin/src/exampleSdJwt.js
+++ b/plugin/src/exampleSdJwt.js
@@ -14,7 +14,7 @@ const customJSONStringify = (obj) => {
 const generateDisclosureHtml = (claimName, hash, disclosure, contents) => {
     return `
 <div class="disclosure">
-    <h3>Claim: <span class="claim-name">${claimName}</span></h3>
+    <h3 id="sd-jwt-claim-${hash}">Claim: <span class="claim-name">${claimName}</span></h3>
     <p><strong>SHA-256 Hash:</strong> <span class="hash">${hash}</span></p>
     <p><strong>Disclosure(s):</strong> <span class="disclosure-value">${disclosure}</span></p>
     <p><strong>Contents:</strong> <span class="contents">${customJSONStringify(contents)}</span></p>


### PR DESCRIPTION
The [build for the previous commit](https://github.com/w3c/vc-jose-cose/actions/runs/9167345084/job/25204335090) failed with a set of errors such as:

```
    No ID for section: 'H3'.
      {
        name: 'structure.section-ids',
        section: 'document-body',
        rule: 'headingWithoutID'
      }
```

to remedy, I've added identifiers for each heading tag. I've also applied a formatter to the HTML so that it is consistently formatted. Sorry for the large change, it is mostly shuffling deck chairs around.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/pull/274.html" title="Last updated on May 21, 2024, 5:48 PM UTC (ca0d12c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/274/a169ee8...ca0d12c.html" title="Last updated on May 21, 2024, 5:48 PM UTC (ca0d12c)">Diff</a>