### PR TITLE
Update media types according to WG resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -1490,7 +1490,11 @@ A document that contains public cryptographic material as defined in the
                 </tr>
                 <tr>
                     <td>Required parameters:</td>
-                    <td>None</td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td>Optional parameters:</td>
+                    <td>N/A</td>
                 </tr>
                 <tr>
                     <td>Encoding considerations:</td>
@@ -1502,12 +1506,60 @@ A document that contains public cryptographic material as defined in the
                 <tr>
                     <td>Security considerations:</td>
                     <td>
-                        <p>As defined in this specification. See also the security
-                            considerations in <a data-cite="JWT"></a>.</p>
+                        <p>As defined in <a href="#security-considerations">this specification</a>.
+                        See also the security considerations in [[RFC7519]].</p>
                     </td>
                 </tr>
                 <tr>
-                    <td>Contact:</td>
+                    <td>Interoperability considerations:</td>
+                    <td>
+                        <p>As defined in <a href="#conformance">this specification</a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Published specification:</td>
+                    <td><a href="https://w3.org/TR/vc-jose-cose">https://w3.org/TR/vc-jose-cose</a></td>
+                </tr>
+                <tr>
+                    <td>Applications that will use this media:</td>
+                    <td>
+                        <p>
+                            W3C Verifiable Credential issuer, holder, and verifier software,
+                            conforming to the [[VC-DATA-MODEL-2.0]],
+                            are among the applications that will use the media types. Conforming
+                            application types are described <a href="#conformance">here</a> and
+                            <a data-cite="VC-DATA-MODEL-2.0#conformance">here</a>.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Restrictions on usage:</td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td>Additional information:</td>
+                    <td>
+                    <ol type="1">
+                        <li>Deprecated alias names for this type: N/A</li>
+                        <li>Magic number(s): N/A</li>
+                        <li>File extension(s): N/A</li>
+                        <li>Macintosh file type code: N/A</li>
+                        <li>Object Identifiers: N/A</li>
+                    </ol>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Author:</td>
+                    <td>Ivan Herman <a
+                            href="mailto:ivan@w3.org">ivan@w3.org</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Intended usage:</td>
+                    <td>COMMON</td>
+                </tr>
+                <tr>
+                    <td>Change controller:</td>
                     <td>
                         W3C Verifiable Credentials Working Group <a
                             href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
@@ -1537,7 +1589,11 @@ A document that contains public cryptographic material as defined in the
                 </tr>
                 <tr>
                     <td>Required parameters:</td>
-                    <td>None</td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td>Optional parameters:</td>
+                    <td>N/A</td>
                 </tr>
                 <tr>
                     <td>Encoding considerations:</td>
@@ -1549,12 +1605,60 @@ A document that contains public cryptographic material as defined in the
                 <tr>
                     <td>Security considerations:</td>
                     <td>
-                        <p>As defined in this specification. See also the security
-                            considerations in <a data-cite="JWT"></a>.</p>
+                        <p>As defined in <a href="#security-considerations">this specification</a>.
+                        See also the security considerations in [[RFC7519]].</p>
                     </td>
                 </tr>
                 <tr>
-                    <td>Contact:</td>
+                    <td>Interoperability considerations:</td>
+                    <td>
+                        <p>As defined in <a href="#conformance">this specification</a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Published specification:</td>
+                    <td><a href="https://w3.org/TR/vc-jose-cose">https://w3.org/TR/vc-jose-cose</a></td>
+                </tr>
+                <tr>
+                    <td>Applications that will use this media:</td>
+                    <td>
+                        <p>
+                            W3C Verifiable Credential issuer, holder, and verifier software,
+                            conforming to the [[VC-DATA-MODEL-2.0]],
+                            are among the applications that will use the media types. Conforming
+                            application types are described <a href="#conformance">here</a> and
+                            <a data-cite="VC-DATA-MODEL-2.0#conformance">here</a>.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Restrictions on usage:</td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td>Additional information:</td>
+                    <td>
+                    <ol type="1">
+                        <li>Deprecated alias names for this type: N/A</li>
+                        <li>Magic number(s): N/A</li>
+                        <li>File extension(s): N/A</li>
+                        <li>Macintosh file type code: N/A</li>
+                        <li>Object Identifiers: N/A</li>
+                    </ol>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Author:</td>
+                    <td>Ivan Herman <a
+                            href="mailto:ivan@w3.org">ivan@w3.org</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Intended usage:</td>
+                    <td>COMMON</td>
+                </tr>
+                <tr>
+                    <td>Change controller:</td>
                     <td>
                         W3C Verifiable Credentials Working Group <a
                             href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
@@ -1584,24 +1688,76 @@ A document that contains public cryptographic material as defined in the
                 </tr>
                 <tr>
                     <td>Required parameters:</td>
-                    <td>None</td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td>Optional parameters:</td>
+                    <td>N/A</td>
                 </tr>
                 <tr>
                     <td>Encoding considerations:</td>
                     <td>
                         binary; `application/sd-jwt` values are a series of base64url-encoded values
-                        (some of which may be the empty string) separated by period ('.') or tilde ('~') characters.
+                        (some of which may be the empty string) separated by period ('.') and tilde ('~') characters.
                     </td>
                 </tr>
                 <tr>
                     <td>Security considerations:</td>
                     <td>
-                        <p>As defined in this specification. See also the security
-                            considerations in <a data-cite="SD-JWT"></a>.</p>
+                        <p>As defined in <a href="#security-considerations">this specification</a>.
+                        See also the security considerations in <a data-cite="SD-JWT"></a>.</p>
                     </td>
                 </tr>
                 <tr>
-                    <td>Contact:</td>
+                    <td>Interoperability considerations:</td>
+                    <td>
+                        <p>As defined in <a href="#conformance">this specification</a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Published specification:</td>
+                    <td><a href="https://w3.org/TR/vc-jose-cose">https://w3.org/TR/vc-jose-cose</a></td>
+                </tr>
+                <tr>
+                    <td>Applications that will use this media:</td>
+                    <td>
+                        <p>
+                            W3C Verifiable Credential issuer, holder, and verifier software,
+                            conforming to the [[VC-DATA-MODEL-2.0]],
+                            are among the applications that will use the media types. Conforming
+                            application types are described <a href="#conformance">here</a> and
+                            <a data-cite="VC-DATA-MODEL-2.0#conformance">here</a>.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Restrictions on usage:</td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td>Additional information:</td>
+                    <td>
+                    <ol type="1">
+                        <li>Deprecated alias names for this type: N/A</li>
+                        <li>Magic number(s): N/A</li>
+                        <li>File extension(s): N/A</li>
+                        <li>Macintosh file type code: N/A</li>
+                        <li>Object Identifiers: N/A</li>
+                    </ol>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Author:</td>
+                    <td>Ivan Herman <a
+                            href="mailto:ivan@w3.org">ivan@w3.org</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Intended usage:</td>
+                    <td>COMMON</td>
+                </tr>
+                <tr>
+                    <td>Change controller:</td>
                     <td>
                         W3C Verifiable Credentials Working Group <a
                             href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
@@ -1631,24 +1787,77 @@ A document that contains public cryptographic material as defined in the
                 </tr>
                 <tr>
                     <td>Required parameters:</td>
-                    <td>None</td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td>Optional parameters:</td>
+                    <td>N/A</td>
                 </tr>
                 <tr>
                     <td>Encoding considerations:</td>
                     <td>
                         binary; `application/sd-jwt` values are a series of base64url-encoded values
-                        (some of which may be the empty string) separated by period ('.') or tilde ('~') characters.
+                        (some of which may be the empty string) separated by period ('.') and tilde ('~') characters.
                     </td>
                 </tr>
                 <tr>
                     <td>Security considerations:</td>
                     <td>
-                        <p>As defined in this specification. See also the security
-                            considerations in <a data-cite="SD-JWT"></a>.</p>
+                        <p>As defined in <a href="#security-considerations">this specification</a>.
+                        See also the security considerations in <a data-cite="SD-JWT"></a>.</p>
                     </td>
                 </tr>
                 <tr>
-                    <td>Contact:</td>
+                    <td>Interoperability considerations:</td>
+                    <td>
+                        <p>As defined in <a href="#conformance">this specification</a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Published specification:</td>
+                    <td><a href="https://w3.org/TR/vc-jose-cose">https://w3.org/TR/vc-jose-cose</a></td>
+                </tr>
+                <tr>
+                    <td>Applications that will use this media:</td>
+                    <td>
+                        <p>
+                            W3C Verifiable Credential issuer, holder, and verifier software,
+                            conforming to the [[VC-DATA-MODEL-2.0]],
+                            are among the applications that will use the media types. Conforming
+                            application types are described <a href="#conformance">here</a> and
+                            <a data-cite="VC-DATA-MODEL-2.0#conformance">here</a>.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Restrictions on usage:</td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td>Additional information:</td>
+                    <td>
+                    <ol type="1">
+                        <li>Deprecated alias names for this type: N/A</li>
+                        <li>Magic number(s): N/A</li>
+                        <li>File extension(s): N/A</li>
+                        <li>Macintosh file type code: N/A</li>
+                        <li>Object Identifiers: N/A</li>
+                    </ol>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Author:</td>
+                    <td>
+                        Ivan Herman <a
+                            href="mailto:ivan@w3.org">ivan@w3.org</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Intended usage:</td>
+                    <td>COMMON</td>
+                </tr>
+                <tr>
+                    <td>Change controller:</td>
                     <td>
                         W3C Verifiable Credentials Working Group <a
                             href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
@@ -1678,23 +1887,73 @@ A document that contains public cryptographic material as defined in the
                 </tr>
                 <tr>
                     <td>Required parameters:</td>
-                    <td>None</td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td>Optional parameters:</td>
+                    <td>N/A</td>
                 </tr>
                 <tr>
                     <td>Encoding considerations:</td>
-                    <td>
-                        binary (CBOR)
-                    </td>
+                    <td>binary (CBOR)</td>
                 </tr>
                 <tr>
                     <td>Security considerations:</td>
                     <td>
-                        <p>As defined in this specification. See also the security
-                            considerations in [[RFC9052]].</p>
+                        <p>As defined in <a href="#security-considerations">this specification</a>.
+                        See also the security considerations in [[RFC9052]].</p>
                     </td>
                 </tr>
                 <tr>
-                    <td>Contact:</td>
+                    <td>Interoperability considerations:</td>
+                    <td>
+                        <p>As defined in <a href="#conformance">this specification</a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Published specification:</td>
+                    <td><a href="https://w3.org/TR/vc-jose-cose">https://w3.org/TR/vc-jose-cose</a></td>
+                </tr>
+                <tr>
+                    <td>Applications that will use this media:</td>
+                    <td>
+                        <p>
+                            W3C Verifiable Credential issuer, holder, and verifier software,
+                            conforming to the [[VC-DATA-MODEL-2.0]],
+                            are among the applications that will use the media types. Conforming
+                            application types are described <a href="#conformance">here</a> and
+                            <a data-cite="VC-DATA-MODEL-2.0#conformance">here</a>.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Restrictions on usage:</td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td>Additional information:</td>
+                    <td>
+                    <ol type="1">
+                        <li>Deprecated alias names for this type: N/A</li>
+                        <li>Magic number(s): N/A</li>
+                        <li>File extension(s): N/A</li>
+                        <li>Macintosh file type code: N/A</li>
+                        <li>Object Identifiers: N/A</li>
+                    </ol>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Author:</td>
+                    <td>Ivan Herman <a
+                            href="mailto:ivan@w3.org">ivan@w3.org</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Intended usage:</td>
+                    <td>COMMON</td>
+                </tr>
+                <tr>
+                    <td>Change controller:</td>
                     <td>
                         W3C Verifiable Credentials Working Group <a
                             href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
@@ -1724,23 +1983,73 @@ A document that contains public cryptographic material as defined in the
                 </tr>
                 <tr>
                     <td>Required parameters:</td>
-                    <td>None</td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td>Optional parameters:</td>
+                    <td>N/A</td>
                 </tr>
                 <tr>
                     <td>Encoding considerations:</td>
-                    <td>
-                        binary (CBOR)
-                    </td>
+                    <td>binary (CBOR)</td>
                 </tr>
                 <tr>
                     <td>Security considerations:</td>
                     <td>
-                        <p>As defined in this specification. See also the security
-                            considerations in [[RFC9052]].</p>
+                        <p>As defined in <a href="#security-considerations">this specification</a>.
+                        See also the security considerations in [[RFC9052]].</p>
                     </td>
                 </tr>
                 <tr>
-                    <td>Contact:</td>
+                    <td>Interoperability considerations:</td>
+                    <td>
+                        <p>As defined in <a href="#conformance">this specification</a>.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Published specification:</td>
+                    <td><a href="https://w3.org/TR/vc-jose-cose">https://w3.org/TR/vc-jose-cose</a></td>
+                </tr>
+                <tr>
+                    <td>Applications that will use this media:</td>
+                    <td>
+                        <p>
+                            W3C Verifiable Credential issuer, holder, and verifier software,
+                            conforming to the [[VC-DATA-MODEL-2.0]],
+                            are among the applications that will use the media types. Conforming
+                            application types are described <a href="#conformance">here</a> and
+                            <a data-cite="VC-DATA-MODEL-2.0#conformance">here</a>.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Restrictions on usage:</td>
+                    <td>N/A</td>
+                </tr>
+                <tr>
+                    <td>Additional information:</td>
+                    <td>
+                    <ol type="1">
+                        <li>Deprecated alias names for this type: N/A</li>
+                        <li>Magic number(s): N/A</li>
+                        <li>File extension(s): N/A</li>
+                        <li>Macintosh file type code: N/A</li>
+                        <li>Object Identifiers: N/A</li>
+                    </ol>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Author:</td>
+                    <td>Ivan Herman <a
+                            href="mailto:ivan@w3.org">ivan@w3.org</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Intended usage:</td>
+                    <td>COMMON</td>
+                </tr>
+                <tr>
+                    <td>Change controller:</td>
                     <td>
                         W3C Verifiable Credentials Working Group <a
                             href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>

--- a/index.html
+++ b/index.html
@@ -284,12 +284,12 @@
           <p>
               The normative statements in <a data-cite="VC-DATA-MODEL-2.0#securing-mechanisms">
               Securing Mechanisms</a> apply to securing
-              <code>application/vc-ld+jwt</code> and
-              <code>application/vp-ld+jwt</code>,
-              <code>application/vc-ld+sd-jwt</code> and
-              <code>application/vp-ld+sd-jwt</code>,
-              <code>application/vc-ld+cose</code> and
-              <code>application/vp-ld+cose</code>.
+              <code>application/vc+jwt</code> and
+              <code>application/vp+jwt</code>,
+              <code>application/vc+sd-jwt</code> and
+              <code>application/vp+sd-jwt</code>,
+              <code>application/vc+cose</code> and
+              <code>application/vp+cose</code>.
           </p>
           <section>
               <h2>JWT Format and Requirements</h2>
@@ -414,7 +414,7 @@ A document that contains public cryptographic material as defined in the
     <p>
         The most specific media type (or subtype) available SHOULD be used, instead of
         more generic media types (or supertypes). For example, rather than the general
-        <code>application/sd-jwt</code>, <code>application/vc-ld+sd-jwt</code>
+        <code>application/sd-jwt</code>, <code>application/vc+sd-jwt</code>
         SHOULD be used, unless there is a more specific media type that would even
         better identify the secured envelope format.
     </p>
@@ -432,10 +432,10 @@ A document that contains public cryptographic material as defined in the
             </p>
             <p>
                 A [=conforming JWS issuer implementation=] MUST use [[RFC7515]] to secure this media type.
-                The unsecured verifiable credential is the unencoded JWS payload.
+                The unsecured [=verifiable credential=] is the unencoded JWS payload.
             </p>
             <p>
-                The <code>typ</code> header parameter SHOULD be <code>vc-ld+jwt</code>.
+                The <code>typ</code> header parameter SHOULD be <code>vc+jwt</code>.
                 When present, the <code>cty</code> header parameter SHOULD be <code>vc</code>.
                 See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
                 for additional details regarding usage of <code>typ</code> and
@@ -489,15 +489,15 @@ A document that contains public cryptographic material as defined in the
         <section>
             <h2 id="securing-vps-with-jose">Securing JSON-LD Verifiable Presentations with JOSE</h2>
             <p>
-                This section details how to use JOSE to secure verifiable presentations conforming
+                This section details how to use JOSE to secure [=verifiable presentations=] conforming
                 to [[VC-DATA-MODEL-2.0]].
             </p>
             <p>
                 A [=conforming JWS issuer implementation=] MUST use [[RFC7515]] to secure this media type.
-                The unsecured verifiable presentation is the unencoded JWS payload.
+                The unsecured [=verifiable presentation=] is the unencoded JWS payload.
             </p>
             <p>
-                The <code>typ</code> header parameter SHOULD be <code>vp-ld+jwt</code>.
+                The <code>typ</code> header parameter SHOULD be <code>vp+jwt</code>.
                 When present, the <code>cty</code> header parameter SHOULD be <code>vp</code>.
                 See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
                 for additional details regarding usage of <code>typ</code> and
@@ -520,8 +520,8 @@ A document that contains public cryptographic material as defined in the
                 Presentation</a> type defined by the [[VC-DATA-MODEL-2.0]].
             </p>
             <p>
-                Credentials in verifiable presentations MUST be secured.
-                These credentials are secured using JWS in this case.
+                Credentials in [=verifiable presentations=] MUST be secured.
+                In this case, these [=credentials=] are secured using JWS.
             <p>
 	    <p>
 	      To encrypt a secured [=verifiable presentation=]
@@ -543,7 +543,7 @@ A document that contains public cryptographic material as defined in the
   "verifiableCredential": [{
     "@context": ["https://www.w3.org/ns/credentials/v2"],
     "type": ["EnvelopedVerifiableCredential"],
-    "id": "data:application/vc-ld+jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMzODQifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwOi8vdW5pdmVyc2l0eS5leGFtcGxlL2NyZWRlbnRpYWxzLzE4NzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRXhhbXBsZUFsdW1uaUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiaWQiOiJodHRwczovL2V4YW1wbGUub3JnL2V4YW1wbGVzL2RlZ3JlZS5qc29uIiwidHlwZSI6Ikpzb25TY2hlbWEifSwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZToxMjMiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19.d2k4O3FytQJf83kLh-HsXuPvh6yeOlhJELVo5TF71gu7elslQyOf2ZItAXrtbXF4Kz9WivNdztOayz4VUQ0Mwa8yCDZkP9B2pH-9S_tcAFxeoeJ6Z4XnFuL_DOfkR1fP"
+    "id": "data:application/vc+jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMzODQifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwOi8vdW5pdmVyc2l0eS5leGFtcGxlL2NyZWRlbnRpYWxzLzE4NzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRXhhbXBsZUFsdW1uaUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiaWQiOiJodHRwczovL2V4YW1wbGUub3JnL2V4YW1wbGVzL2RlZ3JlZS5qc29uIiwidHlwZSI6Ikpzb25TY2hlbWEifSwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZToxMjMiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19.d2k4O3FytQJf83kLh-HsXuPvh6yeOlhJELVo5TF71gu7elslQyOf2ZItAXrtbXF4Kz9WivNdztOayz4VUQ0Mwa8yCDZkP9B2pH-9S_tcAFxeoeJ6Z4XnFuL_DOfkR1fP"
   }]
 }
       </pre>
@@ -560,7 +560,7 @@ A document that contains public cryptographic material as defined in the
     "https://www.w3.org/ns/credentials/examples/v2"
   ],
   "type": "EnvelopedVerifiablePresentation",  
-  "id": "data:application/vp-ld+jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMzODQifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwOi8vdW5pdmVyc2l0eS5leGFtcGxlL2NyZWRlbnRpYWxzLzE4NzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRXhhbXBsZUFsdW1uaUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiaWQiOiJodHRwczovL2V4YW1wbGUub3JnL2V4YW1wbGVzL2RlZ3JlZS5qc29uIiwidHlwZSI6Ikpzb25TY2hlbWEifSwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZToxMjMiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19.d2k4O3FytQJf83kLh-HsXuPvh6yeOlhJELVo5TF71gu7elslQyOf2ZItAXrtbXF4Kz9WivNdztOayz4VUQ0Mwa8yCDZkP9B2pH-9S_tcAFxeoeJ6Z4XnFuL_DOfkR1fP"
+  "id": "data:application/vp+jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMzODQifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwOi8vdW5pdmVyc2l0eS5leGFtcGxlL2NyZWRlbnRpYWxzLzE4NzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRXhhbXBsZUFsdW1uaUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiaWQiOiJodHRwczovL2V4YW1wbGUub3JnL2V4YW1wbGVzL2RlZ3JlZS5qc29uIiwidHlwZSI6Ikpzb25TY2hlbWEifSwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZToxMjMiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19.d2k4O3FytQJf83kLh-HsXuPvh6yeOlhJELVo5TF71gu7elslQyOf2ZItAXrtbXF4Kz9WivNdztOayz4VUQ0Mwa8yCDZkP9B2pH-9S_tcAFxeoeJ6Z4XnFuL_DOfkR1fP"
 }
       </pre>
             <p>
@@ -592,7 +592,7 @@ A document that contains public cryptographic material as defined in the
                 <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>,
                 <a data-cite="RFC7519#section-5">JOSE Header</a>, and
                 <a data-cite="RFC7519#section-5.3">Replicating Claims as Header Parameters</a>
-                apply to securing credentials and presentations.
+                apply to securing [=credentials=] and [=presentations=].
             </p>
             <p>
                 The unencoded JOSE Header is JSON (`application/json`), not JSON-LD
@@ -632,8 +632,8 @@ A document that contains public cryptographic material as defined in the
                 values of verifiable credential properties when a claim and property pair refer
                 to the same conceptual entity, especially with pairs such as `iss` and `issuer`,
                 `jti` and `id`, and `sub` and `credentialSubject.id`. For example, JWK claim
-                `iss` should not be set to a value which conflicts with the value of verifiable
-                credential property `issuer`.
+                `iss` should not be set to a value which conflicts with the value of [=verifiable
+                credential=] property `issuer`.
             </p>
             <p>
                 The JWT Claim Names <code>vc</code> and <code>vp</code> MUST NOT be present.
@@ -650,18 +650,18 @@ A document that contains public cryptographic material as defined in the
         <section>
             <h2 id="securing-with-sd-jwt">Securing JSON-LD Verifiable Credentials with SD-JWT</h2>
             <p>
-                This section details how to use JOSE to secure verifiable credentials conforming
+                This section details how to use JOSE to secure [=verifiable credentials=] conforming
                 to [[VC-DATA-MODEL-2.0]].
             </p>
             <p>
                 A [=conforming SD-JWT issuer implementation=] MUST use [[[SD-JWT]]] [[SD-JWT]] to secure
                 this media type. The unsecured [=verifiable credential=] is the input JSON
                 claim set. The Issuer then converts the input JSON claim set (i.e., the
-                unsecured [=verifiable credential=]) into an SD-JWT payload according to
+                unsecured [=verifiable credential=]) into an [[SD-JWT]] payload according to
                 <a data-cite="SD-JWT#section-6.1">SD-JWT issuance instructions</a>.
             </p>
             <p>
-                The <code>typ</code> header parameter SHOULD be <code>vc-ld+sd-jwt</code>.
+                The <code>typ</code> header parameter SHOULD be <code>vc+sd-jwt</code>.
                 When present, the <code>cty</code> header parameter SHOULD be <code>vc</code>.
                 See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
                 for additional details regarding usage of <code>typ</code> and
@@ -727,15 +727,15 @@ A document that contains public cryptographic material as defined in the
         <section>
             <h2 id="securing-vps-sd-jwt">Securing JSON-LD Verifiable Presentations with SD-JWT</h2>
             <p>
-                This section details how to use SD-JWT to secure verifiable presentations conforming
+                This section details how to use [[SD-JWT]] to secure verifiable presentations conforming
                 to [[VC-DATA-MODEL-2.0]].
             </p>
             <p>
                 A [=conforming SD-JWT issuer implementation=] MUST use [[SD-JWT]] to secure this media type.
-                The unsecured verifiable presentation is the unencoded SD-JWT payload.
+                The unsecured [=verifiable presentation=] is the unencoded [[SD-JWT]] payload.
             </p>
             <p>
-                The <code>typ</code> header parameter SHOULD be <code>vp-ld+sd-jwt</code>.
+                The <code>typ</code> header parameter SHOULD be <code>vp+sd-jwt</code>.
                 When present, the <code>cty</code> header parameter SHOULD be <code>vp</code>.
                 See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
                 for additional details regarding usage of <code>typ</code> and
@@ -758,8 +758,8 @@ A document that contains public cryptographic material as defined in the
                 Presentation</a> type defined by the [[VC-DATA-MODEL-2.0]].
             </p>
             <p>
-                Credentials in verifiable presentations MUST be secured.
-                These credentials are secured using SD-JWT in this case.
+                Credentials in [=verifiable presentations=] MUST be secured.
+                These [=credentials=] are secured using SD-JWT in this case.
             <p>
             <p>
                 When securing [=verifiable presentations=] with [[SD-JWT]] implementers SHOULD ensure that
@@ -791,7 +791,7 @@ A document that contains public cryptographic material as defined in the
   "verifiableCredential": [{
     "@context": "https://www.w3.org/ns/credentials/v2",
     "type": "EnvelopedVerifiableCredential",
-    "id": "data:application/vc-ld+sd-jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJfc2RfYWxnIjoic2hhLTI1NiIsIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiNjVFLVZZbmE3UE5mSGVsUDN6THFwcE5ERXhSLWhjWkhSTnlxN2U0ZVdabyIsIjhJbEwtUGx4Ukt3S0hLaTMtTXhXMjM4d0FkTmQ0NHdabC1iY3NBc2JIQjAiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJuYW1lIjoiQmFjaGVsb3Igb2YgU2NpZW5jZSBhbmQgQXJ0cyIsIl9zZCI6WyJMVXhqcWtsWS1hdDVSVmFoSXpxM3NJZ015dkdwVDlwdlUwdTRyU2ktMXl3Il19LCJfc2QiOlsiVmxZLW50ZklPOUI5RGRsUWp5U2REMldoVWI0bjc3Zl9HWDZ2U1dLQWpCNCJdfSwiX3NkIjpbIi1iREZ4Um94UUVlcEdjZFl6a250aTVGWXBsUTU5N0djaEdUTGVtLVJSY1UiLCJfREFVZ0xrTF9zVkVtLTBvcE8zaWhpeVFhS0ZzT08xUl9ONk1CUmprOWhFIl19.Kc083RKbBxc3Vr5qR3iEEPp3dKxTa6sPaWNsqtkIw8TvMRf9EZL2ajtgkWSBYzyzOzawOrCXryyp4rMTyI9vfA ~WyJiQ1RTaU9HNUo1VXhPY1QwUlNfd01nIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJTclNWMS01SjR6cWhOU3N3STIwaHdRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJKX294dDhtUGUtaDl4MkQzc29uT1N3IiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJDMlpWektmZ185RUh1ajB2S1ExdWJnIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJ6Szd5QlFPbFhfX2Q0X0VoYUc0Y0pRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyJ6b1pzRzMzeXBMeVRGMm9aS3ZmMVFnIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~"
+    "id": "data:application/vc+sd-jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJfc2RfYWxnIjoic2hhLTI1NiIsIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiNjVFLVZZbmE3UE5mSGVsUDN6THFwcE5ERXhSLWhjWkhSTnlxN2U0ZVdabyIsIjhJbEwtUGx4Ukt3S0hLaTMtTXhXMjM4d0FkTmQ0NHdabC1iY3NBc2JIQjAiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJuYW1lIjoiQmFjaGVsb3Igb2YgU2NpZW5jZSBhbmQgQXJ0cyIsIl9zZCI6WyJMVXhqcWtsWS1hdDVSVmFoSXpxM3NJZ015dkdwVDlwdlUwdTRyU2ktMXl3Il19LCJfc2QiOlsiVmxZLW50ZklPOUI5RGRsUWp5U2REMldoVWI0bjc3Zl9HWDZ2U1dLQWpCNCJdfSwiX3NkIjpbIi1iREZ4Um94UUVlcEdjZFl6a250aTVGWXBsUTU5N0djaEdUTGVtLVJSY1UiLCJfREFVZ0xrTF9zVkVtLTBvcE8zaWhpeVFhS0ZzT08xUl9ONk1CUmprOWhFIl19.Kc083RKbBxc3Vr5qR3iEEPp3dKxTa6sPaWNsqtkIw8TvMRf9EZL2ajtgkWSBYzyzOzawOrCXryyp4rMTyI9vfA ~WyJiQ1RTaU9HNUo1VXhPY1QwUlNfd01nIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJTclNWMS01SjR6cWhOU3N3STIwaHdRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJKX294dDhtUGUtaDl4MkQzc29uT1N3IiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJDMlpWektmZ185RUh1ajB2S1ExdWJnIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJ6Szd5QlFPbFhfX2Q0X0VoYUc0Y0pRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyJ6b1pzRzMzeXBMeVRGMm9aS3ZmMVFnIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~"
   }]
 }
       </pre>
@@ -808,7 +808,7 @@ A document that contains public cryptographic material as defined in the
     "https://www.w3.org/ns/credentials/examples/v2"
   ],
   "type": "EnvelopedVerifiablePresentation",
-  "id": "data:application/vp-ld+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlVRTV9fblE0UzZCTzhuUTRuT05YeHB4aHRob3lOeGI1M0xZZ1l6LTJBQnMiLCJ0eXAiOiJ2cCtsZCtqc29uK3NkLWp3dCIsImN0eSI6InZwK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiYWx1bW5pT2YiOnsibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSIsIl9zZCI6WyJoek9LRzU2cDI5c1ByTGFDNUE4RndFdUczVU05dUlZU1p1cU9YczJlVGJBIl19LCJfc2QiOlsiWVdXVmVDRndxQmk4WDBqSF9jV0NWWU16STNhOHBjTEVYRWZicFNSQVlndyJdfSwiX3NkIjpbIjJJZjhhaUs4REZwVWJ4dEc1cGMwel9SaFJzbm1ybGFRMEhzcTk4WFNyYWsiLCJUeDZ4ZWZMVUdUZUpfYWtVUFdGeHNvbUhobGtWVnpfNzVoaVZ6eWpyYmVzIl19XSwiX3NkIjpbIjd2anl0VVN3ZEJ0MXQ5RktlOVFfS3JIRXhFWGxrTEFaTzBKM0Jpd200dlkiXSwiX3NkX2FsZyI6InNoYS0yNTYiLCJpYXQiOjE3MDY1NjI4NDksImV4cCI6MTczODE4NTI0OSwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwiYWxnIjoiRVMzODQiLCJ4IjoidWtEd1U2ZzlQUVRFUWhYaEgyckRZNndMQlg3UHFlUjZBcGlhVHBEUXowcl8tdDl6UXNxem54Z0hEcE5oekZlQyIsInkiOiJMQnhVYnBVdFNGMVVKVTVpYnJIdkpINjBUSG5YMk1xa0xHZGltU1l0UGR4RlkxOEdhcldiS3FZV0djUkZHVE9BIn19fQ.kYD63YtBNYnLUTw6Szf1vs_Ug3UBXhPwCyqpNmPnPDa3rXZQhQLdB1BgaoO8zgQ-c3B41fxaXMnLHYV9-B20uboSpJP0B-2Vre917eQt1cSDswDGA_Ytvn4BSqYVBB2J~WyJFMkFsRzhsY2p0QVFrcllIbjlIbnVRIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd~WyI5NldYMDRneno4cVZzOVZLU2wwYTVnIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJaekU2VFVaamtHMW1DWXBKMEhnc0l3IiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyItQ3NsS25GZGFYb2JiQWsyU0JBVGR3IiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd~WyJuRm1OWl9IczB3WWNoOFdkeTdnQUNRIiwgImlkIiwgImRpZDpleGFtcGxlOmMyNzZlMTJlYzIxZWJmZWIxZjcxMmViYzZmMSJd~"
+  "id": "data:application/vp+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlVRTV9fblE0UzZCTzhuUTRuT05YeHB4aHRob3lOeGI1M0xZZ1l6LTJBQnMiLCJ0eXAiOiJ2cCtsZCtqc29uK3NkLWp3dCIsImN0eSI6InZwK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiYWx1bW5pT2YiOnsibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSIsIl9zZCI6WyJoek9LRzU2cDI5c1ByTGFDNUE4RndFdUczVU05dUlZU1p1cU9YczJlVGJBIl19LCJfc2QiOlsiWVdXVmVDRndxQmk4WDBqSF9jV0NWWU16STNhOHBjTEVYRWZicFNSQVlndyJdfSwiX3NkIjpbIjJJZjhhaUs4REZwVWJ4dEc1cGMwel9SaFJzbm1ybGFRMEhzcTk4WFNyYWsiLCJUeDZ4ZWZMVUdUZUpfYWtVUFdGeHNvbUhobGtWVnpfNzVoaVZ6eWpyYmVzIl19XSwiX3NkIjpbIjd2anl0VVN3ZEJ0MXQ5RktlOVFfS3JIRXhFWGxrTEFaTzBKM0Jpd200dlkiXSwiX3NkX2FsZyI6InNoYS0yNTYiLCJpYXQiOjE3MDY1NjI4NDksImV4cCI6MTczODE4NTI0OSwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwiYWxnIjoiRVMzODQiLCJ4IjoidWtEd1U2ZzlQUVRFUWhYaEgyckRZNndMQlg3UHFlUjZBcGlhVHBEUXowcl8tdDl6UXNxem54Z0hEcE5oekZlQyIsInkiOiJMQnhVYnBVdFNGMVVKVTVpYnJIdkpINjBUSG5YMk1xa0xHZGltU1l0UGR4RlkxOEdhcldiS3FZV0djUkZHVE9BIn19fQ.kYD63YtBNYnLUTw6Szf1vs_Ug3UBXhPwCyqpNmPnPDa3rXZQhQLdB1BgaoO8zgQ-c3B41fxaXMnLHYV9-B20uboSpJP0B-2Vre917eQt1cSDswDGA_Ytvn4BSqYVBB2J~WyJFMkFsRzhsY2p0QVFrcllIbjlIbnVRIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd~WyI5NldYMDRneno4cVZzOVZLU2wwYTVnIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJaekU2VFVaamtHMW1DWXBKMEhnc0l3IiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyItQ3NsS25GZGFYb2JiQWsyU0JBVGR3IiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd~WyJuRm1OWl9IczB3WWNoOFdkeTdnQUNRIiwgImlkIiwgImRpZDpleGFtcGxlOmMyNzZlMTJlYzIxZWJmZWIxZjcxMmViYzZmMSJd~"
 }
       </pre>
             <p>
@@ -837,16 +837,16 @@ A document that contains public cryptographic material as defined in the
         <section>
             <h2 id="securing-vcs-with-cose">Securing JSON-LD Verifiable Credentials with COSE</h2>
             <p>
-                This section details how to use COSE to secure verifiable credentials conforming
+                This section details how to use COSE to secure [=verifiable credentials=] conforming
                 to [[VC-DATA-MODEL-2.0]].
             </p>
             <p>
                 A [=conforming COSE issuer implementation=] MUST use COSE_Sign1 as specified in [[RFC9052]] to secure
                 this media type.
-                The unsecured verifiable credential is the unencoded COSE_Sign1 payload.
+                The unsecured [=verifiable credential=] is the unencoded COSE_Sign1 payload.
             </p>
             <p>
-                The <code>typ</code> header parameter, as described in <a data-cite="RFC9596#section-2">COSE "typ" (type) Header Parameter</a>, SHOULD be <code>application/vc-ld+cose</code>.
+                The <code>typ</code> header parameter, as described in <a data-cite="RFC9596#section-2">COSE "typ" (type) Header Parameter</a>, SHOULD be <code>application/vc+cose</code>.
                 When present, the <code>content type (3)</code> header parameter
                 SHOULD be <code>application/vc</code>.
                 See <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a> for additional details.
@@ -854,6 +854,11 @@ A document that contains public cryptographic material as defined in the
             <p>
                 A [=conforming COSE verifier implementation=] MUST use COSE_Sign1 as specified in [[RFC9052]] to verify
                 [=conforming COSE documents=] that use this media type.
+            </p>
+            <p>
+                When including [=verifiable credentials=] secured with COSE in [=verifiable presentations=]
+                as <a 
+                data-cite="VC-DATA-MODEL-2.0/#defn-EnvelopedVerifiableCredential">Enveloped Verifiable Credentials</a>, the credentials MUST be encoded using base64 as specified in [[RFC2397]].
             </p>
 	    <p>
 	      To encrypt a secured [=verifiable credential=]
@@ -900,17 +905,17 @@ A document that contains public cryptographic material as defined in the
         <section>
             <h2 id="securing-vps-with-cose">Securing JSON-LD Verifiable Presentations with COSE</h2>
             <p>
-                This section details how to use COSE to secure verifiable presentations conforming
+                This section details how to use COSE to secure [=verifiable presentations=] conforming
                 to [[VC-DATA-MODEL-2.0]].
             </p>
             <p>
                 A [=conforming COSE issuer implementation=] MUST use COSE_Sign1 as specified in [[RFC9052]] to secure
                 this media type.
-                The unsecured verifiable presentation is the unencoded COSE_Sign1 payload.
+                The unsecured [=verifiable presentation=] is the unencoded COSE_Sign1 payload.
             </p>
             <p>
-                The <code>typ</code> header parameter SHOULD be <code>application/vp-ld+cose</code>.
-                When present, the <code>cty</code> header parameter SHOULD be <code>application/vp</code>.
+                The <code>typ</code> header parameter SHOULD be <code>application/vp+cose</code>.
+                When present, the <code>content type (3)</code> header parameter SHOULD be <code>application/vp</code>.
                 See <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a> for additional details.
             </p>
             <p>
@@ -930,8 +935,8 @@ A document that contains public cryptographic material as defined in the
                 Presentation</a> type defined by the [[VC-DATA-MODEL-2.0]].
             </p>
             <p>
-                Credentials in verifiable presentations MUST be secured.
-                These credentials are secured using COSE in this case.
+                Credentials in [=verifiable presentations=] MUST be secured.
+                These [=credentials=] are secured using COSE in this case.
             <p>
 	    <p>
 	      To encrypt a secured [=verifiable presentation=]
@@ -953,7 +958,7 @@ A document that contains public cryptographic material as defined in the
   "verifiableCredential": [{
     "@context": "https://www.w3.org/ns/credentials/v2",
     "type": "EnvelopedVerifiableCredential",
-    "id": "data:application/vc-ld+sd-jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJfc2RfYWxnIjoic2hhLTI1NiIsIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiNWJBeDMteHBmQWxVS0ZJOXNuM2hWQ21wR2trcUlzWmMzLUxiMzNmWmpiayIsIlpjQXZIMDhsdEJySUpmSWh0OF9tS1BfYzNscG5YMWNHclltVG8wZ1lCeTgiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJuYW1lIjoiQmFjaGVsb3Igb2YgU2NpZW5jZSBhbmQgQXJ0cyIsIl9zZCI6WyJST1Q3MUl0dTNMNlVXWFVqby1oWVdJQjY3bHVPTkVEUlNCaGxEVENxVU9RIl19LCJfc2QiOlsiTUVuZXNnMlhPUk5jY3NCTWVaXzE2MDJneTQwUi00WUJ2VlIweFE4b0Y4YyJdfSwiX3NkIjpbIkVlc2Jiay1mcGZwd2ZMOXdOczFxcjZ0aU43ZnEtSXQzWVM2V3ZCbl9iWG8iLCJab1I1ZGRhckdtZk15NEhuV0xVak5URnFURjNYRjZpdFBnZnlGQkhVX3FVIl19.gw3paxbkLjpi8CTsyRpXKbC7tpVa0q2sWKSD-_dcbuZ1LpZV3oQ8Ifzcm2bE8RY3fmJgbuyA9gbPL3sQBaTzkg ~WyJSeUQxVlB4VHBvbmtPeXZpczkta293IiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJfVjd1eTd3ay1RM3VZd2ZpZ0NvWUVBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJhazdqMTlnYVMtRDJLX2hzY3RVZGNRIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJUTjBXaXVZRkhXWkV2ZDZIQUJHQS1nIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJVMnBzMkxYVERVbVh3MDcxRVBmRUpnIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyJsQ042eTNEaTNDUk9VX3JuXzRENWRnIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~"
+    "id": "data:application/vc+sd-jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJfc2RfYWxnIjoic2hhLTI1NiIsIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiNWJBeDMteHBmQWxVS0ZJOXNuM2hWQ21wR2trcUlzWmMzLUxiMzNmWmpiayIsIlpjQXZIMDhsdEJySUpmSWh0OF9tS1BfYzNscG5YMWNHclltVG8wZ1lCeTgiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJuYW1lIjoiQmFjaGVsb3Igb2YgU2NpZW5jZSBhbmQgQXJ0cyIsIl9zZCI6WyJST1Q3MUl0dTNMNlVXWFVqby1oWVdJQjY3bHVPTkVEUlNCaGxEVENxVU9RIl19LCJfc2QiOlsiTUVuZXNnMlhPUk5jY3NCTWVaXzE2MDJneTQwUi00WUJ2VlIweFE4b0Y4YyJdfSwiX3NkIjpbIkVlc2Jiay1mcGZwd2ZMOXdOczFxcjZ0aU43ZnEtSXQzWVM2V3ZCbl9iWG8iLCJab1I1ZGRhckdtZk15NEhuV0xVak5URnFURjNYRjZpdFBnZnlGQkhVX3FVIl19.gw3paxbkLjpi8CTsyRpXKbC7tpVa0q2sWKSD-_dcbuZ1LpZV3oQ8Ifzcm2bE8RY3fmJgbuyA9gbPL3sQBaTzkg ~WyJSeUQxVlB4VHBvbmtPeXZpczkta293IiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJfVjd1eTd3ay1RM3VZd2ZpZ0NvWUVBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJhazdqMTlnYVMtRDJLX2hzY3RVZGNRIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJUTjBXaXVZRkhXWkV2ZDZIQUJHQS1nIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJVMnBzMkxYVERVbVh3MDcxRVBmRUpnIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyJsQ042eTNEaTNDUk9VX3JuXzRENWRnIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~"
   }]
 }
       </pre>
@@ -970,7 +975,7 @@ A document that contains public cryptographic material as defined in the
     "https://www.w3.org/ns/credentials/examples/v2"
   ],
   "type": "EnvelopedVerifiablePresentation",
-  "id": "data:application/vp-ld+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlVRTV9fblE0UzZCTzhuUTRuT05YeHB4aHRob3lOeGI1M0xZZ1l6LTJBQnMiLCJ0eXAiOiJ2cCtsZCtqc29uK3NkLWp3dCIsImN0eSI6InZwK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiYWx1bW5pT2YiOnsibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSIsIl9zZCI6WyJoek9LRzU2cDI5c1ByTGFDNUE4RndFdUczVU05dUlZU1p1cU9YczJlVGJBIl19LCJfc2QiOlsiWVdXVmVDRndxQmk4WDBqSF9jV0NWWU16STNhOHBjTEVYRWZicFNSQVlndyJdfSwiX3NkIjpbIjJJZjhhaUs4REZwVWJ4dEc1cGMwel9SaFJzbm1ybGFRMEhzcTk4WFNyYWsiLCJUeDZ4ZWZMVUdUZUpfYWtVUFdGeHNvbUhobGtWVnpfNzVoaVZ6eWpyYmVzIl19XSwiX3NkIjpbIjd2anl0VVN3ZEJ0MXQ5RktlOVFfS3JIRXhFWGxrTEFaTzBKM0Jpd200dlkiXSwiX3NkX2FsZyI6InNoYS0yNTYiLCJpYXQiOjE3MDY1NjI4NDksImV4cCI6MTczODE4NTI0OSwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwiYWxnIjoiRVMzODQiLCJ4IjoidWtEd1U2ZzlQUVRFUWhYaEgyckRZNndMQlg3UHFlUjZBcGlhVHBEUXowcl8tdDl6UXNxem54Z0hEcE5oekZlQyIsInkiOiJMQnhVYnBVdFNGMVVKVTVpYnJIdkpINjBUSG5YMk1xa0xHZGltU1l0UGR4RlkxOEdhcldiS3FZV0djUkZHVE9BIn19fQ.kYD63YtBNYnLUTw6Szf1vs_Ug3UBXhPwCyqpNmPnPDa3rXZQhQLdB1BgaoO8zgQ-c3B41fxaXMnLHYV9-B20uboSpJP0B-2Vre917eQt1cSDswDGA_Ytvn4BSqYVBB2J~WyJFMkFsRzhsY2p0QVFrcllIbjlIbnVRIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd~WyI5NldYMDRneno4cVZzOVZLU2wwYTVnIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJaekU2VFVaamtHMW1DWXBKMEhnc0l3IiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyItQ3NsS25GZGFYb2JiQWsyU0JBVGR3IiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd~WyJuRm1OWl9IczB3WWNoOFdkeTdnQUNRIiwgImlkIiwgImRpZDpleGFtcGxlOmMyNzZlMTJlYzIxZWJmZWIxZjcxMmViYzZmMSJd~"
+  "id": "data:application/vp+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlVRTV9fblE0UzZCTzhuUTRuT05YeHB4aHRob3lOeGI1M0xZZ1l6LTJBQnMiLCJ0eXAiOiJ2cCtsZCtqc29uK3NkLWp3dCIsImN0eSI6InZwK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiYWx1bW5pT2YiOnsibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSIsIl9zZCI6WyJoek9LRzU2cDI5c1ByTGFDNUE4RndFdUczVU05dUlZU1p1cU9YczJlVGJBIl19LCJfc2QiOlsiWVdXVmVDRndxQmk4WDBqSF9jV0NWWU16STNhOHBjTEVYRWZicFNSQVlndyJdfSwiX3NkIjpbIjJJZjhhaUs4REZwVWJ4dEc1cGMwel9SaFJzbm1ybGFRMEhzcTk4WFNyYWsiLCJUeDZ4ZWZMVUdUZUpfYWtVUFdGeHNvbUhobGtWVnpfNzVoaVZ6eWpyYmVzIl19XSwiX3NkIjpbIjd2anl0VVN3ZEJ0MXQ5RktlOVFfS3JIRXhFWGxrTEFaTzBKM0Jpd200dlkiXSwiX3NkX2FsZyI6InNoYS0yNTYiLCJpYXQiOjE3MDY1NjI4NDksImV4cCI6MTczODE4NTI0OSwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwiYWxnIjoiRVMzODQiLCJ4IjoidWtEd1U2ZzlQUVRFUWhYaEgyckRZNndMQlg3UHFlUjZBcGlhVHBEUXowcl8tdDl6UXNxem54Z0hEcE5oekZlQyIsInkiOiJMQnhVYnBVdFNGMVVKVTVpYnJIdkpINjBUSG5YMk1xa0xHZGltU1l0UGR4RlkxOEdhcldiS3FZV0djUkZHVE9BIn19fQ.kYD63YtBNYnLUTw6Szf1vs_Ug3UBXhPwCyqpNmPnPDa3rXZQhQLdB1BgaoO8zgQ-c3B41fxaXMnLHYV9-B20uboSpJP0B-2Vre917eQt1cSDswDGA_Ytvn4BSqYVBB2J~WyJFMkFsRzhsY2p0QVFrcllIbjlIbnVRIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd~WyI5NldYMDRneno4cVZzOVZLU2wwYTVnIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJaekU2VFVaamtHMW1DWXBKMEhnc0l3IiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyItQ3NsS25GZGFYb2JiQWsyU0JBVGR3IiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd~WyJuRm1OWl9IczB3WWNoOFdkeTdnQUNRIiwgImlkIiwgImRpZDpleGFtcGxlOmMyNzZlMTJlYzIxZWJmZWIxZjcxMmViYzZmMSJd~"
 }
       </pre>
             <p>
@@ -1248,8 +1253,8 @@ A document that contains public cryptographic material as defined in the
         </p>
         <ul>
             <li>
-                <code>inputMediaType</code>: <code>vc-ld+jwt</code> or
-                <code>vp-ld+jwt</code>
+                <code>inputMediaType</code>: <code>vc+jwt</code> or
+                <code>vp+jwt</code>
             </li>
             <li>
                 <code>inputDocument</code>: the verifiable credential secured as a JWT [[RFC7519]]
@@ -1306,7 +1311,7 @@ A document that contains public cryptographic material as defined in the
         </p>
         <ul>
             <li>
-                <code>inputMediaType</code>: <code>vc-ld+sd-jwt</code>
+                <code>inputMediaType</code>: <code>vc+sd-jwt</code>
             </li>
             <li>
                 <code>inputDocument</code>: the verifiable credential secured with [[SD-JWT]]
@@ -1367,8 +1372,8 @@ A document that contains public cryptographic material as defined in the
         </p>
         <ul>
             <li>
-                <code>inputMediaType</code>: <code>vc-ld+cose</code> or
-                <code>vp-ld+cose</code>
+                <code>inputMediaType</code>: <code>vc+cose</code> or
+                <code>vp+cose</code>
             </li>
             <li>
                 <code>inputDocument</code>: the verifiable credential or verifiable presentation
@@ -1464,11 +1469,11 @@ A document that contains public cryptographic material as defined in the
     <section>
         <h2 id="media-types">Media Types</h2>
 
-        <section id="vc-ld-jwt-media-type">
-            <h2 id="vcc-ld-json-jwt"><code>application/vc-ld+jwt</code></h2>
+        <section id="vc-jwt-media-type">
+            <h2 id="vc-json-jwt"><code>application/vc+jwt</code></h2>
             <p>
                 This specification registers the
-                <code>application/vc-ld+jwt</code> Media Type specifically for
+                <code>application/vc+jwt</code> Media Type specifically for
                 identifying a <a data-cite="JWT"></a>
                 with a payload
                 conforming to the <a data-cite="VC-DATA-MODEL-2.0#verifiable-credentials">
@@ -1481,7 +1486,7 @@ A document that contains public cryptographic material as defined in the
                 </tr>
                 <tr>
                     <td>Subtype name:</td>
-                    <td>`vc-ld+jwt`</td>
+                    <td>`vc+jwt`</td>
                 </tr>
                 <tr>
                     <td>Required parameters:</td>
@@ -1511,11 +1516,11 @@ A document that contains public cryptographic material as defined in the
             </table>
         </section>
 
-        <section id="vp-ld-jwt-media-type">
-            <h2 id="vp-ld-json-jwt"><code>application/vp-ld+jwt</code></h2>
+        <section id="vp-jwt-media-type">
+            <h2 id="vp-json-jwt"><code>application/vp+jwt</code></h2>
             <p>
                 This specification registers the
-                <code>application/vp-ld+jwt</code> Media Type specifically for
+                <code>application/vp+jwt</code> Media Type specifically for
                 identifying a <a data-cite="JWT"></a>
                 with a payload
                 conforming to the <a data-cite="VC-DATA-MODEL-2.0#verifiable-presentations">
@@ -1528,7 +1533,7 @@ A document that contains public cryptographic material as defined in the
                 </tr>
                 <tr>
                     <td>Subtype name:</td>
-                    <td>vp-ld+jwt</td>
+                    <td>vp+jwt</td>
                 </tr>
                 <tr>
                     <td>Required parameters:</td>
@@ -1558,11 +1563,11 @@ A document that contains public cryptographic material as defined in the
             </table>
         </section>
 
-        <section id="vc-ld-sd-jwt-media-type">
-            <h2 id="vc-ld-json-sd-jwt"><code>application/vc-ld+sd-jwt</code></h2>
+        <section id="vc-sd-jwt-media-type">
+            <h2 id="vc-json-sd-jwt"><code>application/vc+sd-jwt</code></h2>
             <p>
                 This specification registers the
-                <code>application/vc-ld+sd-jwt</code> Media Type specifically for
+                <code>application/vc+sd-jwt</code> Media Type specifically for
                 identifying a <a data-cite="SD-JWT"></a>
                 with a payload
                 conforming to the <a data-cite="VC-DATA-MODEL-2.0#verifiable-credentials">
@@ -1575,7 +1580,7 @@ A document that contains public cryptographic material as defined in the
                 </tr>
                 <tr>
                     <td>Subtype name:</td>
-                    <td>`vc-ld+sd-jwt`</td>
+                    <td>`vc+sd-jwt`</td>
                 </tr>
                 <tr>
                     <td>Required parameters:</td>
@@ -1605,11 +1610,11 @@ A document that contains public cryptographic material as defined in the
             </table>
         </section>
 
-        <section id="vp-ld-sd-jwt-media-type">
-            <h2 id="vp-ld-json-sd-jwt"><code>application/vp-ld+sd-jwt</code></h2>
+        <section id="vp-sd-jwt-media-type">
+            <h2 id="vp-json-sd-jwt"><code>application/vp+sd-jwt</code></h2>
             <p>
                 This specification registers the
-                <code>application/vp-ld+sd-jwt</code> Media Type specifically for
+                <code>application/vp+sd-jwt</code> Media Type specifically for
                 identifying a <a data-cite="SD-JWT"></a>
                 with a payload
                 conforming to the <a data-cite="VC-DATA-MODEL-2.0#verifiable-presentations">
@@ -1622,7 +1627,7 @@ A document that contains public cryptographic material as defined in the
                 </tr>
                 <tr>
                     <td>Subtype name:</td>
-                    <td>vp-ld+sd-jwt</td>
+                    <td>vp+sd-jwt</td>
                 </tr>
                 <tr>
                     <td>Required parameters:</td>
@@ -1652,11 +1657,11 @@ A document that contains public cryptographic material as defined in the
             </table>
         </section>
 
-        <section id="vc-ld-json-cose-media-type">
-            <h2 id="vc-ld-json-cose"><code>application/vc-ld+cose</code></h2>
+        <section id="vc-json-cose-media-type">
+            <h2 id="vc-json-cose"><code>application/vc+cose</code></h2>
             <p>
                 This specification registers the
-                <code>application/vc-ld+cose</code> Media Type specifically for
+                <code>application/vc+cose</code> Media Type specifically for
                 identifying a COSE object [[RFC9052]]
                 with a payload
                 conforming to the <a data-cite="VC-DATA-MODEL-2.0#verifiable-credentials">
@@ -1669,7 +1674,7 @@ A document that contains public cryptographic material as defined in the
                 </tr>
                 <tr>
                     <td>Subtype name:</td>
-                    <td>`vc-ld+cose`</td>
+                    <td>`vc+cose`</td>
                 </tr>
                 <tr>
                     <td>Required parameters:</td>
@@ -1698,11 +1703,11 @@ A document that contains public cryptographic material as defined in the
             </table>
         </section>
 
-        <section id="vp-ld-json-cose-media-type">
-            <h2 id="vp-ld-json-cose"><code>application/vp-ld+cose</code></h2>
+        <section id="vp-json-cose-media-type">
+            <h2 id="vp-json-cose"><code>application/vp+cose</code></h2>
             <p>
                 This specification registers the
-                <code>application/vp-ld+cose</code> Media Type specifically for
+                <code>application/vp+cose</code> Media Type specifically for
                 identifying a COSE object [[RFC9052]]
                 with a payload
                 conforming to the <a data-cite="VC-DATA-MODEL-2.0#verifiable-presentations">
@@ -1715,7 +1720,7 @@ A document that contains public cryptographic material as defined in the
                 </tr>
                 <tr>
                     <td>Subtype name:</td>
-                    <td>`vp-ld+cose`</td>
+                    <td>`vp+cose`</td>
                 </tr>
                 <tr>
                     <td>Required parameters:</td>
@@ -2069,17 +2074,17 @@ A document that contains public cryptographic material as defined in the
   "verifiableCredential": [
     {
       "@context": "https://www.w3.org/ns/credentials/v2",
-      "id": "data:application/vc-ld+cose,QzVjV...RMjU",
+      "id": "data:application/vc+cose;base64,0oREo...+Q==",
       "type": "EnvelopedVerifiableCredential"
     },
     {
       "@context": "https://www.w3.org/ns/credentials/v2",
-      "id": "data:application/vc-ld+jwt,eyVjV...RMjU",
+      "id": "data:application/vc+jwt,eyVjV...RMjU",
       "type": "EnvelopedVerifiableCredential"
     },
     {
       "@context": "https://www.w3.org/ns/credentials/v2",
-      "id": "data:application/vc-ld+sd-jwt,eyVjV...RMjU~",
+      "id": "data:application/vc+sd-jwt,eyVjV...RMjU~",
       "type": "EnvelopedVerifiableCredential"
     }
   ]
@@ -2090,12 +2095,16 @@ A document that contains public cryptographic material as defined in the
 
     <section>
         <h3 id="date-uris">Data URIs</h3>
-        <pre class="example" title="A simple URI-encoded Verifiable Credential">
-data:application/vc-ld+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlNJM1JITm91aDhvODFOT09OUFFVQUw3RWdaLWtJNl94ajlvUkV2WDF4T3ciLCJ0eXAiOiJ2YytsZCtqc29uK3NkLWp3dCIsImN0eSI6InZjK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiX3NkIjpbIkU3dU1sSWFyS29iYXJTdEZGRjctZm5qaV9sQVdnM3BGMkV5dVc4dWFYakUiLCJYelRaSVgyNGdDSWxSQVFHclFoNU5FRm1XWkQtZ3Z3dkIybzB5Y0FwNFZzIl19LCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJfc2QiOlsiT3oxUEZIMG0tWk9TdEhwUVZyeGlmVlpKRzhvNmlQQmNnLVZ2SXQwd2plcyJdfSwiX3NkIjpbIkVZQ1daMTZZMHB5X1VNNzRHU3NVYU9zT19mdDExTlVSaFFUTS1TT1lFTVEiXX0sIl9zZCI6WyJqT055NnZUbGNvVlAzM25oSTdERGN3ekVka3d2R3VVRXlLUjdrWEVLd3VVIiwid21BdHpwc0dRbDJveS1PY2JrSEVZcE8xb3BoX3VYcWVWVTRKekF0aFFibyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vdW5pdmVyc2l0eS5leGFtcGxlL2lzc3VlcnMvNTY1MDQ5IiwiaWF0IjoxNjk3Mjg5OTk2LCJleHAiOjE3Mjg5MTIzOTYsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6InZFdV84WGxZT0ZFU2hTcVRpZ2JSYWduZ0ZGM1p5U0xrclNHekh3azFBT1loanhlazVhV21HY2UwZU05S0pWOEIiLCJ5IjoiRUpNY2czWXBzUTB3M2RLNHlVa25QczE1Z0lsY2Yyay03dzFKLTNlYlBiOERENmQtUkhBeGUwMDkzSWpfdTRCOSJ9fX0.rYzbxb6j1dwop8_s491iArVVJNm6A6C3b742gOm_qYO3zdkyQU4_VxxOSJ8ECcmWj2r5KyiCNC1ojfO4Yms-zBsjt7PoMYpYWBplsqXpiIvnehmM7D0eOLi40uHXki0X~WyJSWTg1YTZNMmEwX3VDWlFTVGZmTFdRIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJMeG5GYTBXVm8wRUluVy1QdS1fd1dRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJUQVdrakpCaVpxdC1rVU54X1EweUJBIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJTd2xuZFpPZzZEZ1ZERFp5X0RvYVFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJuSnJlU3E1Nzg3RGZMSDJCbU03cXFRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyIxMjNNd3hNcHRiek02YUk2aW03ME1RIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~
+        <pre class="example" title="A simple URI-encoded SD-JWT Verifiable Credential">
+data:application/vc+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlNJM1JITm91aDhvODFOT09OUFFVQUw3RWdaLWtJNl94ajlvUkV2WDF4T3ciLCJ0eXAiOiJ2YytsZCtqc29uK3NkLWp3dCIsImN0eSI6InZjK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiX3NkIjpbIkU3dU1sSWFyS29iYXJTdEZGRjctZm5qaV9sQVdnM3BGMkV5dVc4dWFYakUiLCJYelRaSVgyNGdDSWxSQVFHclFoNU5FRm1XWkQtZ3Z3dkIybzB5Y0FwNFZzIl19LCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJfc2QiOlsiT3oxUEZIMG0tWk9TdEhwUVZyeGlmVlpKRzhvNmlQQmNnLVZ2SXQwd2plcyJdfSwiX3NkIjpbIkVZQ1daMTZZMHB5X1VNNzRHU3NVYU9zT19mdDExTlVSaFFUTS1TT1lFTVEiXX0sIl9zZCI6WyJqT055NnZUbGNvVlAzM25oSTdERGN3ekVka3d2R3VVRXlLUjdrWEVLd3VVIiwid21BdHpwc0dRbDJveS1PY2JrSEVZcE8xb3BoX3VYcWVWVTRKekF0aFFibyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vdW5pdmVyc2l0eS5leGFtcGxlL2lzc3VlcnMvNTY1MDQ5IiwiaWF0IjoxNjk3Mjg5OTk2LCJleHAiOjE3Mjg5MTIzOTYsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6InZFdV84WGxZT0ZFU2hTcVRpZ2JSYWduZ0ZGM1p5U0xrclNHekh3azFBT1loanhlazVhV21HY2UwZU05S0pWOEIiLCJ5IjoiRUpNY2czWXBzUTB3M2RLNHlVa25QczE1Z0lsY2Yyay03dzFKLTNlYlBiOERENmQtUkhBeGUwMDkzSWpfdTRCOSJ9fX0.rYzbxb6j1dwop8_s491iArVVJNm6A6C3b742gOm_qYO3zdkyQU4_VxxOSJ8ECcmWj2r5KyiCNC1ojfO4Yms-zBsjt7PoMYpYWBplsqXpiIvnehmM7D0eOLi40uHXki0X~WyJSWTg1YTZNMmEwX3VDWlFTVGZmTFdRIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJMeG5GYTBXVm8wRUluVy1QdS1fd1dRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJUQVdrakpCaVpxdC1rVU54X1EweUJBIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJTd2xuZFpPZzZEZ1ZERFp5X0RvYVFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJuSnJlU3E1Nzg3RGZMSDJCbU03cXFRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyIxMjNNd3hNcHRiek02YUk2aW03ME1RIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~
       </pre>
 
-        <pre class="example" title="A simple URI-encoded Verifiable Presentation">
-data:application/vp-ld+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlNJM1JITm91aDhvODFOT09OUFFVQUw3RWdaLWtJNl94ajlvUkV2WDF4T3ciLCJ0eXAiOiJ2YytsZCtqc29uK3NkLWp3dCIsImN0eSI6InZjK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiX3NkIjpbIkU3dU1sSWFyS29iYXJTdEZGRjctZm5qaV9sQVdnM3BGMkV5dVc4dWFYakUiLCJYelRaSVgyNGdDSWxSQVFHclFoNU5FRm1XWkQtZ3Z3dkIybzB5Y0FwNFZzIl19LCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJfc2QiOlsiT3oxUEZIMG0tWk9TdEhwUVZyeGlmVlpKRzhvNmlQQmNnLVZ2SXQwd2plcyJdfSwiX3NkIjpbIkVZQ1daMTZZMHB5X1VNNzRHU3NVYU9zT19mdDExTlVSaFFUTS1TT1lFTVEiXX0sIl9zZCI6WyJqT055NnZUbGNvVlAzM25oSTdERGN3ekVka3d2R3VVRXlLUjdrWEVLd3VVIiwid21BdHpwc0dRbDJveS1PY2JrSEVZcE8xb3BoX3VYcWVWVTRKekF0aFFibyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vdW5pdmVyc2l0eS5leGFtcGxlL2lzc3VlcnMvNTY1MDQ5IiwiaWF0IjoxNjk3Mjg5OTk2LCJleHAiOjE3Mjg5MTIzOTYsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6InZFdV84WGxZT0ZFU2hTcVRpZ2JSYWduZ0ZGM1p5U0xrclNHekh3azFBT1loanhlazVhV21HY2UwZU05S0pWOEIiLCJ5IjoiRUpNY2czWXBzUTB3M2RLNHlVa25QczE1Z0lsY2Yyay03dzFKLTNlYlBiOERENmQtUkhBeGUwMDkzSWpfdTRCOSJ9fX0.rYzbxb6j1dwop8_s491iArVVJNm6A6C3b742gOm_qYO3zdkyQU4_VxxOSJ8ECcmWj2r5KyiCNC1ojfO4Yms-zBsjt7PoMYpYWBplsqXpiIvnehmM7D0eOLi40uHXki0X~WyJTd2xuZFpPZzZEZ1ZERFp5X0RvYVFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyIxMjNNd3hNcHRiek02YUk2aW03ME1RIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~WyJMeG5GYTBXVm8wRUluVy1QdS1fd1dRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJSWTg1YTZNMmEwX3VDWlFTVGZmTFdRIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~eyJhbGciOiJFUzM4NCIsInR5cCI6ImtiK2p3dCJ9.eyJub25jZSI6IkVmeTROTFJPX3ZvSkszdDIzcUNfQlEiLCJhdWQiOiJodHRwczovL3ZlcmlmaWVyLmV4YW1wbGUiLCJpYXQiOjE2OTcyODk5OTZ9.6G-1nVcrDKFzR6BdbcFHcbtassEb8NZ7ZavTYz3SJ-e4pXleXs0tNcCkUCwMI70gsuOY0AXzeDPbHjp5GKyLDVuNWgWCt3Wo2VSaCwUkyfLyvhkCsmkF9kvFhMIOhp1i~
+        <pre class="example" title="A simple URI-encoded SD-JWT Verifiable Presentation">
+data:application/vp+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlNJM1JITm91aDhvODFOT09OUFFVQUw3RWdaLWtJNl94ajlvUkV2WDF4T3ciLCJ0eXAiOiJ2YytsZCtqc29uK3NkLWp3dCIsImN0eSI6InZjK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiX3NkIjpbIkU3dU1sSWFyS29iYXJTdEZGRjctZm5qaV9sQVdnM3BGMkV5dVc4dWFYakUiLCJYelRaSVgyNGdDSWxSQVFHclFoNU5FRm1XWkQtZ3Z3dkIybzB5Y0FwNFZzIl19LCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJfc2QiOlsiT3oxUEZIMG0tWk9TdEhwUVZyeGlmVlpKRzhvNmlQQmNnLVZ2SXQwd2plcyJdfSwiX3NkIjpbIkVZQ1daMTZZMHB5X1VNNzRHU3NVYU9zT19mdDExTlVSaFFUTS1TT1lFTVEiXX0sIl9zZCI6WyJqT055NnZUbGNvVlAzM25oSTdERGN3ekVka3d2R3VVRXlLUjdrWEVLd3VVIiwid21BdHpwc0dRbDJveS1PY2JrSEVZcE8xb3BoX3VYcWVWVTRKekF0aFFibyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vdW5pdmVyc2l0eS5leGFtcGxlL2lzc3VlcnMvNTY1MDQ5IiwiaWF0IjoxNjk3Mjg5OTk2LCJleHAiOjE3Mjg5MTIzOTYsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6InZFdV84WGxZT0ZFU2hTcVRpZ2JSYWduZ0ZGM1p5U0xrclNHekh3azFBT1loanhlazVhV21HY2UwZU05S0pWOEIiLCJ5IjoiRUpNY2czWXBzUTB3M2RLNHlVa25QczE1Z0lsY2Yyay03dzFKLTNlYlBiOERENmQtUkhBeGUwMDkzSWpfdTRCOSJ9fX0.rYzbxb6j1dwop8_s491iArVVJNm6A6C3b742gOm_qYO3zdkyQU4_VxxOSJ8ECcmWj2r5KyiCNC1ojfO4Yms-zBsjt7PoMYpYWBplsqXpiIvnehmM7D0eOLi40uHXki0X~WyJTd2xuZFpPZzZEZ1ZERFp5X0RvYVFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyIxMjNNd3hNcHRiek02YUk2aW03ME1RIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~WyJMeG5GYTBXVm8wRUluVy1QdS1fd1dRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJSWTg1YTZNMmEwX3VDWlFTVGZmTFdRIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~eyJhbGciOiJFUzM4NCIsInR5cCI6ImtiK2p3dCJ9.eyJub25jZSI6IkVmeTROTFJPX3ZvSkszdDIzcUNfQlEiLCJhdWQiOiJodHRwczovL3ZlcmlmaWVyLmV4YW1wbGUiLCJpYXQiOjE2OTcyODk5OTZ9.6G-1nVcrDKFzR6BdbcFHcbtassEb8NZ7ZavTYz3SJ-e4pXleXs0tNcCkUCwMI70gsuOY0AXzeDPbHjp5GKyLDVuNWgWCt3Wo2VSaCwUkyfLyvhkCsmkF9kvFhMIOhp1i~
+      </pre>
+
+      <pre class="example" title="A simple URI-encoded COSE Verifiable Presentation">
+data:application/vp+cose;base64,0oREoQE4IqBZDSJ7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJ0eXBlIjoiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiIsInZlcmlmaWFibGVDcmVkZW50aWFsIjpbeyJAY29udGV4dCI6Imh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImlkIjoiZGF0YTphcHBsaWNhdGlvbi92Yy1sZCtzZC1qd3QsZXlKcmFXUWlPaUpGZUVoclFrMVhPV1p0WW10MlZqSTJObTFTY0hWUU1uTlZXVjlPWDBWWFNVNHhiR0Z3VlhwUE9ISnZJaXdpWVd4bklqb2lSVk15TlRZaWZRLmV5SmZjMlJmWVd4bklqb2ljMmhoTFRJMU5pSXNJa0JqYjI1MFpYaDBJanBiSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk5dWN5OWpjbVZrWlc1MGFXRnNjeTkyTWlJc0ltaDBkSEJ6T2k4dmQzZDNMbmN6TG05eVp5OXVjeTlqY21Wa1pXNTBhV0ZzY3k5bGVHRnRjR3hsY3k5Mk1pSmRMQ0pwYzNOMVpYSWlPaUpvZEhSd2N6b3ZMM1Z1YVhabGNuTnBkSGt1WlhoaGJYQnNaUzlwYzNOMVpYSnpMelUyTlRBME9TSXNJblpoYkdsa1JuSnZiU0k2SWpJd01UQXRNREV0TURGVU1UazZNak02TWpSYUlpd2lZM0psWkdWdWRHbGhiRk5qYUdWdFlTSTZleUpmYzJRaU9sc2lOV0pCZURNdGVIQm1RV3hWUzBaSk9YTnVNMmhXUTIxd1IydHJjVWx6V21NekxVeGlNek5tV21waWF5SXNJbHBqUVhaSU1EaHNkRUp5U1VwbVNXaDBPRjl0UzFCZll6TnNjRzVZTVdOSGNsbHRWRzh3WjFsQ2VUZ2lYWDBzSW1OeVpXUmxiblJwWVd4VGRXSnFaV04wSWpwN0ltUmxaM0psWlNJNmV5SnVZVzFsSWpvaVFtRmphR1ZzYjNJZ2IyWWdVMk5wWlc1alpTQmhibVFnUVhKMGN5SXNJbDl6WkNJNld5SlNUMVEzTVVsMGRUTk1ObFZYV0ZWcWJ5MW9XVmRKUWpZM2JIVlBUa1ZFVWxOQ2FHeEVWRU54VlU5UklsMTlMQ0pmYzJRaU9sc2lUVVZ1WlhObk1saFBVazVqWTNOQ1RXVmFYekUyTURKbmVUUXdVaTAwV1VKMlZsSXdlRkU0YjBZNFl5SmRmU3dpWDNOa0lqcGJJa1ZsYzJKaWF5MW1jR1p3ZDJaTU9YZE9jekZ4Y2paMGFVNDNabkV0U1hReldWTTJWM1pDYmw5aVdHOGlMQ0phYjFJMVpHUmhja2R0WmsxNU5FaHVWMHhWYWs1VVJuRlVSak5ZUmpacGRGQm5abmxHUWtoVlgzRlZJbDE5Lmd3M3BheGJrTGpwaThDVHN5UnBYS2JDN3RwVmEwcTJzV0tTRC1fZGNidVoxTHBaVjNvUThJZnpjbTJiRThSWTNmbUpnYnV5QTlnYlBMM3NRQmFUemtnIH5XeUpTZVVReFZsQjRWSEJ2Ym10UGVYWnBjemt0YTI5M0lpd2dJbWxrSWl3Z0ltaDBkSEE2THk5MWJtbDJaWEp6YVhSNUxtVjRZVzF3YkdVdlkzSmxaR1Z1ZEdsaGJITXZNVGczTWlKZH5XeUpmVmpkMWVUZDNheTFSTTNWWmQyWnBaME52V1VWQklpd2dJblI1Y0dVaUxDQmJJbFpsY21sbWFXRmliR1ZEY21Wa1pXNTBhV0ZzSWl3Z0lrVjRZVzF3YkdWQmJIVnRibWxEY21Wa1pXNTBhV0ZzSWwxZH5XeUpoYXpkcU1UbG5ZVk10UkRKTFgyaHpZM1JWWkdOUklpd2dJbWxrSWl3Z0ltaDBkSEJ6T2k4dlpYaGhiWEJzWlM1dmNtY3ZaWGhoYlhCc1pYTXZaR1ZuY21WbExtcHpiMjRpWFF+V3lKVVRqQlhhWFZaUmtoWFdrVjJaRFpJUVVKSFFTMW5JaXdnSW5SNWNHVWlMQ0FpU25OdmJsTmphR1Z0WVNKZH5XeUpWTW5Cek1reFlWRVJWYlZoM01EY3hSVkJtUlVwbklpd2dJbWxrSWl3Z0ltUnBaRHBsZUdGdGNHeGxPakV5TXlKZH5XeUpzUTA0MmVUTkVhVE5EVWs5VlgzSnVYelJFTldSbklpd2dJblI1Y0dVaUxDQWlRbUZqYUdWc2IzSkVaV2R5WldVaVhRfjtkYXRhOmFwcGxpY2F0aW9uL3ZjLWxkK3NkLWp3dCxleUpyYVdRaU9pSkZlRWhyUWsxWE9XWnRZbXQyVmpJMk5tMVNjSFZRTW5OVldWOU9YMFZYU1U0eGJHRndWWHBQT0hKdklpd2lZV3huSWpvaVJWTXlOVFlpZlEuZXlKZmMyUmZZV3huSWpvaWMyaGhMVEkxTmlJc0lrQmpiMjUwWlhoMElqcGJJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OTJNaUlzSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk5dWN5OWpjbVZrWlc1MGFXRnNjeTlsZUdGdGNHeGxjeTkyTWlKZExDSnBjM04xWlhJaU9pSm9kSFJ3Y3pvdkwzVnVhWFpsY25OcGRIa3VaWGhoYlhCc1pTOXBjM04xWlhKekx6VTJOVEEwT1NJc0luWmhiR2xrUm5KdmJTSTZJakl3TVRBdE1ERXRNREZVTVRrNk1qTTZNalJhSWl3aVkzSmxaR1Z1ZEdsaGJGTmphR1Z0WVNJNmV5SmZjMlFpT2xzaU5XSkJlRE10ZUhCbVFXeFZTMFpKT1hOdU0yaFdRMjF3UjJ0cmNVbHpXbU16TFV4aU16Tm1XbXBpYXlJc0lscGpRWFpJTURoc2RFSnlTVXBtU1doME9GOXRTMUJmWXpOc2NHNVlNV05IY2xsdFZHOHdaMWxDZVRnaVhYMHNJbU55WldSbGJuUnBZV3hUZFdKcVpXTjBJanA3SW1SbFozSmxaU0k2ZXlKdVlXMWxJam9pUW1GamFHVnNiM0lnYjJZZ1UyTnBaVzVqWlNCaGJtUWdRWEowY3lJc0lsOXpaQ0k2V3lKU1QxUTNNVWwwZFROTU5sVlhXRlZxYnkxb1dWZEpRalkzYkhWUFRrVkVVbE5DYUd4RVZFTnhWVTlSSWwxOUxDSmZjMlFpT2xzaVRVVnVaWE5uTWxoUFVrNWpZM05DVFdWYVh6RTJNREpuZVRRd1VpMDBXVUoyVmxJd2VGRTRiMFk0WXlKZGZTd2lYM05rSWpwYklrVmxjMkppYXkxbWNHWndkMlpNT1hkT2N6RnhjalowYVU0M1puRXRTWFF6V1ZNMlYzWkNibDlpV0c4aUxDSmFiMUkxWkdSaGNrZHRaazE1TkVodVYweFZhazVVUm5GVVJqTllSalpwZEZCblpubEdRa2hWWDNGVklsMTkuZ3czcGF4YmtManBpOENUc3lScFhLYkM3dHBWYTBxMnNXS1NELV9kY2J1WjFMcFpWM29ROElmemNtMmJFOFJZM2ZtSmdidXlBOWdiUEwzc1FCYVR6a2cgfld5SlNlVVF4VmxCNFZIQnZibXRQZVhacGN6a3RhMjkzSWl3Z0ltbGtJaXdnSW1oMGRIQTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2WTNKbFpHVnVkR2xoYkhNdk1UZzNNaUpkfld5SmZWamQxZVRkM2F5MVJNM1ZaZDJacFowTnZXVVZCSWl3Z0luUjVjR1VpTENCYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdnSWtWNFlXMXdiR1ZCYkhWdGJtbERjbVZrWlc1MGFXRnNJbDFkfld5SmhhemRxTVRsbllWTXRSREpMWDJoelkzUlZaR05SSWl3Z0ltbGtJaXdnSW1oMGRIQnpPaTh2WlhoaGJYQnNaUzV2Y21jdlpYaGhiWEJzWlhNdlpHVm5jbVZsTG1wemIyNGlYUX5XeUpVVGpCWGFYVlpSa2hYV2tWMlpEWklRVUpIUVMxbklpd2dJblI1Y0dVaUxDQWlTbk52YmxOamFHVnRZU0pkfld5SlZNbkJ6TWt4WVZFUlZiVmgzTURjeFJWQm1SVXBuSWl3Z0ltbGtJaXdnSW1ScFpEcGxlR0Z0Y0d4bE9qRXlNeUpkfld5SnNRMDQyZVRORWFUTkRVazlWWDNKdVh6UkVOV1JuSWl3Z0luUjVjR1VpTENBaVFtRmphR1ZzYjNKRVpXZHlaV1VpWFF+IiwidHlwZSI6IkVudmVsb3BlZFZlcmlmaWFibGVDcmVkZW50aWFsIn1dfVhA4c9H+cu0VfS8NsItpzbB1mpvjP5y2DCxTCW+bY6/4SNPCaeP+uR+JRpJ+GzVNz7/W7ZlHoXguhgBBjWhlnhh+Q==
       </pre>
     </section>
 


### PR DESCRIPTION
fix #282 

as per the [TPAC resolution on Friday September 27th](https://www.w3.org/2024/09/27-vcwg-minutes.html#r01)

> RESOLUTION: For VC-JOSE-COSE, we will proceed with a request to register application/vc+jwt, application/vp+jwt, application/vc+cose, application/vp+cose, application/vc+sd-jwt, and application/vp+sd-jwt. We will note in particular that the cty property is the point of differentiation for others that may wish to use identical media types. This group intends to use application/vc and application/vp as the cty values.

This PR updates the media types accordingly. Separately, there is a [PR to the `respec-vc` plugin](https://github.com/w3c/respec-vc/pull/49) to fix the examples. This PR will be merged _after_ the change to the `respec-vc` plugin is merged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/pull/306.html" title="Last updated on Oct 9, 2024, 6:30 PM UTC (4ce59ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/306/183b998...4ce59ae.html" title="Last updated on Oct 9, 2024, 6:30 PM UTC (4ce59ae)">Diff</a>