### PR TITLE
Add language from resolution about differentiating using cty

### DIFF
--- a/index.html
+++ b/index.html
@@ -849,11 +849,11 @@
             The <code>typ</code> header parameter, as described in
             <a data-cite="RFC9596#section-2">COSE "typ" (type) Header Parameter</a>,
             SHOULD be <code>application/vc+cose</code>.
+            When present, the <code>content type (3)</code> header parameter
+            SHOULD be <code>application/vc</code>.
             The <code>content type (3)</code> header parameter value can be used
             to differentiate between secured content of different types when using
             <code>application/vc+cose</code>.
-            When present, the <code>content type (3)</code> header parameter
-            SHOULD be <code>application/vc</code>.
             See <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a>
             for additional details.
           </p>

--- a/index.html
+++ b/index.html
@@ -919,9 +919,9 @@
           </p>
           <p>
             The <code>typ</code> header parameter SHOULD be <code>application/vp+cose</code>.
+            When present, the <code>content type (3)</code> header parameter SHOULD be   <code>application/vp</code>.
             The <code>content type (3)</code> header parameter value can be used to differentiate
             between secured content of different types when using <code>application/vp+cose</code>.
-            When present, the <code>content type (3)</code> header parameter SHOULD be <code>application/vp</code>.
             See <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a>
             for additional details.
           </p>

--- a/index.html
+++ b/index.html
@@ -919,7 +919,7 @@
           </p>
           <p>
             The <code>typ</code> header parameter SHOULD be <code>application/vp+cose</code>.
-            When present, the <code>content type (3)</code> header parameter SHOULD be   <code>application/vp</code>.
+            When present, the <code>content type (3)</code> header parameter SHOULD be <code>application/vp</code>.
             The <code>content type (3)</code> header parameter value can be used to differentiate
             between secured content of different types when using <code>application/vp+cose</code>.
             See <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a>

--- a/index.html
+++ b/index.html
@@ -434,10 +434,11 @@
           <p>
             The <code>typ</code> header parameter SHOULD be <code>vc+jwt</code>.
             When present, the <code>cty</code> header parameter SHOULD be
-            <code>vc</code>. See
-            <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
-            for additional details regarding usage of <code>typ</code> and
-            <code>cty</code>.
+            <code>vc</code>. 
+            The <code>cty</code> header parameter value can be used to differentiate
+            between secured content of different types when using <code>vc+jwt</code>.
+            See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
+            for additional details regarding usage of <code>typ</code> and <code>cty</code>.
           </p>
           <p>
             A [=conforming JWS verifier implementation=] MUST use [[RFC7515]] to
@@ -497,10 +498,11 @@
           <p>
             The <code>typ</code> header parameter SHOULD be <code>vp+jwt</code>.
             When present, the <code>cty</code> header parameter SHOULD be
-            <code>vp</code>. See
-            <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
-            for additional details regarding usage of <code>typ</code> and
-            <code>cty</code>.
+            <code>vp</code>.
+            The <code>cty</code> header parameter value can be used to differentiate
+            between secured content of different types when using <code>vp+jwt</code>.
+            See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
+            for additional details regarding usage of <code>typ</code> and <code>cty</code>.
           </p>
           <p>
             A [=conforming JWS verifier implementation=] MUST use [[RFC7515]] to
@@ -664,9 +666,10 @@
           <p>
             The <code>typ</code> header parameter SHOULD be <code>vc+sd-jwt</code>.
             When present, the <code>cty</code> header parameter SHOULD be <code>vc</code>.
+            The <code>cty</code> header parameter value can be used to differentiate 
+            between secured content of different types when using <code>vc+sd-jwt</code>.
             See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
-            for additional details regarding usage of <code>typ</code> and
-            <code>cty</code>.
+            for additional details regarding usage of <code>typ</code> and <code>cty</code>.
           </p>
           <p>
             A [=conforming SD-JWT verifier implementation=] MUST use [[SD-JWT]]
@@ -735,8 +738,9 @@
           <p>
             The <code>typ</code> header parameter SHOULD be <code>vp+sd-jwt</code>.
             When present, the <code>cty</code> header parameter SHOULD be <code>vp</code>.
-            See
-            <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
+            The <code>cty</code> header parameter value can be used to differentiate
+            between secured content of different types when using <code>vp+sd-jwt</code>.
+            See <a data-cite="RFC7515#section-4.1">Registered Header Parameter Names</a>
             for additional details regarding usage of <code>typ</code> and <code>cty</code>.
           </p>
           <p>
@@ -845,10 +849,12 @@
             The <code>typ</code> header parameter, as described in
             <a data-cite="RFC9596#section-2">COSE "typ" (type) Header Parameter</a>,
             SHOULD be <code>application/vc+cose</code>.
+            The <code>content type (3)</code> header parameter value can be used
+            to differentiate between secured content of different types when using
+            <code>application/vc+cose</code>.
             When present, the <code>content type (3)</code> header parameter
             SHOULD be <code>application/vc</code>.
-            See
-            <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a>
+            See <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a>
             for additional details.
           </p>
           <p>
@@ -912,12 +918,11 @@
             The unsecured [=verifiable presentation=] is the unencoded COSE_Sign1 payload.
           </p>
           <p>
-            The <code>typ</code> header parameter SHOULD be
-            <code>application/vp+cose</code>.
-            When present, the <code>content type (3)</code> header parameter
-            SHOULD be <code>application/vp</code>.
-            See
-            <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a>
+            The <code>typ</code> header parameter SHOULD be <code>application/vp+cose</code>.
+            The <code>content type (3)</code> header parameter value can be used to differentiate
+            between secured content of different types when using <code>application/vp+cose</code>.
+            When present, the <code>content type (3)</code> header parameter SHOULD be <code>application/vp</code>.
+            See <a data-cite="RFC9052#section-3.1">Common COSE Header Parameters</a>
             for additional details.
           </p>
           <p>
@@ -1307,8 +1312,7 @@
         </ol>
       </section>
       <section>
-        <h3 id="alg-sd-jwt">Verifying a Credential or Presentation Secured
-         with [[SD-JWT]]</h3>
+        <h3 id="alg-sd-jwt">Verifying a Credential or Presentation Secured with SD-JWT</h3>
         <p>
           The inputs for this algorithm are:
         </p>


### PR DESCRIPTION
Some of the language from the WG's resolution is not yet captured in the specification, in particular:
```
We will note in particular that the cty property is the point of differentiation
for others that may wish to use identical media types. This group intends to
use application/vc and application/vp as the cty values.
```
This PR adds that language to the specification, and if merged may address issue #313


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-jose-cose/pull/314.html" title="Last updated on Oct 10, 2024, 10:34 PM UTC (81a6b69)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/314/0bf848a...brentzundel:81a6b69.html" title="Last updated on Oct 10, 2024, 10:34 PM UTC (81a6b69)">Diff</a>