### PR TITLE
Restore qualifying language about vc and vp claims

### DIFF
--- a/index.html
+++ b/index.html
@@ -315,7 +315,8 @@
               </p>
               <p>
                   The JWT Claim Names <code>vc</code> and <code>vp</code>
-                  MUST NOT be present in any JWT Claim Set.
+                  MUST NOT be present in any JWT Claim Set that comprises a
+		  [=verifiable credential=] or a [=verifiable presentation=].
               </p>
           </section>
           <section>


### PR DESCRIPTION
Restores qualifying language inadvertently deleted by #304.

Fixes #305


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/vc-jose-cose/pull/307.html" title="Last updated on Sep 27, 2024, 10:23 PM UTC (ccc8491)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/307/41b73cc...selfissued:ccc8491.html" title="Last updated on Sep 27, 2024, 10:23 PM UTC (ccc8491)">Diff</a>