### PR TITLE
Changed the last references to Controller Documents to CID

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,15 +74,15 @@
           inlineCSS: true,
           postProcess: [window.respecVc.createVcExamples],
           license: "w3c-software-doc",
-          xref: ["INFRA", "VC-DATA-MODEL-2.0", "CONTROLLER-DOCUMENT"],
+          xref: ["INFRA", "VC-DATA-MODEL-2.0", "CID-1.0"],
           otherLinks: [{
               key: "Related Documents",
               data: [{
                   value: "Verifiable Credentials Data Model v2.0",
                   href: "https://www.w3.org/TR/vc-data-model-2.0/"
               }, {
-                  value: "Controlled Identifier Document 1.0",
-                  href: "https://www.w3.org/TR/controller-document/"
+                  value: "Controlled Identifiers 1.0",
+                  href: "https://www.w3.org/TR/cid-1.0/"
               }]
           }],
           localBiblio: {
@@ -374,7 +374,7 @@
         <dt><dfn>controlled identifier document</dfn></dt>
         <dd>
           A document that contains public cryptographic material as defined in
-          the [[[CONTROLLER-DOCUMENT]]] specification.
+          the [[[CID-1.0]]] specification.
         </dd>
       </dl>
     </section>


### PR DESCRIPTION
The references had to be changed to the new short name as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/pull/326.html" title="Last updated on Feb 4, 2025, 3:59 PM UTC (a720a41)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/326/b635459...a720a41.html" title="Last updated on Feb 4, 2025, 3:59 PM UTC (a720a41)">Diff</a>