### PR TITLE
Display errata and rec preview, and added a REC preview for publication

### DIFF
--- a/errata.html
+++ b/errata.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+  <!--
+    The data-githubrepo attribute provides the owner/repo name on github. For W3C repositories most of those are of the
+    form 'w3c/XXX', although there are groups that have their own owner for their repository.
+  -->
+  <head data-githubrepo="w3c/vc-jose-cose">
+    <meta charset="UTF-8">
+    <title>Open Errata for Securing Verifiable Credentials using JOSE and COSE</title>
+    <link rel="stylesheet" type="text/css" href="https://w3c.github.io/display_errata/assets/errata.css"/>
+    <script src="https://www.w3.org/scripts/jquery/1.11/jquery.min.js"></script>
+    <script src="https://w3c.github.io/display_errata/assets/moment.min.js" type="text/javascript"></script>
+    <script src="https://w3c.github.io/display_errata/assets/errata.js" type="text/javascript"></script>
+    <script src="https://www.w3.org/scripts/underscore/1.8/underscore-min.js" type="text/javascript"></script>
+    <script src="https://w3c.github.io/display_errata/assets/toc.js" type="text/javascript"></script>
+
+    <style type="text/css">
+      .todo {
+        background-color: yellow
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <p class="banner"><a accesskey="W" href="/"><img width="72" height="48" alt="W3C" src="https://www.w3.org/Icons/w3c_home" /></a> </p>
+      <br />
+      <h1 class="title">Open Errata for Securing Verifiable Credentials using JOSE and COSE</h1>
+      <dl>
+        <dt>Latest errata update:</dt>
+        <dd><span id="date"></span></dd>
+        <dt>Number of recorded errata:</dt>
+        <dd><span id="number"></span></dd>
+        <dt>Link to all errata:</dt>
+        <dd><span id="errata_link"></span></dd>
+      </dl>
+
+      <section data-notoc>
+        <h1>How to Submit an Erratum?</h1>
+        <p>Errata are introduced and stored in the <a href="https://github.com/w3c/vc-jose-cose/issues/">issue list of the group‘s GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
+        <ul>
+          <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>PossibleErratum</code>”. One erratum might have several labels.</li>
+          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>PossibleErratum</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
+          <li>Issues labeled as “<code>Errata</code>” are displayed below.</li>
+          <li>If the community rejects the issue as an erratum, the issue should be closed (but they will not be removed from the listing below, to ensure a historical record).</li>
+          <li>Each errata may also be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantive ones.</li>
+          <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
+        </ul>
+
+        <p>This report contains a reference to all open issues with the label <code>Errata</code>.</p>
+
+        <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact the staff contact of the Working Group, <a href="mailto:ivan@w3.org">ivan</a>.</p>
+      </section>
+    </header>
+
+    <div class="toc" id="toc"></div>
+
+    <main>
+      <!-- The data-erratalabel should include one label that filters the errata -->
+      <section data-nolabel>
+        <h1>Open Errata on the “Securing Verifiable Credentials using JOSE and COSE”</h1>
+        <dl>
+          <dt>Latest Published Version:</dt>
+          <dd><a href="https://www.w3.org/TR/vc-jose-cose/">https://www.w3.org/TR/vc-jose-cose/</a></dd>
+          <dt>Editor’s draft:</dt>
+          <dd><a href="https://w3c.github.io/vc-jose-cose/">https://w3c.github.io/vc-jose-cose/</a></dd>
+          <dt>Latest Publication Date:</dt>
+          <dd>15 May 2025</dd>
+        </dl>
+        <section id="first">
+          <h2>Substantive Issues</h2>
+        </section>
+        <section id="last">
+          <h2>Editorial Issues</h2>
+        </section>
+      </section>
+    </main>
+
+    <footer>
+      <address><a href="mailto:ivan@w3.org" class=''>ivan</a>, &lt;ivan@w3.org&gt;, (W3C)</address>
+      <p class="copyright">
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © <span class="todo">2025</span>
+        World Wide Web Consortium.
+        W3C® <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, and
+        <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a>
+        rules apply.
+      </p>
+    </footer>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -358,7 +358,7 @@
         these terms is included whenever they appear in this specification.
       </p>
       <dl class="termlist">
-        <dt><dfn>public key</dfn></dt>
+        <dt><dfn class="lint-ignore">public key</dfn></dt>
         <dd>
           Cryptographic material that can be used to verify digital proofs
           created with a corresponding <a>private key</a>.
@@ -1156,7 +1156,7 @@
           </p>
         </section>
       </section>
-      <section>
+      <!-- <section>
         <h2 id="well-known-uris">Well-Known URIs</h2>
         <section>
           <h3 id="jwt-issuer">JWT Issuer</h3>
@@ -1178,7 +1178,7 @@
         }
         </pre>
         </section>
-      </section>
+      </section> -->
       <section>
         <h3 id="using-controlled-identifier-documents">Using Controlled Identifier Documents</h3>
         <p>

--- a/index.html
+++ b/index.html
@@ -657,13 +657,13 @@
       </section>
       <section id="secure-with-sd-jwt">
         <h2 id="with-sd-jwt">With SD-JWT</h2>
-        <p class="issue" title="(AT RISK) Feature depends on completion of an IETF specification currently in Working Group Last Call">
+        <!-- <p class="issue" title="(AT RISK) Feature depends on completion of an IETF specification currently in Working Group Last Call">
           The normative statements in this section depend on the IETF OAuth working group
           draft [[SD-JWT]]. Features related to [[SD-JWT]] are at risk and will be removed
           from the specification if the IETF standardization process occurs after this
           specification's timeline for reaching a Proposed Recommendation, and if at least
           two independent, interoperable implementations are not demonstrated.
-        </p>
+        </p> -->
         <section>
           <h2 id="securing-with-sd-jwt">Securing JSON-LD Verifiable Credentials with SD-JWT</h2>
           <p>

--- a/index.html
+++ b/index.html
@@ -26,12 +26,12 @@
           // publishDate: "2024-12-19",
 
           implementationReportURI: "https://w3c.github.io/vc-jose-cose-test-suite/",
-          // errata:  "https://w3c.github.io/vc-data-model/errata.html",
+          errata:  "https://w3c.github.io/vc-jose-cose/errata.html",
 
           // if there is a previously published draft, uncomment this and
           // set its YYYY-MM-DD date and its maturity status
           previousPublishDate: "2024-11-05",
-          previousMaturity: "CR",
+          previousMaturity: "PR",
 
           // extend the bibliography entries localBiblio: vcwg.localBiblio,
           doJsonLd: true,

--- a/transitions/REC/index.html
+++ b/transitions/REC/index.html
@@ -10,19 +10,6 @@ div.illegal-example p{color:#000}
 aside.example div.example{border-left-width:.1em;border-color:#999;background:#fff}
 </style>
 <style>
-.issue-label{text-transform:initial}
-.warning>p:first-child{margin-top:0}
-.warning{padding:.5em;border-left-width:.5em;border-left-style:solid}
-span.warning{padding:.1em .5em .15em}
-.issue.closed span.issue-number{text-decoration:line-through}
-.issue.closed span.issue-number::after{content:" (Closed)";font-size:smaller}
-.warning{border-color:#f11;border-color:var(--warning-border,#f11);border-width:.2em;border-style:solid;background:#fbe9e9;background:var(--warning-bg,#fbe9e9);color:#000;color:var(--text,#000)}
-.warning-title:before{content:"⚠";font-size:1.3em;float:left;padding-right:.3em;margin-top:-.3em}
-li.task-list-item{list-style:none}
-input.task-list-item-checkbox{margin:0 .35em .25em -1.6em;vertical-align:middle}
-.issue a.respec-gh-label{padding:5px;margin:0 2px 0 2px;font-size:10px;text-transform:none;text-decoration:none;font-weight:700;border-radius:4px;position:relative;bottom:2px;border:none;display:inline-block}
-</style>
-<style>
 dfn{cursor:pointer}
 .dfn-panel{position:absolute;z-index:35;min-width:300px;max-width:500px;padding:.5em .75em;margin-top:.6em;font-family:"Helvetica Neue",sans-serif;font-size:small;background:#fff;background:var(--indextable-hover-bg,#fff);color:#000;color:var(--text,#000);box-shadow:0 1em 3em -.4em rgba(0,0,0,.3),0 0 1px 1px rgba(0,0,0,.05);box-shadow:0 1em 3em -.4em var(--tocsidebar-shadow,rgba(0,0,0,.3)),0 0 1px 1px var(--tocsidebar-shadow,rgba(0,0,0,.05));border-radius:2px}
 .dfn-panel:not(.docked)>.caret{position:absolute;top:-9px}
@@ -379,26 +366,6 @@ dd{margin-left:0}
         },
         {
           "name": "H. Tschofenig"
-        }
-      ],
-      "publisher": {
-        "name": "IETF"
-      }
-    },
-    {
-      "id": "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc",
-      "type": "TechArticle",
-      "name": "SD-JWT-based Verifiable Credentials (SD-JWT VC)",
-      "url": "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc",
-      "creator": [
-        {
-          "name": "Oliver Terbu"
-        },
-        {
-          "name": "Daniel Fett"
-        },
-        {
-          "name": "Brian Campbell"
         }
       ],
       "publisher": {
@@ -1000,8 +967,7 @@ li.sd-jwt-tab {
         "Brian Campbell"
       ],
       "status": "Internet-Draft",
-      "publisher": "IETF",
-      "id": "sd-jwt-vc"
+      "publisher": "IETF"
     },
     "JOSE-REGISTRIES": {
       "title": "The JSON Object Signing and Encryption (JOSE) Registries",
@@ -1166,7 +1132,7 @@ li.sd-jwt-tab {
           with JOSE</a></li><li class="tocline"><a class="tocxref" href="#securing-vps-with-jose"><bdi class="secno">3.1.2 </bdi>Securing JSON-LD
           Verifiable Presentations with JOSE</a></li><li class="tocline"><a class="tocxref" href="#jose-header-parameters-jwt-claims"><bdi class="secno">3.1.3 </bdi>JOSE Header Parameters and
            JWT Claims</a></li></ol></li><li class="tocline"><a class="tocxref" href="#with-sd-jwt"><bdi class="secno">3.2 </bdi>With SD-JWT</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#securing-with-sd-jwt"><bdi class="secno">3.2.1 </bdi>Securing JSON-LD Verifiable Credentials with SD-JWT</a></li><li class="tocline"><a class="tocxref" href="#securing-vps-sd-jwt"><bdi class="secno">3.2.2 </bdi>Securing JSON-LD Verifiable Presentations with SD-JWT</a></li></ol></li><li class="tocline"><a class="tocxref" href="#securing-with-cose"><bdi class="secno">3.3 </bdi>With COSE</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#securing-vcs-with-cose"><bdi class="secno">3.3.1 </bdi>Securing JSON-LD
-          Verifiable Credentials with COSE</a></li><li class="tocline"><a class="tocxref" href="#securing-vps-with-cose"><bdi class="secno">3.3.2 </bdi>Securing JSON-LD Verifiable Presentations with COSE</a></li><li class="tocline"><a class="tocxref" href="#cose-header-param-cwt-claims"><bdi class="secno">3.3.3 </bdi>COSE Header Parameters and CWT Claims</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#key-discovery"><bdi class="secno">4. </bdi>Key Discovery</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#using-header-params-claims-key-discovery"><bdi class="secno">4.1 </bdi>Using Header Parameters and Claims for Key Discovery</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#kid"><bdi class="secno">4.1.1 </bdi>kid</a></li><li class="tocline"><a class="tocxref" href="#iss"><bdi class="secno">4.1.2 </bdi>iss</a></li><li class="tocline"><a class="tocxref" href="#cnf"><bdi class="secno">4.1.3 </bdi>cnf</a></li></ol></li><li class="tocline"><a class="tocxref" href="#well-known-uris"><bdi class="secno">4.2 </bdi>Well-Known URIs</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#jwt-issuer"><bdi class="secno">4.2.1 </bdi>JWT Issuer</a></li></ol></li><li class="tocline"><a class="tocxref" href="#using-controlled-identifier-documents"><bdi class="secno">4.3 </bdi>Using Controlled Identifier Documents</a></li></ol></li><li class="tocline"><a class="tocxref" href="#algorithms"><bdi class="secno">5. </bdi>Algorithms</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#alg-jose"><bdi class="secno">5.1 </bdi>Verifying a Credential or Presentation Secured with JOSE</a></li><li class="tocline"><a class="tocxref" href="#alg-sd-jwt"><bdi class="secno">5.2 </bdi>Verifying a Credential or Presentation Secured with SD-JWT</a></li><li class="tocline"><a class="tocxref" href="#alg-cose"><bdi class="secno">5.3 </bdi>Verifying a Credential or Presentation Secured with
+          Verifiable Credentials with COSE</a></li><li class="tocline"><a class="tocxref" href="#securing-vps-with-cose"><bdi class="secno">3.3.2 </bdi>Securing JSON-LD Verifiable Presentations with COSE</a></li><li class="tocline"><a class="tocxref" href="#cose-header-param-cwt-claims"><bdi class="secno">3.3.3 </bdi>COSE Header Parameters and CWT Claims</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#key-discovery"><bdi class="secno">4. </bdi>Key Discovery</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#using-header-params-claims-key-discovery"><bdi class="secno">4.1 </bdi>Using Header Parameters and Claims for Key Discovery</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#kid"><bdi class="secno">4.1.1 </bdi>kid</a></li><li class="tocline"><a class="tocxref" href="#iss"><bdi class="secno">4.1.2 </bdi>iss</a></li><li class="tocline"><a class="tocxref" href="#cnf"><bdi class="secno">4.1.3 </bdi>cnf</a></li></ol></li><li class="tocline"><a class="tocxref" href="#using-controlled-identifier-documents"><bdi class="secno">4.2 </bdi>Using Controlled Identifier Documents</a></li></ol></li><li class="tocline"><a class="tocxref" href="#algorithms"><bdi class="secno">5. </bdi>Algorithms</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#alg-jose"><bdi class="secno">5.1 </bdi>Verifying a Credential or Presentation Secured with JOSE</a></li><li class="tocline"><a class="tocxref" href="#alg-sd-jwt"><bdi class="secno">5.2 </bdi>Verifying a Credential or Presentation Secured with SD-JWT</a></li><li class="tocline"><a class="tocxref" href="#alg-cose"><bdi class="secno">5.3 </bdi>Verifying a Credential or Presentation Secured with
          COSE</a></li><li class="tocline"><a class="tocxref" href="#validation-algorithm"><bdi class="secno">5.4 </bdi>Validation</a></li></ol></li><li class="tocline"><a class="tocxref" href="#iana-considerations"><bdi class="secno">6. </bdi>IANA Considerations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#media-types"><bdi class="secno">6.1 </bdi>Media Types</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#vc-json-jwt"><bdi class="secno">6.1.1 </bdi><code>application/vc+jwt</code></a></li><li class="tocline"><a class="tocxref" href="#vp-json-jwt"><bdi class="secno">6.1.2 </bdi><code>application/vp+jwt</code></a></li><li class="tocline"><a class="tocxref" href="#vc-json-sd-jwt"><bdi class="secno">6.1.3 </bdi><code>application/vc+sd-jwt</code></a></li><li class="tocline"><a class="tocxref" href="#vp-json-sd-jwt"><bdi class="secno">6.1.4 </bdi><code>application/vp+sd-jwt</code></a></li><li class="tocline"><a class="tocxref" href="#vc-json-cose"><bdi class="secno">6.1.5 </bdi><code>application/vc+cose</code></a></li><li class="tocline"><a class="tocxref" href="#vp-json-cose"><bdi class="secno">6.1.6 </bdi><code>application/vp+cose</code></a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#other-considerations"><bdi class="secno">7. </bdi>Other Considerations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#privacy-considerations"><bdi class="secno">7.1 </bdi>Privacy Considerations</a></li><li class="tocline"><a class="tocxref" href="#security-considerations"><bdi class="secno">7.2 </bdi>Security Considerations</a></li><li class="tocline"><a class="tocxref" href="#accessibility"><bdi class="secno">7.3 </bdi>Accessibility</a></li></ol></li><li class="tocline"><a class="tocxref" href="#examples"><bdi class="secno">8. </bdi>Examples</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#controllers"><bdi class="secno">8.1 </bdi>Controllers</a></li><li class="tocline"><a class="tocxref" href="#credentials"><bdi class="secno">8.2 </bdi>Credentials</a></li><li class="tocline"><a class="tocxref" href="#presentations"><bdi class="secno">8.3 </bdi>Presentations</a></li><li class="tocline"><a class="tocxref" href="#date-uris"><bdi class="secno">8.4 </bdi>Data URIs</a></li><li class="tocline"><a class="tocxref" href="#cose-examples"><bdi class="secno">8.5 </bdi>COSE Examples</a></li></ol></li><li class="tocline"><a class="tocxref" href="#revision-history"><bdi class="secno">A. </bdi>Revision History</a></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><bdi class="secno">B. </bdi>Acknowledgements</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">C. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">C.1 </bdi>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">C.2 </bdi>Informative references</a></li></ol></li></ol></nav>
     <section id="introduction"><div class="header-wrapper"><h2 id="section-introduction"><bdi class="secno">1. </bdi>Introduction</h2><a class="self-link" href="#section-introduction" aria-label="Permalink for Section 1."></a></div>
       
@@ -1387,7 +1353,7 @@ li.sd-jwt-tab {
         these terms is included whenever they appear in this specification.
       </p>
       <dl class="termlist">
-        <dt><dfn data-plurals="public keys" id="dfn-public-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">public key</dfn></dt>
+        <dt><dfn class="lint-ignore" id="dfn-public-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">public key</dfn></dt>
         <dd>
           Cryptographic material that can be used to verify digital proofs
           created with a corresponding <a href="#dfn-private-key" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-private-key-1">private key</a>.
@@ -1564,7 +1530,7 @@ li.sd-jwt-tab {
 <div class="jwt-compact">
 <span class="jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
 .<span class="jwt-payload">eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwOi8vdW5pdmVyc2l0eS5leGFtcGxlL2NyZWRlbnRpYWxzLzM3MzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRXhhbXBsZURlZ3JlZUNyZWRlbnRpYWwiLCJFeGFtcGxlUGVyc29uQ3JlZGVudGlhbCJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzE0IiwidmFsaWRGcm9tIjoiMjAxMC0wMS0wMVQxOToyMzoyNFoiLCJjcmVkZW50aWFsU3ViamVjdCI6eyJpZCI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsImRlZ3JlZSI6eyJ0eXBlIjoiRXhhbXBsZUJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifSwiYWx1bW5pT2YiOnsibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSJ9fSwiY3JlZGVudGlhbFNjaGVtYSI6W3siaWQiOiJodHRwczovL2V4YW1wbGUub3JnL2V4YW1wbGVzL2RlZ3JlZS5qc29uIiwidHlwZSI6Ikpzb25TY2hlbWEifSx7ImlkIjoiaHR0cHM6Ly9leGFtcGxlLm9yZy9leGFtcGxlcy9hbHVtbmkuanNvbiIsInR5cGUiOiJKc29uU2NoZW1hIn1dfQ</span>
-.<span class="jwt-signature">w7T-Tan_Ck4TwJ7TtUnMSQXSV64-cSGZPV_c-_xivMiMYCfW_07dAiWLt0kOxYVUML9KGj591wGbwSdL0h0IMQ</span>
+.<span class="jwt-signature">xbpSjNX9SAAn8YM31TcXFIWgdLwNGpQguO2xoTWv_NoE1cSNW5RlWbsaO3hlYE6y9aa4q7ie5FXubvPwi1K__g</span>
 </div>
 </div>
     </div>
@@ -1671,7 +1637,7 @@ li.sd-jwt-tab {
 <div class="jwt-compact">
 <span class="jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
 .<span class="jwt-payload">eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidHlwZSI6IlZlcmlmaWFibGVQcmVzZW50YXRpb24iLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6W3siQGNvbnRleHQiOiJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJpZCI6ImRhdGE6YXBwbGljYXRpb24vdmMrand0LGV5SnJhV1FpT2lKRmVFaHJRazFYT1dadFltdDJWakkyTm0xU2NIVlFNbk5WV1Y5T1gwVlhTVTR4YkdGd1ZYcFBPSEp2SWl3aVlXeG5Jam9pUlZNek9EUWlmUS5leUpBWTI5dWRHVjRkQ0k2V3lKb2RIUndjem92TDNkM2R5NTNNeTV2Y21jdmJuTXZZM0psWkdWdWRHbGhiSE12ZGpJaUxDSm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdlpYaGhiWEJzWlhNdmRqSWlYU3dpYVdRaU9pSm9kSFJ3T2k4dmRXNXBkbVZ5YzJsMGVTNWxlR0Z0Y0d4bEwyTnlaV1JsYm5ScFlXeHpMekU0TnpJaUxDSjBlWEJsSWpwYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdpUlhoaGJYQnNaVUZzZFcxdWFVTnlaV1JsYm5ScFlXd2lYU3dpYVhOemRXVnlJam9pYUhSMGNITTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2YVhOemRXVnljeTgxTmpVd05Ea2lMQ0oyWVd4cFpFWnliMjBpT2lJeU1ERXdMVEF4TFRBeFZERTVPakl6T2pJMFdpSXNJbU55WldSbGJuUnBZV3hUWTJobGJXRWlPbnNpYVdRaU9pSm9kSFJ3Y3pvdkwyVjRZVzF3YkdVdWIzSm5MMlY0WVcxd2JHVnpMMlJsWjNKbFpTNXFjMjl1SWl3aWRIbHdaU0k2SWtwemIyNVRZMmhsYldFaWZTd2lZM0psWkdWdWRHbGhiRk4xWW1wbFkzUWlPbnNpYVdRaU9pSmthV1E2WlhoaGJYQnNaVG94TWpNaUxDSmtaV2R5WldVaU9uc2lkSGx3WlNJNklrSmhZMmhsYkc5eVJHVm5jbVZsSWl3aWJtRnRaU0k2SWtKaFkyaGxiRzl5SUc5bUlGTmphV1Z1WTJVZ1lXNWtJRUZ5ZEhNaWZYMTkuZDJrNE8zRnl0UUpmODNrTGgtSHNYdVB2aDZ5ZU9saEpFTFZvNVRGNzFndTdlbHNsUXlPZjJaSXRBWHJ0YlhGNEt6OVdpdk5kenRPYXl6NFZVUTBNd2E4eUNEWmtQOUIycEgtOVNfdGNBRnhlb2VKNlo0WG5GdUxfRE9ma1IxZlA7ZGF0YTphcHBsaWNhdGlvbi92Yytqd3QsZXlKcmFXUWlPaUpGZUVoclFrMVhPV1p0WW10MlZqSTJObTFTY0hWUU1uTlZXVjlPWDBWWFNVNHhiR0Z3VlhwUE9ISnZJaXdpWVd4bklqb2lSVk16T0RRaWZRLmV5SkFZMjl1ZEdWNGRDSTZXeUpvZEhSd2N6b3ZMM2QzZHk1M015NXZjbWN2Ym5NdlkzSmxaR1Z1ZEdsaGJITXZkaklpTENKb2RIUndjem92TDNkM2R5NTNNeTV2Y21jdmJuTXZZM0psWkdWdWRHbGhiSE12WlhoaGJYQnNaWE12ZGpJaVhTd2lhV1FpT2lKb2RIUndPaTh2ZFc1cGRtVnljMmwwZVM1bGVHRnRjR3hsTDJOeVpXUmxiblJwWVd4ekx6RTROeklpTENKMGVYQmxJanBiSWxabGNtbG1hV0ZpYkdWRGNtVmtaVzUwYVdGc0lpd2lSWGhoYlhCc1pVRnNkVzF1YVVOeVpXUmxiblJwWVd3aVhTd2lhWE56ZFdWeUlqb2lhSFIwY0hNNkx5OTFibWwyWlhKemFYUjVMbVY0WVcxd2JHVXZhWE56ZFdWeWN5ODFOalV3TkRraUxDSjJZV3hwWkVaeWIyMGlPaUl5TURFd0xUQXhMVEF4VkRFNU9qSXpPakkwV2lJc0ltTnlaV1JsYm5ScFlXeFRZMmhsYldFaU9uc2lhV1FpT2lKb2RIUndjem92TDJWNFlXMXdiR1V1YjNKbkwyVjRZVzF3YkdWekwyUmxaM0psWlM1cWMyOXVJaXdpZEhsd1pTSTZJa3B6YjI1VFkyaGxiV0VpZlN3aVkzSmxaR1Z1ZEdsaGJGTjFZbXBsWTNRaU9uc2lhV1FpT2lKa2FXUTZaWGhoYlhCc1pUb3hNak1pTENKa1pXZHlaV1VpT25zaWRIbHdaU0k2SWtKaFkyaGxiRzl5UkdWbmNtVmxJaXdpYm1GdFpTSTZJa0poWTJobGJHOXlJRzltSUZOamFXVnVZMlVnWVc1a0lFRnlkSE1pZlgxOS5kMms0TzNGeXRRSmY4M2tMaC1Ic1h1UHZoNnllT2xoSkVMVm81VEY3MWd1N2Vsc2xReU9mMlpJdEFYcnRiWEY0S3o5V2l2TmR6dE9heXo0VlVRME13YTh5Q0Raa1A5QjJwSC05U190Y0FGeGVvZUo2WjRYbkZ1TF9ET2ZrUjFmUCIsInR5cGUiOiJFbnZlbG9wZWRWZXJpZmlhYmxlQ3JlZGVudGlhbCJ9XX0</span>
-.<span class="jwt-signature">L0y-DE_Y9xfLsdvcCP4ZvB9I8hOaKkoR1T5C9eE2urMTpzadnC_5va7CsZM4MpQDzpc6aw6IZFROkRuIW9076w</span>
+.<span class="jwt-signature">W-VCYKsmbzHlKT13jPIDNqx49jXb5VNyRLVI-cNoBy8gOoYpLJgrV1OYtG8BQd5FtU5K7DxYuwY6HxiKM5cpbQ</span>
 </div>
 </div>
     </div>
@@ -1715,7 +1681,7 @@ li.sd-jwt-tab {
 <div class="jwt-compact">
 <span class="jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
 .<span class="jwt-payload">eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidHlwZSI6IkVudmVsb3BlZFZlcmlmaWFibGVQcmVzZW50YXRpb24iLCJpZCI6ImRhdGE6YXBwbGljYXRpb24vdnArand0LGV5SnJhV1FpT2lKRmVFaHJRazFYT1dadFltdDJWakkyTm0xU2NIVlFNbk5WV1Y5T1gwVlhTVTR4YkdGd1ZYcFBPSEp2SWl3aVlXeG5Jam9pUlZNeU5UWWlmUS5leUpBWTI5dWRHVjRkQ0k2V3lKb2RIUndjem92TDNkM2R5NTNNeTV2Y21jdmJuTXZZM0psWkdWdWRHbGhiSE12ZGpJaUxDSm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdlpYaGhiWEJzWlhNdmRqSWlYU3dpZEhsd1pTSTZJbFpsY21sbWFXRmliR1ZRY21WelpXNTBZWFJwYjI0aUxDSjJaWEpwWm1saFlteGxRM0psWkdWdWRHbGhiQ0k2VzNzaVFHTnZiblJsZUhRaU9pSm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdmRqSWlMQ0pwWkNJNkltUmhkR0U2WVhCd2JHbGpZWFJwYjI0dmRtTXJhbmQwTEdWNVNuSmhWMUZwVDJsS1JtVkZhSEpSYXpGWVQxZGFkRmx0ZERKV2Fra3lUbTB4VTJOSVZsRk5iazVXVjFZNVQxZ3dWbGhUVlRSNFlrZEdkMVpZY0ZCUFNFcDJTV2wzYVZsWGVHNUphbTlwVWxaTmVrOUVVV2xtVVM1bGVVcEJXVEk1ZFdSSFZqUmtRMGsyVjNsS2IyUklVbmRqZW05MlRETmtNMlI1TlROTmVUVjJZMjFqZG1KdVRYWlpNMHBzV2tkV2RXUkhiR2hpU0UxMlpHcEphVXhEU205a1NGSjNZM3B2ZGt3elpETmtlVFV6VFhrMWRtTnRZM1ppYmsxMldUTktiRnBIVm5Wa1IyeG9Za2hOZGxwWWFHaGlXRUp6V2xoTmRtUnFTV2xZVTNkcFlWZFJhVTlwU205a1NGSjNUMms0ZG1SWE5YQmtiVlo1WXpKc01HVlROV3hsUjBaMFkwZDRiRXd5VG5sYVYxSnNZbTVTY0ZsWGVIcE1la1UwVG5wSmFVeERTakJsV0VKc1NXcHdZa2xzV214amJXeHRZVmRHYVdKSFZrUmpiVlpyV2xjMU1HRlhSbk5KYVhkcFVsaG9hR0pZUW5OYVZVWnpaRmN4ZFdGVlRubGFWMUpzWW01U2NGbFhkMmxZVTNkcFlWaE9lbVJYVm5sSmFtOXBZVWhTTUdOSVRUWk1lVGt4WW0xc01scFlTbnBoV0ZJMVRHMVdORmxYTVhkaVIxVjJZVmhPZW1SWFZubGplVGd4VG1wVmQwNUVhMmxNUTBveVdWZDRjRnBGV25saU1qQnBUMmxKZVUxRVJYZE1WRUY0VEZSQmVGWkVSVFZQYWtsNlQycEpNRmRwU1hOSmJVNTVXbGRTYkdKdVVuQlpWM2hVV1RKb2JHSlhSV2xQYm5OcFlWZFJhVTlwU205a1NGSjNZM3B2ZGt3eVZqUlpWekYzWWtkVmRXSXpTbTVNTWxZMFdWY3hkMkpIVm5wTU1sSnNXak5LYkZwVE5YRmpNamwxU1dsM2FXUkliSGRhVTBrMlNXdHdlbUl5TlZSWk1taHNZbGRGYVdaVGQybFpNMHBzV2tkV2RXUkhiR2hpUms0eFdXMXdiRmt6VVdsUGJuTnBZVmRSYVU5cFNtdGhWMUUyV2xob2FHSllRbk5hVkc5NFRXcE5hVXhEU210YVYyUjVXbGRWYVU5dWMybGtTR3gzV2xOSk5rbHJTbWhaTW1oc1lrYzVlVkpIVm01amJWWnNTV2wzYVdKdFJuUmFVMGsyU1d0S2FGa3lhR3hpUnpsNVNVYzViVWxHVG1waFYxWjFXVEpWWjFsWE5XdEpSVVo1WkVoTmFXWllNVGt1WkRKck5FOHpSbmwwVVVwbU9ETnJUR2d0U0hOWWRWQjJhRFo1WlU5c2FFcEZURlp2TlZSR056Rm5kVGRsYkhOc1VYbFBaakphU1hSQldISjBZbGhHTkV0Nk9WZHBkazVrZW5SUFlYbDZORlpWVVRCTmQyRTRlVU5FV210UU9VSXljRWd0T1ZOZmRHTkJSbmhsYjJWS05sbzBXRzVHZFV4ZlJFOW1hMUl4WmxBN1pHRjBZVHBoY0hCc2FXTmhkR2x2Ymk5Mll5dHFkM1FzWlhsS2NtRlhVV2xQYVVwR1pVVm9jbEZyTVZoUFYxcDBXVzEwTWxacVNUSk9iVEZUWTBoV1VVMXVUbFpYVmpsUFdEQldXRk5WTkhoaVIwWjNWbGh3VUU5SVNuWkphWGRwV1ZkNGJrbHFiMmxTVmsxNlQwUlJhV1pSTG1WNVNrRlpNamwxWkVkV05HUkRTVFpYZVVwdlpFaFNkMk42YjNaTU0yUXpaSGsxTTAxNU5YWmpiV04yWW01TmRsa3pTbXhhUjFaMVpFZHNhR0pJVFhaa2FrbHBURU5LYjJSSVVuZGplbTkyVEROa00yUjVOVE5OZVRWMlkyMWpkbUp1VFhaWk0wcHNXa2RXZFdSSGJHaGlTRTEyV2xob2FHSllRbk5hV0UxMlpHcEphVmhUZDJsaFYxRnBUMmxLYjJSSVVuZFBhVGgyWkZjMWNHUnRWbmxqTW13d1pWTTFiR1ZIUm5SalIzaHNUREpPZVZwWFVteGlibEp3V1ZkNGVreDZSVFJPZWtscFRFTktNR1ZZUW14SmFuQmlTV3hhYkdOdGJHMWhWMFpwWWtkV1JHTnRWbXRhVnpVd1lWZEdjMGxwZDJsU1dHaG9ZbGhDYzFwVlJuTmtWekYxWVZWT2VWcFhVbXhpYmxKd1dWZDNhVmhUZDJsaFdFNTZaRmRXZVVscWIybGhTRkl3WTBoTk5reDVPVEZpYld3eVdsaEtlbUZZVWpWTWJWWTBXVmN4ZDJKSFZYWmhXRTU2WkZkV2VXTjVPREZPYWxWM1RrUnJhVXhEU2pKWlYzaHdXa1ZhZVdJeU1HbFBhVWw1VFVSRmQweFVRWGhNVkVGNFZrUkZOVTlxU1hwUGFra3dWMmxKYzBsdFRubGFWMUpzWW01U2NGbFhlRlJaTW1oc1lsZEZhVTl1YzJsaFYxRnBUMmxLYjJSSVVuZGplbTkyVERKV05GbFhNWGRpUjFWMVlqTktia3d5VmpSWlZ6RjNZa2RXZWt3eVVteGFNMHBzV2xNMWNXTXlPWFZKYVhkcFpFaHNkMXBUU1RaSmEzQjZZakkxVkZreWFHeGlWMFZwWmxOM2FWa3pTbXhhUjFaMVpFZHNhR0pHVGpGWmJYQnNXVE5SYVU5dWMybGhWMUZwVDJsS2EyRlhVVFphV0dob1lsaENjMXBVYjNoTmFrMXBURU5LYTFwWFpIbGFWMVZwVDI1emFXUkliSGRhVTBrMlNXdEthRmt5YUd4aVJ6bDVVa2RXYm1OdFZteEphWGRwWW0xR2RGcFRTVFpKYTBwb1dUSm9iR0pIT1hsSlJ6bHRTVVpPYW1GWFZuVlpNbFZuV1ZjMWEwbEZSbmxrU0UxcFpsZ3hPUzVrTW1zMFR6TkdlWFJSU21ZNE0ydE1hQzFJYzFoMVVIWm9ObmxsVDJ4b1NrVk1WbTgxVkVZM01XZDFOMlZzYzJ4UmVVOW1NbHBKZEVGWWNuUmlXRVkwUzNvNVYybDJUbVI2ZEU5aGVYbzBWbFZSTUUxM1lUaDVRMFJhYTFBNVFqSndTQzA1VTE5MFkwRkdlR1Z2WlVvMldqUllia1oxVEY5RVQyWnJVakZtVUNJc0luUjVjR1VpT2lKRmJuWmxiRzl3WldSV1pYSnBabWxoWW14bFEzSmxaR1Z1ZEdsaGJDSjlYWDAuRGlaZlh3NWpUWGVEQm9icTVaZGNMM1MzbzhtaW9aSmxxbzNpSER0TGNFd3c1TF9uMlpKZkFKVS1hLVNtcXZNWU0tLTd3NENtZU9mcTg5MFVHc2dfYVEiLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6W119</span>
-.<span class="jwt-signature">EogM7TRguKB_cvYID8cuakO1nSnIf94Qon5nkaD8FiCHvz3GoemnUrg72GPJ7u81ptt1aR6izBKukEN-lvh2EQ</span>
+.<span class="jwt-signature">ndvXgG0tEU5qu5B9hoYgQBSExPrjgQSs8mO1Sd62hUVyfeND3Dcym5gFL4gr_rM-_0glipfbNTZK7BxvSoibHw</span>
 </div>
 </div>
     </div>
@@ -1890,96 +1856,96 @@ li.sd-jwt-tab {
 }</pre></div><div class="vc-tab-content" style="min-height: 605px;"><div>
 
 <div class="sd-jwt-tabbed">
-    <input type="radio" id="sd-jwt-4-e54y3ej-encoded" name="sd-jwt-4-e54y3ej-tabs" checked="checked" tabindex="0">
-    <input type="radio" id="sd-jwt-4-e54y3ej-decoded" name="sd-jwt-4-e54y3ej-tabs" tabindex="0">
-    <input type="radio" id="sd-jwt-4-e54y3ej-disclosures" name="sd-jwt-4-e54y3ej-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-4-vqner73-encoded" name="sd-jwt-4-vqner73-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="sd-jwt-4-vqner73-decoded" name="sd-jwt-4-vqner73-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-4-vqner73-disclosures" name="sd-jwt-4-vqner73-tabs" tabindex="0">
     <ul class="sd-jwt-tabs">
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-4-e54y3ej-encoded">Encoded</label>
+        <label for="sd-jwt-4-vqner73-encoded">Encoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-4-e54y3ej-decoded">Decoded</label>
+        <label for="sd-jwt-4-vqner73-decoded">Decoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-4-e54y3ej-disclosures">Issuer Disclosures</label>
+        <label for="sd-jwt-4-vqner73-disclosures">Issuer Disclosures</label>
       </li>
     </ul>
-    <div class="sd-jwt-tab-content" id="sd-jwt-4-e54y3ej-content-encoded">
+    <div class="sd-jwt-tab-content" id="sd-jwt-4-vqner73-content-encoded">
       
 <div class="sd-jwt-compact">
 <span class="sd-jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
-.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1NjU5NzksImV4cCI6MTc0Njc3NTU3OSwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy8xNCIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiZGVncmVlIjp7Im5hbWUiOiJCYWNoZWxvciBvZiBTY2llbmNlIGFuZCBBcnRzIiwiX3NkIjpbIkpzWUlhQXBMejhaVDdwOFhFeXVJeG5sOXNYMHRCUktILWZKSnBYRWhtNEkiXX0sImFsdW1uaU9mIjp7Im5hbWUiOiJFeGFtcGxlIFVuaXZlcnNpdHkifSwiX3NkIjpbImFwMTM5MUJ3ZERnM2lLelJoQlFkUkFvS3ZHbWc0MkpndW00bThZQTRsLTAiXX0sImNyZWRlbnRpYWxTY2hlbWEiOlt7Il9zZCI6WyJJd2hPdGs1V2QzQ2M5cUVNbXBaOERPeEd6WlAzc0Q5b2ltQWpfUlc3eUNzIiwiS3N3R1pVRzRQOFllbTM4eV9ROUpwcUhrN0dUWmkzeDU2S3o1cV9CVnpLdyJdfSx7Il9zZCI6WyJQNWJnLVFqakhQcHo0N3lWd1VGNmhHSkJRQ0pBT291WmFuX1l5SnZTY0NRIiwic3R6bVEyQTJmaG9NVWdxakFXTlNBRk9ZbzYySFNvLXIwTktmNG1oVkxZQSJdfV0sIl9zZCI6WyJGUmNRRjlGaTBlSnMzaVdCdXlDb3dlUEpCdWxiYjhqNk50elpjSElROHpnIiwibEJJY3ZmTHRuSGdKcG83dlFfUVpTTDhGN1lkVWF1eUdRb1lYMHR1bkk0VSJdfQ</span>
-.<span class="sd-jwt-signature">BrAFD0LOzMo6Yq4_G99PT9MiscdbdxPBgSg72cGx5I4po-JAPfBg7Q5KNS-kb2D6YoWF_9nq7gKMHconTrPQPA</span>
-~<span class="sd-jwt-disclosure">WyJvRERrZnpFZWdFZzI0WktkeUdBSmJ3IiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMzczMiJd</span>~<span class="sd-jwt-disclosure">WyIwazkxbXpIV2tSNkM1TW0wNS1Id3pBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVEZWdyZWVDcmVkZW50aWFsIiwgIkV4YW1wbGVQZXJzb25DcmVkZW50aWFsIl1d</span>~<span class="sd-jwt-disclosure">WyJmbmNCcGdDMXBlQ2JjTDRDcVRWNzdnIiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd</span>~<span class="sd-jwt-disclosure">WyIxVlFBRklXQUNlb0RBblNNc1czU2x3IiwgInR5cGUiLCAiRXhhbXBsZUJhY2hlbG9yRGVncmVlIl0</span>~<span class="sd-jwt-disclosure">WyJ2T0R1VVQ5dm9jVU95Uk1XVkR2ME53IiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ</span>~<span class="sd-jwt-disclosure">WyJqUG5zbHBxaG1RV0tIbl9tMWNXb2xRIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span>~<span class="sd-jwt-disclosure">WyJtWE9pQkdsYlVyWVdkUzYtRXBVMzVRIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvYWx1bW5pLmpzb24iXQ</span>~<span class="sd-jwt-disclosure">WyJINjR4U0hRdFRNZXZZUENLOGJCajlnIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span>~
+.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1OTQ3NzIsImV4cCI6MTc0NjgwNDM3MiwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy8xNCIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiZGVncmVlIjp7Im5hbWUiOiJCYWNoZWxvciBvZiBTY2llbmNlIGFuZCBBcnRzIiwiX3NkIjpbIkdRMHZrZUVGZ2RWWkxMdEhZYTdPSkZqQmtJeVRGVGo3SlAxX1pnb3hpejgiXX0sImFsdW1uaU9mIjp7Im5hbWUiOiJFeGFtcGxlIFVuaXZlcnNpdHkifSwiX3NkIjpbIlFHOFdjdkZpcVBKcE9YVUFPWnJ5a2FYMWhTRWhKRHA2cVFNZFhiOTJPRzQiXX0sImNyZWRlbnRpYWxTY2hlbWEiOlt7Il9zZCI6WyI3S2lOSENFSEVjR3JjbExOa2t1TXZHc0lld2ZCaVVOMEJWZnA1YzU1TGlvIiwicTAyWU16dWlEX25jQ0F5S1c4Q0xMbXhmd2RqVUJvai1tbWFhNVJVTjVlVSJdfSx7Il9zZCI6WyJHZGR2b3QtZTY3eGlRd0JCcjBhZXFQOGNnMXQzQWZMcEVQdTBMLUpubFBFIiwieUNDbU5PRGhKR3dqQzJPUjRXa29XRzNia1U1X0FhYjN3cDE0QzNjSjBoZyJdfV0sIl9zZCI6WyJHYWc4bkhyVjRIbHlLQy1KWm9KTWV1TWNlSjVwNVNnaDlTZWQ3ZF9hc29nIiwicGl3RFFtME1HUjlMQ2ZHRnlQd2xIUGIwT3ZpM05aQU5xeUZCNl9iRDE0YyJdfQ</span>
+.<span class="sd-jwt-signature">6A0qNztAmhl4HWw4pdgEaeM5hMJZie69xKJRjk2-bkwTdqlx1xDvZRtjH6kBduFRmUo_1JtyDqOPxGHe6w-nxg</span>
+~<span class="sd-jwt-disclosure">WyJGOEprZFJiT3hDbUM3UU9GbjZSX0F3IiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMzczMiJd</span>~<span class="sd-jwt-disclosure">WyI4d0NOVnpjcHRyZnVlQ3ZkX1ByVnpRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVEZWdyZWVDcmVkZW50aWFsIiwgIkV4YW1wbGVQZXJzb25DcmVkZW50aWFsIl1d</span>~<span class="sd-jwt-disclosure">WyIwcEYzMVBUem9oRnNnZW1qXzNMb2tBIiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd</span>~<span class="sd-jwt-disclosure">WyJMaU9qeGZZTU9uOTVUcEhnRnp0SGZ3IiwgInR5cGUiLCAiRXhhbXBsZUJhY2hlbG9yRGVncmVlIl0</span>~<span class="sd-jwt-disclosure">WyJBTlUta1NPWGoxZWg3NHlUcC0xcjNnIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ</span>~<span class="sd-jwt-disclosure">WyJhcXRSLU93Wk0xWjh0eTFIbzBwa3BRIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span>~<span class="sd-jwt-disclosure">WyJIdE91TkllQ2FaN0ZQY0lpQ3RoRS1nIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvYWx1bW5pLmpzb24iXQ</span>~<span class="sd-jwt-disclosure">WyJKZWpaYy1JY0JvNjNJcUZiUWVpY19nIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span>~
 </div>
     </div>
-    <div class="sd-jwt-tab-content" id="sd-jwt-4-e54y3ej-content-decoded">
+    <div class="sd-jwt-tab-content" id="sd-jwt-4-vqner73-content-decoded">
       <pre class="header-value">{<br>&nbsp;&nbsp;"kid":&nbsp;"ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",<br>&nbsp;&nbsp;"alg":&nbsp;"ES256"<br>}</pre>
-      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745565979,<br>&nbsp;&nbsp;"exp":&nbsp;1746775579,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"issuer":&nbsp;"https://university.example/issuers/14",<br>&nbsp;&nbsp;"validFrom":&nbsp;"2010-01-01T19:23:24Z",<br>&nbsp;&nbsp;"credentialSubject":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"degree":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name":&nbsp;"Bachelor&nbsp;of&nbsp;Science&nbsp;and&nbsp;Arts",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"JsYIaApLz8ZT7p8XEyuIxnl9sX0tBRKH-fJJpXEhm4I"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;"alumniOf":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name":&nbsp;"Example&nbsp;University"<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"ap1391BwdDg3iKzRhBQdRAoKvGmg42Jgum4m8YA4l-0"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"credentialSchema":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"IwhOtk5Wd3Cc9qEMmpZ8DOxGzZP3sD9oimAj_RW7yCs",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"KswGZUG4P8Yem38y_Q9JpqHk7GTZi3x56Kz5q_BVzKw"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"P5bg-QjjHPpz47yVwUF6hGJBQCJAOouZan_YyJvScCQ",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"stzmQ2A2fhoMUgqjAWNSAFOYo62HSo-r0NKf4mhVLYA"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"FRcQF9Fi0eJs3iWBuyCowePJBulbb8j6NtzZcHIQ8zg",<br>&nbsp;&nbsp;&nbsp;&nbsp;"lBIcvfLtnHgJpo7vQ_QZSL8F7YdUauyGQoYX0tunI4U"<br>&nbsp;&nbsp;]<br>}</pre>
+      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745594772,<br>&nbsp;&nbsp;"exp":&nbsp;1746804372,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"issuer":&nbsp;"https://university.example/issuers/14",<br>&nbsp;&nbsp;"validFrom":&nbsp;"2010-01-01T19:23:24Z",<br>&nbsp;&nbsp;"credentialSubject":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"degree":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name":&nbsp;"Bachelor&nbsp;of&nbsp;Science&nbsp;and&nbsp;Arts",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"GQ0vkeEFgdVZLLtHYa7OJFjBkIyTFTj7JP1_Zgoxiz8"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;"alumniOf":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name":&nbsp;"Example&nbsp;University"<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"QG8WcvFiqPJpOXUAOZrykaX1hSEhJDp6qQMdXb92OG4"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"credentialSchema":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"7KiNHCEHEcGrclLNkkuMvGsIewfBiUN0BVfp5c55Lio",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"q02YMzuiD_ncCAyKW8CLLmxfwdjUBoj-mmaa5RUN5eU"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Gddvot-e67xiQwBBr0aeqP8cg1t3AfLpEPu0L-JnlPE",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"yCCmNODhJGwjC2OR4WkoWG3bkU5_Aab3wp14C3cJ0hg"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"Gag8nHrV4HlyKC-JZoJMeuMceJ5p5Sgh9Sed7d_asog",<br>&nbsp;&nbsp;&nbsp;&nbsp;"piwDQm0MGR9LCfGFyPwlHPb0Ovi3NZANqyFB6_bD14c"<br>&nbsp;&nbsp;]<br>}</pre>
     </div>
-    <div class="sd-jwt-tab-content" id="sd-jwt-4-e54y3ej-content-disclosures">
+    <div class="sd-jwt-tab-content" id="sd-jwt-4-vqner73-content-disclosures">
       <div class="disclosures">
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-lBIcvfLtnHgJpo7vQ_QZSL8F7YdUauyGQoYX0tunI4U">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">lBIcvfLtnHgJpo7vQ_QZSL8F7YdUauyGQoYX0tunI4U</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJvRERrZnpFZWdFZzI0WktkeUdBSmJ3IiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMzczMiJd</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"oDDkfzEegEg24ZKdyGAJbw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"http://university.example/credentials/3732"<br>]</span></p>
+    <h3 id="sd-jwt-claim-Gag8nHrV4HlyKC-JZoJMeuMceJ5p5Sgh9Sed7d_asog">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">Gag8nHrV4HlyKC-JZoJMeuMceJ5p5Sgh9Sed7d_asog</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJGOEprZFJiT3hDbUM3UU9GbjZSX0F3IiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMzczMiJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"F8JkdRbOxCmC7QOFn6R_Aw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"http://university.example/credentials/3732"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-FRcQF9Fi0eJs3iWBuyCowePJBulbb8j6NtzZcHIQ8zg">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">FRcQF9Fi0eJs3iWBuyCowePJBulbb8j6NtzZcHIQ8zg</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyIwazkxbXpIV2tSNkM1TW0wNS1Id3pBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVEZWdyZWVDcmVkZW50aWFsIiwgIkV4YW1wbGVQZXJzb25DcmVkZW50aWFsIl1d</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"0k91mzHWkR6C5Mm05-HwzA",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"VerifiableCredential",<br>&nbsp;&nbsp;&nbsp;&nbsp;"ExampleDegreeCredential",<br>&nbsp;&nbsp;&nbsp;&nbsp;"ExamplePersonCredential"<br>&nbsp;&nbsp;]<br>]</span></p>
+    <h3 id="sd-jwt-claim-piwDQm0MGR9LCfGFyPwlHPb0Ovi3NZANqyFB6_bD14c">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">piwDQm0MGR9LCfGFyPwlHPb0Ovi3NZANqyFB6_bD14c</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyI4d0NOVnpjcHRyZnVlQ3ZkX1ByVnpRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVEZWdyZWVDcmVkZW50aWFsIiwgIkV4YW1wbGVQZXJzb25DcmVkZW50aWFsIl1d</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"8wCNVzcptrfueCvd_PrVzQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"VerifiableCredential",<br>&nbsp;&nbsp;&nbsp;&nbsp;"ExampleDegreeCredential",<br>&nbsp;&nbsp;&nbsp;&nbsp;"ExamplePersonCredential"<br>&nbsp;&nbsp;]<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-ap1391BwdDg3iKzRhBQdRAoKvGmg42Jgum4m8YA4l-0">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">ap1391BwdDg3iKzRhBQdRAoKvGmg42Jgum4m8YA4l-0</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJmbmNCcGdDMXBlQ2JjTDRDcVRWNzdnIiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"fncBpgC1peCbcL4CqTV77g",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"did:example:ebfeb1f712ebc6f1c276e12ec21"<br>]</span></p>
+    <h3 id="sd-jwt-claim-QG8WcvFiqPJpOXUAOZrykaX1hSEhJDp6qQMdXb92OG4">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">QG8WcvFiqPJpOXUAOZrykaX1hSEhJDp6qQMdXb92OG4</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyIwcEYzMVBUem9oRnNnZW1qXzNMb2tBIiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"0pF31PTzohFsgemj_3LokA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"did:example:ebfeb1f712ebc6f1c276e12ec21"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-JsYIaApLz8ZT7p8XEyuIxnl9sX0tBRKH-fJJpXEhm4I">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">JsYIaApLz8ZT7p8XEyuIxnl9sX0tBRKH-fJJpXEhm4I</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyIxVlFBRklXQUNlb0RBblNNc1czU2x3IiwgInR5cGUiLCAiRXhhbXBsZUJhY2hlbG9yRGVncmVlIl0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"1VQAFIWACeoDAnSMsW3Slw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"ExampleBachelorDegree"<br>]</span></p>
+    <h3 id="sd-jwt-claim-GQ0vkeEFgdVZLLtHYa7OJFjBkIyTFTj7JP1_Zgoxiz8">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">GQ0vkeEFgdVZLLtHYa7OJFjBkIyTFTj7JP1_Zgoxiz8</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJMaU9qeGZZTU9uOTVUcEhnRnp0SGZ3IiwgInR5cGUiLCAiRXhhbXBsZUJhY2hlbG9yRGVncmVlIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"LiOjxfYMOn95TpHgFztHfw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"ExampleBachelorDegree"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-KswGZUG4P8Yem38y_Q9JpqHk7GTZi3x56Kz5q_BVzKw">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">KswGZUG4P8Yem38y_Q9JpqHk7GTZi3x56Kz5q_BVzKw</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ2T0R1VVQ5dm9jVU95Uk1XVkR2ME53IiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"vODuUT9vocUOyRMWVDv0Nw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://example.org/examples/degree.json"<br>]</span></p>
+    <h3 id="sd-jwt-claim-q02YMzuiD_ncCAyKW8CLLmxfwdjUBoj-mmaa5RUN5eU">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">q02YMzuiD_ncCAyKW8CLLmxfwdjUBoj-mmaa5RUN5eU</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJBTlUta1NPWGoxZWg3NHlUcC0xcjNnIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"ANU-kSOXj1eh74yTp-1r3g",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://example.org/examples/degree.json"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-IwhOtk5Wd3Cc9qEMmpZ8DOxGzZP3sD9oimAj_RW7yCs">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">IwhOtk5Wd3Cc9qEMmpZ8DOxGzZP3sD9oimAj_RW7yCs</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJqUG5zbHBxaG1RV0tIbl9tMWNXb2xRIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"jPnslpqhmQWKHn_m1cWolQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"JsonSchema"<br>]</span></p>
+    <h3 id="sd-jwt-claim-7KiNHCEHEcGrclLNkkuMvGsIewfBiUN0BVfp5c55Lio">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">7KiNHCEHEcGrclLNkkuMvGsIewfBiUN0BVfp5c55Lio</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJhcXRSLU93Wk0xWjh0eTFIbzBwa3BRIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"aqtR-OwZM1Z8ty1Ho0pkpQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"JsonSchema"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-stzmQ2A2fhoMUgqjAWNSAFOYo62HSo-r0NKf4mhVLYA">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">stzmQ2A2fhoMUgqjAWNSAFOYo62HSo-r0NKf4mhVLYA</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJtWE9pQkdsYlVyWVdkUzYtRXBVMzVRIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvYWx1bW5pLmpzb24iXQ</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"mXOiBGlbUrYWdS6-EpU35Q",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://example.org/examples/alumni.json"<br>]</span></p>
+    <h3 id="sd-jwt-claim-Gddvot-e67xiQwBBr0aeqP8cg1t3AfLpEPu0L-JnlPE">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">Gddvot-e67xiQwBBr0aeqP8cg1t3AfLpEPu0L-JnlPE</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJIdE91TkllQ2FaN0ZQY0lpQ3RoRS1nIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvYWx1bW5pLmpzb24iXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"HtOuNIeCaZ7FPcIiCthE-g",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://example.org/examples/alumni.json"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-P5bg-QjjHPpz47yVwUF6hGJBQCJAOouZan_YyJvScCQ">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">P5bg-QjjHPpz47yVwUF6hGJBQCJAOouZan_YyJvScCQ</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJINjR4U0hRdFRNZXZZUENLOGJCajlnIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"H64xSHQtTMevYPCK8bBj9g",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"JsonSchema"<br>]</span></p>
+    <h3 id="sd-jwt-claim-yCCmNODhJGwjC2OR4WkoWG3bkU5_Aab3wp14C3cJ0hg">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">yCCmNODhJGwjC2OR4WkoWG3bkU5_Aab3wp14C3cJ0hg</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJKZWpaYy1JY0JvNjNJcUZiUWVpY19nIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"JejZc-IcBo63IqFbQeic_g",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"JsonSchema"<br>]</span></p>
 </div>
 </div>
     </div>
@@ -2070,56 +2036,56 @@ li.sd-jwt-tab {
 }</pre></div><div class="vc-tab-content" style="min-height: 259px;"><div>
 
 <div class="sd-jwt-tabbed">
-    <input type="radio" id="sd-jwt-5-uxcfkkd-encoded" name="sd-jwt-5-uxcfkkd-tabs" checked="checked" tabindex="0">
-    <input type="radio" id="sd-jwt-5-uxcfkkd-decoded" name="sd-jwt-5-uxcfkkd-tabs" tabindex="0">
-    <input type="radio" id="sd-jwt-5-uxcfkkd-disclosures" name="sd-jwt-5-uxcfkkd-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-5-mmo9tvs-encoded" name="sd-jwt-5-mmo9tvs-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="sd-jwt-5-mmo9tvs-decoded" name="sd-jwt-5-mmo9tvs-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-5-mmo9tvs-disclosures" name="sd-jwt-5-mmo9tvs-tabs" tabindex="0">
     <ul class="sd-jwt-tabs">
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-5-uxcfkkd-encoded">Encoded</label>
+        <label for="sd-jwt-5-mmo9tvs-encoded">Encoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-5-uxcfkkd-decoded">Decoded</label>
+        <label for="sd-jwt-5-mmo9tvs-decoded">Decoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-5-uxcfkkd-disclosures">Issuer Disclosures</label>
+        <label for="sd-jwt-5-mmo9tvs-disclosures">Issuer Disclosures</label>
       </li>
     </ul>
-    <div class="sd-jwt-tab-content" id="sd-jwt-5-uxcfkkd-content-encoded">
+    <div class="sd-jwt-tab-content" id="sd-jwt-5-mmo9tvs-content-encoded">
       
 <div class="sd-jwt-compact">
 <span class="sd-jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
-.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1NjU5NzksImV4cCI6MTc0Njc3NTU3OSwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjoiaHR0cHM6Ly93d3cudzMub3JnL25zL2NyZWRlbnRpYWxzL3YyIiwiX3NkIjpbIlJxNmlWM0RYSUl3R1JoMjBWbDBjX2IxbkUtR1J4aUlOWkxONHF2NzVodkkiLCJ3MzhfeVlfdUxRemY3WDNfMFM3c2VmZ1I5TjlnTnMzakQ3VTNrRXVTWC1vIl19XSwiX3NkIjpbInRBeC01N2wwNlUzZzhTdmNRWXRfMndyem4xOUJsMkk0Nm56NThib0NwT2MiXX0</span>
-.<span class="sd-jwt-signature">yqd93PdaHzsTVz-mQT17vnyay9AJoCMWMH4BsMwtLC1byvkrA2w_3CXz2bc0MJMEAgp63NHK07w495sZzAYtTg</span>
-~<span class="sd-jwt-disclosure">WyJRU0U0eVZzYk1kU3E1dE8yR0NiR3J3IiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span>~<span class="sd-jwt-disclosure">WyJ1bko3emplY3ByVG8wZHkyWTBGZkFRIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span>~<span class="sd-jwt-disclosure">WyJIaVJySEowSmNzWjlsQ2xGZk9LSUp3IiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleUpyYVdRaU9pSkZlRWhyUWsxWE9XWnRZbXQyVmpJMk5tMVNjSFZRTW5OVldWOU9YMFZYU1U0eGJHRndWWHBQT0hKdklpd2lZV3huSWpvaVJWTXlOVFlpZlEuZXlKZmMyUmZZV3huSWpvaWMyaGhMVEkxTmlJc0lrQmpiMjUwWlhoMElqcGJJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OTJNaUlzSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk5dWN5OWpjbVZrWlc1MGFXRnNjeTlsZUdGdGNHeGxjeTkyTWlKZExDSnBjM04xWlhJaU9pSm9kSFJ3Y3pvdkwzVnVhWFpsY25OcGRIa3VaWGhoYlhCc1pTOXBjM04xWlhKekx6VTJOVEEwT1NJc0luWmhiR2xrUm5KdmJTSTZJakl3TVRBdE1ERXRNREZVTVRrNk1qTTZNalJhSWl3aVkzSmxaR1Z1ZEdsaGJGTmphR1Z0WVNJNmV5SmZjMlFpT2xzaU5qVkZMVlpaYm1FM1VFNW1TR1ZzVURONlRIRndjRTVFUlhoU0xXaGpXa2hTVG5seE4yVTBaVmRhYnlJc0lqaEpiRXd0VUd4NFVrdDNTMGhMYVRNdFRYaFhNak00ZDBGa1RtUTBOSGRhYkMxaVkzTkJjMkpJUWpBaVhYMHNJbU55WldSbGJuUnBZV3hUZFdKcVpXTjBJanA3SW1SbFozSmxaU0k2ZXlKdVlXMWxJam9pUW1GamFHVnNiM0lnYjJZZ1UyTnBaVzVqWlNCaGJtUWdRWEowY3lJc0lsOXpaQ0k2V3lKTVZYaHFjV3RzV1MxaGREVlNWbUZvU1hweE0zTkpaMDE1ZGtkd1ZEbHdkbFV3ZFRSeVUya3RNWGwzSWwxOUxDSmZjMlFpT2xzaVZteFpMVzUwWmtsUE9VSTVSR1JzVVdwNVUyUkVNbGRvVldJMGJqYzNabDlIV0RaMlUxZExRV3BDTkNKZGZTd2lYM05rSWpwYklpMWlSRVo0VW05NFVVVmxjRWRqWkZsNmEyNTBhVFZHV1hCc1VUVTVOMGRqYUVkVVRHVnRMVkpTWTFVaUxDSmZSRUZWWjB4clRGOXpWa1Z0TFRCdmNFOHphV2hwZVZGaFMwWnpUMDh4VWw5T05rMUNVbXByT1doRklsMTkuS2MwODNSS2JCeGMzVnI1cVIzaUVFUHAzZEt4VGE2c1BhV05zcXRrSXc4VHZNUmY5RVpMMmFqdGdrV1NCWXp5ek96YXdPckNYcnl5cDRyTVR5STl2ZkEgfld5SmlRMVJUYVU5SE5VbzFWWGhQWTFRd1VsTmZkMDFuSWl3Z0ltbGtJaXdnSW1oMGRIQTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2WTNKbFpHVnVkR2xoYkhNdk1UZzNNaUpkfld5SlRjbE5XTVMwMVNqUjZjV2hPVTNOM1NUSXdhSGRSSWl3Z0luUjVjR1VpTENCYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdnSWtWNFlXMXdiR1ZCYkhWdGJtbERjbVZrWlc1MGFXRnNJbDFkfld5SktYMjk0ZERodFVHVXRhRGw0TWtRemMyOXVUMU4zSWl3Z0ltbGtJaXdnSW1oMGRIQnpPaTh2WlhoaGJYQnNaUzV2Y21jdlpYaGhiWEJzWlhNdlpHVm5jbVZsTG1wemIyNGlYUX5XeUpETWxwV2VrdG1aMTg1UlVoMWFqQjJTMUV4ZFdKbklpd2dJblI1Y0dVaUxDQWlTbk52YmxOamFHVnRZU0pkfld5SjZTemQ1UWxGUGJGaGZYMlEwWDBWb1lVYzBZMHBSSWl3Z0ltbGtJaXdnSW1ScFpEcGxlR0Z0Y0d4bE9qRXlNeUpkfld5SjZiMXB6UnpNemVYQk1lVlJHTW05YVMzWm1NVkZuSWl3Z0luUjVjR1VpTENBaVFtRmphR1ZzYjNKRVpXZHlaV1VpWFF-Il0</span>~
+.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1OTQ3NzIsImV4cCI6MTc0NjgwNDM3MiwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjoiaHR0cHM6Ly93d3cudzMub3JnL25zL2NyZWRlbnRpYWxzL3YyIiwiX3NkIjpbIi1UVlJVNnlRUmtWRi01cTA4NmNYdWZ4RnU4dnA0QVpKTy1oX1U4enlGX1EiLCJhZ0wxdzlFS3hLMGw2cVZLeDc5RGt1eUdGaDJzemdIRzlSZjBrR18ybnVnIl19XSwiX3NkIjpbIlJ6VHI4ek0wcDEtMHJ3aEx3czAyX0kzMEQ4RzZrcERQRmxPRmdhZzB5YTAiXX0</span>
+.<span class="sd-jwt-signature">-CPblBXo8Oep4RSgE7QjlZwy2oAMlfmWUue7MHjYlqhyZSX6BvZ4hLGBKNqdqgaKDvq6M-VFXB8xE9GUvF9Iqg</span>
+~<span class="sd-jwt-disclosure">WyIwempCdDNBa0VRd0tJbllMNmhvX0lBIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span>~<span class="sd-jwt-disclosure">WyJHRXRVYzJuSS1Qd2xMYVhZM19Wd2p3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span>~<span class="sd-jwt-disclosure">WyJRenl4OTJ5azNZQ2tyZmdRejZQVHVnIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleUpyYVdRaU9pSkZlRWhyUWsxWE9XWnRZbXQyVmpJMk5tMVNjSFZRTW5OVldWOU9YMFZYU1U0eGJHRndWWHBQT0hKdklpd2lZV3huSWpvaVJWTXlOVFlpZlEuZXlKZmMyUmZZV3huSWpvaWMyaGhMVEkxTmlJc0lrQmpiMjUwWlhoMElqcGJJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OTJNaUlzSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk5dWN5OWpjbVZrWlc1MGFXRnNjeTlsZUdGdGNHeGxjeTkyTWlKZExDSnBjM04xWlhJaU9pSm9kSFJ3Y3pvdkwzVnVhWFpsY25OcGRIa3VaWGhoYlhCc1pTOXBjM04xWlhKekx6VTJOVEEwT1NJc0luWmhiR2xrUm5KdmJTSTZJakl3TVRBdE1ERXRNREZVTVRrNk1qTTZNalJhSWl3aVkzSmxaR1Z1ZEdsaGJGTmphR1Z0WVNJNmV5SmZjMlFpT2xzaU5qVkZMVlpaYm1FM1VFNW1TR1ZzVURONlRIRndjRTVFUlhoU0xXaGpXa2hTVG5seE4yVTBaVmRhYnlJc0lqaEpiRXd0VUd4NFVrdDNTMGhMYVRNdFRYaFhNak00ZDBGa1RtUTBOSGRhYkMxaVkzTkJjMkpJUWpBaVhYMHNJbU55WldSbGJuUnBZV3hUZFdKcVpXTjBJanA3SW1SbFozSmxaU0k2ZXlKdVlXMWxJam9pUW1GamFHVnNiM0lnYjJZZ1UyTnBaVzVqWlNCaGJtUWdRWEowY3lJc0lsOXpaQ0k2V3lKTVZYaHFjV3RzV1MxaGREVlNWbUZvU1hweE0zTkpaMDE1ZGtkd1ZEbHdkbFV3ZFRSeVUya3RNWGwzSWwxOUxDSmZjMlFpT2xzaVZteFpMVzUwWmtsUE9VSTVSR1JzVVdwNVUyUkVNbGRvVldJMGJqYzNabDlIV0RaMlUxZExRV3BDTkNKZGZTd2lYM05rSWpwYklpMWlSRVo0VW05NFVVVmxjRWRqWkZsNmEyNTBhVFZHV1hCc1VUVTVOMGRqYUVkVVRHVnRMVkpTWTFVaUxDSmZSRUZWWjB4clRGOXpWa1Z0TFRCdmNFOHphV2hwZVZGaFMwWnpUMDh4VWw5T05rMUNVbXByT1doRklsMTkuS2MwODNSS2JCeGMzVnI1cVIzaUVFUHAzZEt4VGE2c1BhV05zcXRrSXc4VHZNUmY5RVpMMmFqdGdrV1NCWXp5ek96YXdPckNYcnl5cDRyTVR5STl2ZkEgfld5SmlRMVJUYVU5SE5VbzFWWGhQWTFRd1VsTmZkMDFuSWl3Z0ltbGtJaXdnSW1oMGRIQTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2WTNKbFpHVnVkR2xoYkhNdk1UZzNNaUpkfld5SlRjbE5XTVMwMVNqUjZjV2hPVTNOM1NUSXdhSGRSSWl3Z0luUjVjR1VpTENCYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdnSWtWNFlXMXdiR1ZCYkhWdGJtbERjbVZrWlc1MGFXRnNJbDFkfld5SktYMjk0ZERodFVHVXRhRGw0TWtRemMyOXVUMU4zSWl3Z0ltbGtJaXdnSW1oMGRIQnpPaTh2WlhoaGJYQnNaUzV2Y21jdlpYaGhiWEJzWlhNdlpHVm5jbVZsTG1wemIyNGlYUX5XeUpETWxwV2VrdG1aMTg1UlVoMWFqQjJTMUV4ZFdKbklpd2dJblI1Y0dVaUxDQWlTbk52YmxOamFHVnRZU0pkfld5SjZTemQ1UWxGUGJGaGZYMlEwWDBWb1lVYzBZMHBSSWl3Z0ltbGtJaXdnSW1ScFpEcGxlR0Z0Y0d4bE9qRXlNeUpkfld5SjZiMXB6UnpNemVYQk1lVlJHTW05YVMzWm1NVkZuSWl3Z0luUjVjR1VpTENBaVFtRmphR1ZzYjNKRVpXZHlaV1VpWFF-Il0</span>~
 </div>
     </div>
-    <div class="sd-jwt-tab-content" id="sd-jwt-5-uxcfkkd-content-decoded">
+    <div class="sd-jwt-tab-content" id="sd-jwt-5-mmo9tvs-content-decoded">
       <pre class="header-value">{<br>&nbsp;&nbsp;"kid":&nbsp;"ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",<br>&nbsp;&nbsp;"alg":&nbsp;"ES256"<br>}</pre>
-      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745565979,<br>&nbsp;&nbsp;"exp":&nbsp;1746775579,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"verifiableCredential":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"@context":&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Rq6iV3DXIIwGRh20Vl0c_b1nE-GRxiINZLN4qv75hvI",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"w38_yY_uLQzf7X3_0S7sefgR9N9gNs3jD7U3kEuSX-o"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"tAx-57l06U3g8SvcQYt_2wrzn19Bl2I46nz58boCpOc"<br>&nbsp;&nbsp;]<br>}</pre>
+      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745594772,<br>&nbsp;&nbsp;"exp":&nbsp;1746804372,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"verifiableCredential":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"@context":&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"-TVRU6yQRkVF-5q086cXufxFu8vp4AZJO-h_U8zyF_Q",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"agL1w9EKxK0l6qVKx79DkuyGFh2szgHG9Rf0kG_2nug"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"RzTr8zM0p1-0rwhLws02_I30D8G6kpDPFlOFgag0ya0"<br>&nbsp;&nbsp;]<br>}</pre>
     </div>
-    <div class="sd-jwt-tab-content" id="sd-jwt-5-uxcfkkd-content-disclosures">
+    <div class="sd-jwt-tab-content" id="sd-jwt-5-mmo9tvs-content-disclosures">
       <div class="disclosures">
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-tAx-57l06U3g8SvcQYt_2wrzn19Bl2I46nz58boCpOc">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">tAx-57l06U3g8SvcQYt_2wrzn19Bl2I46nz58boCpOc</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJRU0U0eVZzYk1kU3E1dE8yR0NiR3J3IiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"QSE4yVsbMdSq5tO2GCbGrw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"VerifiablePresentation"<br>]</span></p>
+    <h3 id="sd-jwt-claim-RzTr8zM0p1-0rwhLws02_I30D8G6kpDPFlOFgag0ya0">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">RzTr8zM0p1-0rwhLws02_I30D8G6kpDPFlOFgag0ya0</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyIwempCdDNBa0VRd0tJbllMNmhvX0lBIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"0zjBt3AkEQwKInYL6ho_IA",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"VerifiablePresentation"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-Rq6iV3DXIIwGRh20Vl0c_b1nE-GRxiINZLN4qv75hvI">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">Rq6iV3DXIIwGRh20Vl0c_b1nE-GRxiINZLN4qv75hvI</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ1bko3emplY3ByVG8wZHkyWTBGZkFRIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"unJ7zjecprTo0dy2Y0FfAQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiableCredential"<br>]</span></p>
+    <h3 id="sd-jwt-claim-agL1w9EKxK0l6qVKx79DkuyGFh2szgHG9Rf0kG_2nug">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">agL1w9EKxK0l6qVKx79DkuyGFh2szgHG9Rf0kG_2nug</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJHRXRVYzJuSS1Qd2xMYVhZM19Wd2p3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"GEtUc2nI-PwlLaXY3_Vwjw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiableCredential"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-w38_yY_uLQzf7X3_0S7sefgR9N9gNs3jD7U3kEuSX-o">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">w38_yY_uLQzf7X3_0S7sefgR9N9gNs3jD7U3kEuSX-o</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJIaVJySEowSmNzWjlsQ2xGZk9LSUp3IiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleUpyYVdRaU9pSkZlRWhyUWsxWE9XWnRZbXQyVmpJMk5tMVNjSFZRTW5OVldWOU9YMFZYU1U0eGJHRndWWHBQT0hKdklpd2lZV3huSWpvaVJWTXlOVFlpZlEuZXlKZmMyUmZZV3huSWpvaWMyaGhMVEkxTmlJc0lrQmpiMjUwWlhoMElqcGJJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OTJNaUlzSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk5dWN5OWpjbVZrWlc1MGFXRnNjeTlsZUdGdGNHeGxjeTkyTWlKZExDSnBjM04xWlhJaU9pSm9kSFJ3Y3pvdkwzVnVhWFpsY25OcGRIa3VaWGhoYlhCc1pTOXBjM04xWlhKekx6VTJOVEEwT1NJc0luWmhiR2xrUm5KdmJTSTZJakl3TVRBdE1ERXRNREZVTVRrNk1qTTZNalJhSWl3aVkzSmxaR1Z1ZEdsaGJGTmphR1Z0WVNJNmV5SmZjMlFpT2xzaU5qVkZMVlpaYm1FM1VFNW1TR1ZzVURONlRIRndjRTVFUlhoU0xXaGpXa2hTVG5seE4yVTBaVmRhYnlJc0lqaEpiRXd0VUd4NFVrdDNTMGhMYVRNdFRYaFhNak00ZDBGa1RtUTBOSGRhYkMxaVkzTkJjMkpJUWpBaVhYMHNJbU55WldSbGJuUnBZV3hUZFdKcVpXTjBJanA3SW1SbFozSmxaU0k2ZXlKdVlXMWxJam9pUW1GamFHVnNiM0lnYjJZZ1UyTnBaVzVqWlNCaGJtUWdRWEowY3lJc0lsOXpaQ0k2V3lKTVZYaHFjV3RzV1MxaGREVlNWbUZvU1hweE0zTkpaMDE1ZGtkd1ZEbHdkbFV3ZFRSeVUya3RNWGwzSWwxOUxDSmZjMlFpT2xzaVZteFpMVzUwWmtsUE9VSTVSR1JzVVdwNVUyUkVNbGRvVldJMGJqYzNabDlIV0RaMlUxZExRV3BDTkNKZGZTd2lYM05rSWpwYklpMWlSRVo0VW05NFVVVmxjRWRqWkZsNmEyNTBhVFZHV1hCc1VUVTVOMGRqYUVkVVRHVnRMVkpTWTFVaUxDSmZSRUZWWjB4clRGOXpWa1Z0TFRCdmNFOHphV2hwZVZGaFMwWnpUMDh4VWw5T05rMUNVbXByT1doRklsMTkuS2MwODNSS2JCeGMzVnI1cVIzaUVFUHAzZEt4VGE2c1BhV05zcXRrSXc4VHZNUmY5RVpMMmFqdGdrV1NCWXp5ek96YXdPckNYcnl5cDRyTVR5STl2ZkEgfld5SmlRMVJUYVU5SE5VbzFWWGhQWTFRd1VsTmZkMDFuSWl3Z0ltbGtJaXdnSW1oMGRIQTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2WTNKbFpHVnVkR2xoYkhNdk1UZzNNaUpkfld5SlRjbE5XTVMwMVNqUjZjV2hPVTNOM1NUSXdhSGRSSWl3Z0luUjVjR1VpTENCYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdnSWtWNFlXMXdiR1ZCYkhWdGJtbERjbVZrWlc1MGFXRnNJbDFkfld5SktYMjk0ZERodFVHVXRhRGw0TWtRemMyOXVUMU4zSWl3Z0ltbGtJaXdnSW1oMGRIQnpPaTh2WlhoaGJYQnNaUzV2Y21jdlpYaGhiWEJzWlhNdlpHVm5jbVZsTG1wemIyNGlYUX5XeUpETWxwV2VrdG1aMTg1UlVoMWFqQjJTMUV4ZFdKbklpd2dJblI1Y0dVaUxDQWlTbk52YmxOamFHVnRZU0pkfld5SjZTemQ1UWxGUGJGaGZYMlEwWDBWb1lVYzBZMHBSSWl3Z0ltbGtJaXdnSW1ScFpEcGxlR0Z0Y0d4bE9qRXlNeUpkfld5SjZiMXB6UnpNemVYQk1lVlJHTW05YVMzWm1NVkZuSWl3Z0luUjVjR1VpTENBaVFtRmphR1ZzYjNKRVpXZHlaV1VpWFF-Il0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"HiRrHJ0JcsZ9lClFfOKIJw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vc+sd-jwt,&nbsp;eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJfc2RfYWxnIjoic2hhLTI1NiIsIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiNjVFLVZZbmE3UE5mSGVsUDN6THFwcE5ERXhSLWhjWkhSTnlxN2U0ZVdabyIsIjhJbEwtUGx4Ukt3S0hLaTMtTXhXMjM4d0FkTmQ0NHdabC1iY3NBc2JIQjAiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJuYW1lIjoiQmFjaGVsb3Igb2YgU2NpZW5jZSBhbmQgQXJ0cyIsIl9zZCI6WyJMVXhqcWtsWS1hdDVSVmFoSXpxM3NJZ015dkdwVDlwdlUwdTRyU2ktMXl3Il19LCJfc2QiOlsiVmxZLW50ZklPOUI5RGRsUWp5U2REMldoVWI0bjc3Zl9HWDZ2U1dLQWpCNCJdfSwiX3NkIjpbIi1iREZ4Um94UUVlcEdjZFl6a250aTVGWXBsUTU5N0djaEdUTGVtLVJSY1UiLCJfREFVZ0xrTF9zVkVtLTBvcE8zaWhpeVFhS0ZzT08xUl9ONk1CUmprOWhFIl19.Kc083RKbBxc3Vr5qR3iEEPp3dKxTa6sPaWNsqtkIw8TvMRf9EZL2ajtgkWSBYzyzOzawOrCXryyp4rMTyI9vfA&nbsp;~WyJiQ1RTaU9HNUo1VXhPY1QwUlNfd01nIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJTclNWMS01SjR6cWhOU3N3STIwaHdRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJKX294dDhtUGUtaDl4MkQzc29uT1N3IiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJDMlpWektmZ185RUh1ajB2S1ExdWJnIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJ6Szd5QlFPbFhfX2Q0X0VoYUc0Y0pRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyJ6b1pzRzMzeXBMeVRGMm9aS3ZmMVFnIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~"<br>]</span></p>
+    <h3 id="sd-jwt-claim--TVRU6yQRkVF-5q086cXufxFu8vp4AZJO-h_U8zyF_Q">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">-TVRU6yQRkVF-5q086cXufxFu8vp4AZJO-h_U8zyF_Q</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJRenl4OTJ5azNZQ2tyZmdRejZQVHVnIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleUpyYVdRaU9pSkZlRWhyUWsxWE9XWnRZbXQyVmpJMk5tMVNjSFZRTW5OVldWOU9YMFZYU1U0eGJHRndWWHBQT0hKdklpd2lZV3huSWpvaVJWTXlOVFlpZlEuZXlKZmMyUmZZV3huSWpvaWMyaGhMVEkxTmlJc0lrQmpiMjUwWlhoMElqcGJJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OTJNaUlzSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk5dWN5OWpjbVZrWlc1MGFXRnNjeTlsZUdGdGNHeGxjeTkyTWlKZExDSnBjM04xWlhJaU9pSm9kSFJ3Y3pvdkwzVnVhWFpsY25OcGRIa3VaWGhoYlhCc1pTOXBjM04xWlhKekx6VTJOVEEwT1NJc0luWmhiR2xrUm5KdmJTSTZJakl3TVRBdE1ERXRNREZVTVRrNk1qTTZNalJhSWl3aVkzSmxaR1Z1ZEdsaGJGTmphR1Z0WVNJNmV5SmZjMlFpT2xzaU5qVkZMVlpaYm1FM1VFNW1TR1ZzVURONlRIRndjRTVFUlhoU0xXaGpXa2hTVG5seE4yVTBaVmRhYnlJc0lqaEpiRXd0VUd4NFVrdDNTMGhMYVRNdFRYaFhNak00ZDBGa1RtUTBOSGRhYkMxaVkzTkJjMkpJUWpBaVhYMHNJbU55WldSbGJuUnBZV3hUZFdKcVpXTjBJanA3SW1SbFozSmxaU0k2ZXlKdVlXMWxJam9pUW1GamFHVnNiM0lnYjJZZ1UyTnBaVzVqWlNCaGJtUWdRWEowY3lJc0lsOXpaQ0k2V3lKTVZYaHFjV3RzV1MxaGREVlNWbUZvU1hweE0zTkpaMDE1ZGtkd1ZEbHdkbFV3ZFRSeVUya3RNWGwzSWwxOUxDSmZjMlFpT2xzaVZteFpMVzUwWmtsUE9VSTVSR1JzVVdwNVUyUkVNbGRvVldJMGJqYzNabDlIV0RaMlUxZExRV3BDTkNKZGZTd2lYM05rSWpwYklpMWlSRVo0VW05NFVVVmxjRWRqWkZsNmEyNTBhVFZHV1hCc1VUVTVOMGRqYUVkVVRHVnRMVkpTWTFVaUxDSmZSRUZWWjB4clRGOXpWa1Z0TFRCdmNFOHphV2hwZVZGaFMwWnpUMDh4VWw5T05rMUNVbXByT1doRklsMTkuS2MwODNSS2JCeGMzVnI1cVIzaUVFUHAzZEt4VGE2c1BhV05zcXRrSXc4VHZNUmY5RVpMMmFqdGdrV1NCWXp5ek96YXdPckNYcnl5cDRyTVR5STl2ZkEgfld5SmlRMVJUYVU5SE5VbzFWWGhQWTFRd1VsTmZkMDFuSWl3Z0ltbGtJaXdnSW1oMGRIQTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2WTNKbFpHVnVkR2xoYkhNdk1UZzNNaUpkfld5SlRjbE5XTVMwMVNqUjZjV2hPVTNOM1NUSXdhSGRSSWl3Z0luUjVjR1VpTENCYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdnSWtWNFlXMXdiR1ZCYkhWdGJtbERjbVZrWlc1MGFXRnNJbDFkfld5SktYMjk0ZERodFVHVXRhRGw0TWtRemMyOXVUMU4zSWl3Z0ltbGtJaXdnSW1oMGRIQnpPaTh2WlhoaGJYQnNaUzV2Y21jdlpYaGhiWEJzWlhNdlpHVm5jbVZsTG1wemIyNGlYUX5XeUpETWxwV2VrdG1aMTg1UlVoMWFqQjJTMUV4ZFdKbklpd2dJblI1Y0dVaUxDQWlTbk52YmxOamFHVnRZU0pkfld5SjZTemQ1UWxGUGJGaGZYMlEwWDBWb1lVYzBZMHBSSWl3Z0ltbGtJaXdnSW1ScFpEcGxlR0Z0Y0d4bE9qRXlNeUpkfld5SjZiMXB6UnpNemVYQk1lVlJHTW05YVMzWm1NVkZuSWl3Z0luUjVjR1VpTENBaVFtRmphR1ZzYjNKRVpXZHlaV1VpWFF-Il0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"Qzyx92yk3YCkrfgQz6PTug",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vc+sd-jwt,&nbsp;eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJfc2RfYWxnIjoic2hhLTI1NiIsIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiNjVFLVZZbmE3UE5mSGVsUDN6THFwcE5ERXhSLWhjWkhSTnlxN2U0ZVdabyIsIjhJbEwtUGx4Ukt3S0hLaTMtTXhXMjM4d0FkTmQ0NHdabC1iY3NBc2JIQjAiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJuYW1lIjoiQmFjaGVsb3Igb2YgU2NpZW5jZSBhbmQgQXJ0cyIsIl9zZCI6WyJMVXhqcWtsWS1hdDVSVmFoSXpxM3NJZ015dkdwVDlwdlUwdTRyU2ktMXl3Il19LCJfc2QiOlsiVmxZLW50ZklPOUI5RGRsUWp5U2REMldoVWI0bjc3Zl9HWDZ2U1dLQWpCNCJdfSwiX3NkIjpbIi1iREZ4Um94UUVlcEdjZFl6a250aTVGWXBsUTU5N0djaEdUTGVtLVJSY1UiLCJfREFVZ0xrTF9zVkVtLTBvcE8zaWhpeVFhS0ZzT08xUl9ONk1CUmprOWhFIl19.Kc083RKbBxc3Vr5qR3iEEPp3dKxTa6sPaWNsqtkIw8TvMRf9EZL2ajtgkWSBYzyzOzawOrCXryyp4rMTyI9vfA&nbsp;~WyJiQ1RTaU9HNUo1VXhPY1QwUlNfd01nIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJTclNWMS01SjR6cWhOU3N3STIwaHdRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJKX294dDhtUGUtaDl4MkQzc29uT1N3IiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJDMlpWektmZ185RUh1ajB2S1ExdWJnIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJ6Szd5QlFPbFhfX2Q0X0VoYUc0Y0pRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyJ6b1pzRzMzeXBMeVRGMm9aS3ZmMVFnIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~"<br>]</span></p>
 </div>
 </div>
     </div>
@@ -2144,48 +2110,48 @@ li.sd-jwt-tab {
 }</pre></div><div class="vc-tab-content" style="min-height: 173px;"><div>
 
 <div class="sd-jwt-tabbed">
-    <input type="radio" id="sd-jwt-6-kh1fl6x-encoded" name="sd-jwt-6-kh1fl6x-tabs" checked="checked" tabindex="0">
-    <input type="radio" id="sd-jwt-6-kh1fl6x-decoded" name="sd-jwt-6-kh1fl6x-tabs" tabindex="0">
-    <input type="radio" id="sd-jwt-6-kh1fl6x-disclosures" name="sd-jwt-6-kh1fl6x-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-6-gcb7lcu-encoded" name="sd-jwt-6-gcb7lcu-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="sd-jwt-6-gcb7lcu-decoded" name="sd-jwt-6-gcb7lcu-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-6-gcb7lcu-disclosures" name="sd-jwt-6-gcb7lcu-tabs" tabindex="0">
     <ul class="sd-jwt-tabs">
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-6-kh1fl6x-encoded">Encoded</label>
+        <label for="sd-jwt-6-gcb7lcu-encoded">Encoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-6-kh1fl6x-decoded">Decoded</label>
+        <label for="sd-jwt-6-gcb7lcu-decoded">Decoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-6-kh1fl6x-disclosures">Issuer Disclosures</label>
+        <label for="sd-jwt-6-gcb7lcu-disclosures">Issuer Disclosures</label>
       </li>
     </ul>
-    <div class="sd-jwt-tab-content" id="sd-jwt-6-kh1fl6x-content-encoded">
+    <div class="sd-jwt-tab-content" id="sd-jwt-6-gcb7lcu-content-encoded">
       
 <div class="sd-jwt-compact">
 <span class="sd-jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
-.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1NjU5NzksImV4cCI6MTc0Njc3NTU3OSwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiX3NkIjpbIlpTOTNQQ0xvWkpmQm1YanM4cjVLeXlULU14MVpKb2YwYnViZW9GZmFFalkiLCJ2c3VPYy13Y3JpZWhSVnNXVk55NWhrbHBweTQ2SmdDc05LUzNyN3A5eWhRIl19</span>
-.<span class="sd-jwt-signature">RYVsmuhUJJYVTLrVZUUBjU2gfBk_rG1k-w7yVWWKXcvi4Px4OxqMepgWuAiGu9H0upLFqP1gHCn-2BBgyGlwxw</span>
-~<span class="sd-jwt-disclosure">WyJGUXI4Qm9IT00xbF84QVV3YkkyYlBRIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span>~<span class="sd-jwt-disclosure">WyJTa0ViejVQRjNxTDU1Vy1sZWhISFhRIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdnArc2Qtand0LCBleUpoYkdjaU9pSkZVek00TkNJc0ltdHBaQ0k2SWxWUlRWOWZibEUwVXpaQ1R6aHVVVFJ1VDA1WWVIQjRhSFJvYjNsT2VHSTFNMHhaWjFsNkxUSkJRbk1pTENKMGVYQWlPaUoyY0N0c1pDdHFjMjl1SzNOa0xXcDNkQ0lzSW1OMGVTSTZJblp3SzJ4a0sycHpiMjRpZlEuZXlKQVkyOXVkR1Y0ZENJNld5Sm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdmRqSWlMQ0pvZEhSd2N6b3ZMM2QzZHk1M015NXZjbWN2Ym5NdlkzSmxaR1Z1ZEdsaGJITXZaWGhoYlhCc1pYTXZkaklpWFN3aWRtVnlhV1pwWVdKc1pVTnlaV1JsYm5ScFlXd2lPbHQ3SWtCamIyNTBaWGgwSWpwYkltaDBkSEJ6T2k4dmQzZDNMbmN6TG05eVp5OXVjeTlqY21Wa1pXNTBhV0ZzY3k5Mk1pSXNJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OWxlR0Z0Y0d4bGN5OTJNaUpkTENKcGMzTjFaWElpT2lKb2RIUndjem92TDNWdWFYWmxjbk5wZEhrdVpYaGhiWEJzWlM5cGMzTjFaWEp6THpVMk5UQTBPU0lzSW5aaGJHbGtSbkp2YlNJNklqSXdNVEF0TURFdE1ERlVNVGs2TWpNNk1qUmFJaXdpWTNKbFpHVnVkR2xoYkZOMVltcGxZM1FpT25zaVlXeDFiVzVwVDJZaU9uc2libUZ0WlNJNklrVjRZVzF3YkdVZ1ZXNXBkbVZ5YzJsMGVTSXNJbDl6WkNJNld5Sm9lazlMUnpVMmNESTVjMUJ5VEdGRE5VRTRSbmRGZFVjelZVMDVkVWxaVTFwMWNVOVljekpsVkdKQklsMTlMQ0pmYzJRaU9sc2lXVmRYVm1WRFJuZHhRbWs0V0RCcVNGOWpWME5XV1UxNlNUTmhPSEJqVEVWWVJXWmljRk5TUVZsbmR5SmRmU3dpWDNOa0lqcGJJakpKWmpoaGFVczRSRVp3VldKNGRFYzFjR013ZWw5U2FGSnpibTF5YkdGUk1FaHpjVGs0V0ZOeVlXc2lMQ0pVZURaNFpXWk1WVWRVWlVwZllXdFZVRmRHZUhOdmJVaG9iR3RXVm5wZk56Vm9hVlo2ZVdweVltVnpJbDE5WFN3aVgzTmtJanBiSWpkMmFubDBWVk4zWkVKME1YUTVSa3RsT1ZGZlMzSklSWGhGV0d4clRFRmFUekJLTTBKcGQyMDBkbGtpWFN3aVgzTmtYMkZzWnlJNkluTm9ZUzB5TlRZaUxDSnBZWFFpT2pFM01EWTFOakk0TkRrc0ltVjRjQ0k2TVRjek9ERTROVEkwT1N3aVkyNW1JanA3SW1wM2F5STZleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TXpnMElpd2lZV3huSWpvaVJWTXpPRFFpTENKNElqb2lkV3RFZDFVMlp6bFFVVlJGVVdoWWFFZ3lja1JaTm5kTVFsZzNVSEZsVWpaQmNHbGhWSEJFVVhvd2NsOHRkRGw2VVhOeGVtNTRaMGhFY0U1b2VrWmxReUlzSW5raU9pSk1RbmhWWW5CVmRGTkdNVlZLVlRWcFluSklka3BJTmpCVVNHNVlNazF4YTB4SFpHbHRVMWwwVUdSNFJsa3hPRWRoY2xkaVMzRlpWMGRqVWtaSFZFOUJJbjE5ZlEua1lENjNZdEJOWW5MVVR3NlN6ZjF2c19VZzNVQlhoUHdDeXFwTm1QblBEYTNyWFpRaFFMZEIxQmdhb084emdRLWMzQjQxZnhhWE1uTEhZVjktQjIwdWJvU3BKUDBCLTJWcmU5MTdlUXQxY1NEc3dER0FfWXR2bjRCU3FZVkJCMkp-V3lKRk1rRnNSemhzWTJwMFFWRnJjbGxJYmpsSWJuVlJJaXdnSW5SNWNHVWlMQ0FpVm1WeWFXWnBZV0pzWlZCeVpYTmxiblJoZEdsdmJpSmR-V3lJNU5sZFlNRFJuZW5vNGNWWnpPVlpMVTJ3d1lUVm5JaXdnSW1sa0lpd2dJbWgwZEhBNkx5OTFibWwyWlhKemFYUjVMbVY0WVcxd2JHVXZZM0psWkdWdWRHbGhiSE12TVRnM01pSmR-V3lKYWVrVTJWRlZhYW10SE1XMURXWEJLTUVobmMwbDNJaXdnSW5SNWNHVWlMQ0JiSWxabGNtbG1hV0ZpYkdWRGNtVmtaVzUwYVdGc0lpd2dJa1Y0WVcxd2JHVkJiSFZ0Ym1sRGNtVmtaVzUwYVdGc0lsMWR-V3lJdFEzTnNTMjVHWkdGWWIySmlRV3N5VTBKQlZHUjNJaXdnSW1sa0lpd2dJbVJwWkRwbGVHRnRjR3hsT21WaVptVmlNV1kzTVRKbFltTTJaakZqTWpjMlpURXlaV015TVNKZH5XeUp1Um0xT1dsOUljekIzV1dOb09GZGtlVGRuUVVOUklpd2dJbWxrSWl3Z0ltUnBaRHBsZUdGdGNHeGxPbU15TnpabE1USmxZekl4WldKbVpXSXhaamN4TW1WaVl6Wm1NU0pkfiJd</span>~
+.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1OTQ3NzIsImV4cCI6MTc0NjgwNDM3MiwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiX3NkIjpbIjNoUmczNzNhVEhVblI0b2NrMkNBU2EzeHdpaVdlOGVVUndWNU1GVFA3dlEiLCJXb2J4dDdHZ1VtRVpKaEJJZGkyb1NyaDN4aEtqak5Xa0Rnc2t4M0RJNmtnIl19</span>
+.<span class="sd-jwt-signature">789HJKTur9F0FpxUR_EUk8SudozGvoayr83QyxuoiDbP7BudeJMibmU_CWB_AGSVR5XNDMlqJW4XLvj3XQ3WCw</span>
+~<span class="sd-jwt-disclosure">WyJZM3JRNVNkUFd3YW5ieTRlMGhMSDF3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span>~<span class="sd-jwt-disclosure">WyJFUWRUZEprS3Fjd3RrMkVVMUxkOTZnIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdnArc2Qtand0LCBleUpoYkdjaU9pSkZVek00TkNJc0ltdHBaQ0k2SWxWUlRWOWZibEUwVXpaQ1R6aHVVVFJ1VDA1WWVIQjRhSFJvYjNsT2VHSTFNMHhaWjFsNkxUSkJRbk1pTENKMGVYQWlPaUoyY0N0c1pDdHFjMjl1SzNOa0xXcDNkQ0lzSW1OMGVTSTZJblp3SzJ4a0sycHpiMjRpZlEuZXlKQVkyOXVkR1Y0ZENJNld5Sm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdmRqSWlMQ0pvZEhSd2N6b3ZMM2QzZHk1M015NXZjbWN2Ym5NdlkzSmxaR1Z1ZEdsaGJITXZaWGhoYlhCc1pYTXZkaklpWFN3aWRtVnlhV1pwWVdKc1pVTnlaV1JsYm5ScFlXd2lPbHQ3SWtCamIyNTBaWGgwSWpwYkltaDBkSEJ6T2k4dmQzZDNMbmN6TG05eVp5OXVjeTlqY21Wa1pXNTBhV0ZzY3k5Mk1pSXNJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OWxlR0Z0Y0d4bGN5OTJNaUpkTENKcGMzTjFaWElpT2lKb2RIUndjem92TDNWdWFYWmxjbk5wZEhrdVpYaGhiWEJzWlM5cGMzTjFaWEp6THpVMk5UQTBPU0lzSW5aaGJHbGtSbkp2YlNJNklqSXdNVEF0TURFdE1ERlVNVGs2TWpNNk1qUmFJaXdpWTNKbFpHVnVkR2xoYkZOMVltcGxZM1FpT25zaVlXeDFiVzVwVDJZaU9uc2libUZ0WlNJNklrVjRZVzF3YkdVZ1ZXNXBkbVZ5YzJsMGVTSXNJbDl6WkNJNld5Sm9lazlMUnpVMmNESTVjMUJ5VEdGRE5VRTRSbmRGZFVjelZVMDVkVWxaVTFwMWNVOVljekpsVkdKQklsMTlMQ0pmYzJRaU9sc2lXVmRYVm1WRFJuZHhRbWs0V0RCcVNGOWpWME5XV1UxNlNUTmhPSEJqVEVWWVJXWmljRk5TUVZsbmR5SmRmU3dpWDNOa0lqcGJJakpKWmpoaGFVczRSRVp3VldKNGRFYzFjR013ZWw5U2FGSnpibTF5YkdGUk1FaHpjVGs0V0ZOeVlXc2lMQ0pVZURaNFpXWk1WVWRVWlVwZllXdFZVRmRHZUhOdmJVaG9iR3RXVm5wZk56Vm9hVlo2ZVdweVltVnpJbDE5WFN3aVgzTmtJanBiSWpkMmFubDBWVk4zWkVKME1YUTVSa3RsT1ZGZlMzSklSWGhGV0d4clRFRmFUekJLTTBKcGQyMDBkbGtpWFN3aVgzTmtYMkZzWnlJNkluTm9ZUzB5TlRZaUxDSnBZWFFpT2pFM01EWTFOakk0TkRrc0ltVjRjQ0k2TVRjek9ERTROVEkwT1N3aVkyNW1JanA3SW1wM2F5STZleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TXpnMElpd2lZV3huSWpvaVJWTXpPRFFpTENKNElqb2lkV3RFZDFVMlp6bFFVVlJGVVdoWWFFZ3lja1JaTm5kTVFsZzNVSEZsVWpaQmNHbGhWSEJFVVhvd2NsOHRkRGw2VVhOeGVtNTRaMGhFY0U1b2VrWmxReUlzSW5raU9pSk1RbmhWWW5CVmRGTkdNVlZLVlRWcFluSklka3BJTmpCVVNHNVlNazF4YTB4SFpHbHRVMWwwVUdSNFJsa3hPRWRoY2xkaVMzRlpWMGRqVWtaSFZFOUJJbjE5ZlEua1lENjNZdEJOWW5MVVR3NlN6ZjF2c19VZzNVQlhoUHdDeXFwTm1QblBEYTNyWFpRaFFMZEIxQmdhb084emdRLWMzQjQxZnhhWE1uTEhZVjktQjIwdWJvU3BKUDBCLTJWcmU5MTdlUXQxY1NEc3dER0FfWXR2bjRCU3FZVkJCMkp-V3lKRk1rRnNSemhzWTJwMFFWRnJjbGxJYmpsSWJuVlJJaXdnSW5SNWNHVWlMQ0FpVm1WeWFXWnBZV0pzWlZCeVpYTmxiblJoZEdsdmJpSmR-V3lJNU5sZFlNRFJuZW5vNGNWWnpPVlpMVTJ3d1lUVm5JaXdnSW1sa0lpd2dJbWgwZEhBNkx5OTFibWwyWlhKemFYUjVMbVY0WVcxd2JHVXZZM0psWkdWdWRHbGhiSE12TVRnM01pSmR-V3lKYWVrVTJWRlZhYW10SE1XMURXWEJLTUVobmMwbDNJaXdnSW5SNWNHVWlMQ0JiSWxabGNtbG1hV0ZpYkdWRGNtVmtaVzUwYVdGc0lpd2dJa1Y0WVcxd2JHVkJiSFZ0Ym1sRGNtVmtaVzUwYVdGc0lsMWR-V3lJdFEzTnNTMjVHWkdGWWIySmlRV3N5VTBKQlZHUjNJaXdnSW1sa0lpd2dJbVJwWkRwbGVHRnRjR3hsT21WaVptVmlNV1kzTVRKbFltTTJaakZqTWpjMlpURXlaV015TVNKZH5XeUp1Um0xT1dsOUljekIzV1dOb09GZGtlVGRuUVVOUklpd2dJbWxrSWl3Z0ltUnBaRHBsZUdGdGNHeGxPbU15TnpabE1USmxZekl4WldKbVpXSXhaamN4TW1WaVl6Wm1NU0pkfiJd</span>~
 </div>
     </div>
-    <div class="sd-jwt-tab-content" id="sd-jwt-6-kh1fl6x-content-decoded">
+    <div class="sd-jwt-tab-content" id="sd-jwt-6-gcb7lcu-content-decoded">
       <pre class="header-value">{<br>&nbsp;&nbsp;"kid":&nbsp;"ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",<br>&nbsp;&nbsp;"alg":&nbsp;"ES256"<br>}</pre>
-      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745565979,<br>&nbsp;&nbsp;"exp":&nbsp;1746775579,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"ZS93PCLoZJfBmXjs8r5KyyT-Mx1ZJof0bubeoFfaEjY",<br>&nbsp;&nbsp;&nbsp;&nbsp;"vsuOc-wcriehRVsWVNy5hklppy46JgCsNKS3r7p9yhQ"<br>&nbsp;&nbsp;]<br>}</pre>
+      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745594772,<br>&nbsp;&nbsp;"exp":&nbsp;1746804372,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"3hRg373aTHUnR4ock2CASa3xwiiWe8eURwV5MFTP7vQ",<br>&nbsp;&nbsp;&nbsp;&nbsp;"Wobxt7GgUmEZJhBIdi2oSrh3xhKjjNWkDgskx3DI6kg"<br>&nbsp;&nbsp;]<br>}</pre>
     </div>
-    <div class="sd-jwt-tab-content" id="sd-jwt-6-kh1fl6x-content-disclosures">
+    <div class="sd-jwt-tab-content" id="sd-jwt-6-gcb7lcu-content-disclosures">
       <div class="disclosures">
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-vsuOc-wcriehRVsWVNy5hklppy46JgCsNKS3r7p9yhQ">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">vsuOc-wcriehRVsWVNy5hklppy46JgCsNKS3r7p9yhQ</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJGUXI4Qm9IT00xbF84QVV3YkkyYlBRIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"FQr8BoHOM1l_8AUwbI2bPQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiablePresentation"<br>]</span></p>
+    <h3 id="sd-jwt-claim-3hRg373aTHUnR4ock2CASa3xwiiWe8eURwV5MFTP7vQ">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">3hRg373aTHUnR4ock2CASa3xwiiWe8eURwV5MFTP7vQ</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJZM3JRNVNkUFd3YW5ieTRlMGhMSDF3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"Y3rQ5SdPWwanby4e0hLH1w",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiablePresentation"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-ZS93PCLoZJfBmXjs8r5KyyT-Mx1ZJof0bubeoFfaEjY">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">ZS93PCLoZJfBmXjs8r5KyyT-Mx1ZJof0bubeoFfaEjY</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJTa0ViejVQRjNxTDU1Vy1sZWhISFhRIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdnArc2Qtand0LCBleUpoYkdjaU9pSkZVek00TkNJc0ltdHBaQ0k2SWxWUlRWOWZibEUwVXpaQ1R6aHVVVFJ1VDA1WWVIQjRhSFJvYjNsT2VHSTFNMHhaWjFsNkxUSkJRbk1pTENKMGVYQWlPaUoyY0N0c1pDdHFjMjl1SzNOa0xXcDNkQ0lzSW1OMGVTSTZJblp3SzJ4a0sycHpiMjRpZlEuZXlKQVkyOXVkR1Y0ZENJNld5Sm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdmRqSWlMQ0pvZEhSd2N6b3ZMM2QzZHk1M015NXZjbWN2Ym5NdlkzSmxaR1Z1ZEdsaGJITXZaWGhoYlhCc1pYTXZkaklpWFN3aWRtVnlhV1pwWVdKc1pVTnlaV1JsYm5ScFlXd2lPbHQ3SWtCamIyNTBaWGgwSWpwYkltaDBkSEJ6T2k4dmQzZDNMbmN6TG05eVp5OXVjeTlqY21Wa1pXNTBhV0ZzY3k5Mk1pSXNJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OWxlR0Z0Y0d4bGN5OTJNaUpkTENKcGMzTjFaWElpT2lKb2RIUndjem92TDNWdWFYWmxjbk5wZEhrdVpYaGhiWEJzWlM5cGMzTjFaWEp6THpVMk5UQTBPU0lzSW5aaGJHbGtSbkp2YlNJNklqSXdNVEF0TURFdE1ERlVNVGs2TWpNNk1qUmFJaXdpWTNKbFpHVnVkR2xoYkZOMVltcGxZM1FpT25zaVlXeDFiVzVwVDJZaU9uc2libUZ0WlNJNklrVjRZVzF3YkdVZ1ZXNXBkbVZ5YzJsMGVTSXNJbDl6WkNJNld5Sm9lazlMUnpVMmNESTVjMUJ5VEdGRE5VRTRSbmRGZFVjelZVMDVkVWxaVTFwMWNVOVljekpsVkdKQklsMTlMQ0pmYzJRaU9sc2lXVmRYVm1WRFJuZHhRbWs0V0RCcVNGOWpWME5XV1UxNlNUTmhPSEJqVEVWWVJXWmljRk5TUVZsbmR5SmRmU3dpWDNOa0lqcGJJakpKWmpoaGFVczRSRVp3VldKNGRFYzFjR013ZWw5U2FGSnpibTF5YkdGUk1FaHpjVGs0V0ZOeVlXc2lMQ0pVZURaNFpXWk1WVWRVWlVwZllXdFZVRmRHZUhOdmJVaG9iR3RXVm5wZk56Vm9hVlo2ZVdweVltVnpJbDE5WFN3aVgzTmtJanBiSWpkMmFubDBWVk4zWkVKME1YUTVSa3RsT1ZGZlMzSklSWGhGV0d4clRFRmFUekJLTTBKcGQyMDBkbGtpWFN3aVgzTmtYMkZzWnlJNkluTm9ZUzB5TlRZaUxDSnBZWFFpT2pFM01EWTFOakk0TkRrc0ltVjRjQ0k2TVRjek9ERTROVEkwT1N3aVkyNW1JanA3SW1wM2F5STZleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TXpnMElpd2lZV3huSWpvaVJWTXpPRFFpTENKNElqb2lkV3RFZDFVMlp6bFFVVlJGVVdoWWFFZ3lja1JaTm5kTVFsZzNVSEZsVWpaQmNHbGhWSEJFVVhvd2NsOHRkRGw2VVhOeGVtNTRaMGhFY0U1b2VrWmxReUlzSW5raU9pSk1RbmhWWW5CVmRGTkdNVlZLVlRWcFluSklka3BJTmpCVVNHNVlNazF4YTB4SFpHbHRVMWwwVUdSNFJsa3hPRWRoY2xkaVMzRlpWMGRqVWtaSFZFOUJJbjE5ZlEua1lENjNZdEJOWW5MVVR3NlN6ZjF2c19VZzNVQlhoUHdDeXFwTm1QblBEYTNyWFpRaFFMZEIxQmdhb084emdRLWMzQjQxZnhhWE1uTEhZVjktQjIwdWJvU3BKUDBCLTJWcmU5MTdlUXQxY1NEc3dER0FfWXR2bjRCU3FZVkJCMkp-V3lKRk1rRnNSemhzWTJwMFFWRnJjbGxJYmpsSWJuVlJJaXdnSW5SNWNHVWlMQ0FpVm1WeWFXWnBZV0pzWlZCeVpYTmxiblJoZEdsdmJpSmR-V3lJNU5sZFlNRFJuZW5vNGNWWnpPVlpMVTJ3d1lUVm5JaXdnSW1sa0lpd2dJbWgwZEhBNkx5OTFibWwyWlhKemFYUjVMbVY0WVcxd2JHVXZZM0psWkdWdWRHbGhiSE12TVRnM01pSmR-V3lKYWVrVTJWRlZhYW10SE1XMURXWEJLTUVobmMwbDNJaXdnSW5SNWNHVWlMQ0JiSWxabGNtbG1hV0ZpYkdWRGNtVmtaVzUwYVdGc0lpd2dJa1Y0WVcxd2JHVkJiSFZ0Ym1sRGNtVmtaVzUwYVdGc0lsMWR-V3lJdFEzTnNTMjVHWkdGWWIySmlRV3N5VTBKQlZHUjNJaXdnSW1sa0lpd2dJbVJwWkRwbGVHRnRjR3hsT21WaVptVmlNV1kzTVRKbFltTTJaakZqTWpjMlpURXlaV015TVNKZH5XeUp1Um0xT1dsOUljekIzV1dOb09GZGtlVGRuUVVOUklpd2dJbWxrSWl3Z0ltUnBaRHBsZUdGdGNHeGxPbU15TnpabE1USmxZekl4WldKbVpXSXhaamN4TW1WaVl6Wm1NU0pkfiJd</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"SkEbz5PF3qL55W-lehHHXQ",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vp+sd-jwt,&nbsp;eyJhbGciOiJFUzM4NCIsImtpZCI6IlVRTV9fblE0UzZCTzhuUTRuT05YeHB4aHRob3lOeGI1M0xZZ1l6LTJBQnMiLCJ0eXAiOiJ2cCtsZCtqc29uK3NkLWp3dCIsImN0eSI6InZwK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiYWx1bW5pT2YiOnsibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSIsIl9zZCI6WyJoek9LRzU2cDI5c1ByTGFDNUE4RndFdUczVU05dUlZU1p1cU9YczJlVGJBIl19LCJfc2QiOlsiWVdXVmVDRndxQmk4WDBqSF9jV0NWWU16STNhOHBjTEVYRWZicFNSQVlndyJdfSwiX3NkIjpbIjJJZjhhaUs4REZwVWJ4dEc1cGMwel9SaFJzbm1ybGFRMEhzcTk4WFNyYWsiLCJUeDZ4ZWZMVUdUZUpfYWtVUFdGeHNvbUhobGtWVnpfNzVoaVZ6eWpyYmVzIl19XSwiX3NkIjpbIjd2anl0VVN3ZEJ0MXQ5RktlOVFfS3JIRXhFWGxrTEFaTzBKM0Jpd200dlkiXSwiX3NkX2FsZyI6InNoYS0yNTYiLCJpYXQiOjE3MDY1NjI4NDksImV4cCI6MTczODE4NTI0OSwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwiYWxnIjoiRVMzODQiLCJ4IjoidWtEd1U2ZzlQUVRFUWhYaEgyckRZNndMQlg3UHFlUjZBcGlhVHBEUXowcl8tdDl6UXNxem54Z0hEcE5oekZlQyIsInkiOiJMQnhVYnBVdFNGMVVKVTVpYnJIdkpINjBUSG5YMk1xa0xHZGltU1l0UGR4RlkxOEdhcldiS3FZV0djUkZHVE9BIn19fQ.kYD63YtBNYnLUTw6Szf1vs_Ug3UBXhPwCyqpNmPnPDa3rXZQhQLdB1BgaoO8zgQ-c3B41fxaXMnLHYV9-B20uboSpJP0B-2Vre917eQt1cSDswDGA_Ytvn4BSqYVBB2J~WyJFMkFsRzhsY2p0QVFrcllIbjlIbnVRIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd~WyI5NldYMDRneno4cVZzOVZLU2wwYTVnIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJaekU2VFVaamtHMW1DWXBKMEhnc0l3IiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyItQ3NsS25GZGFYb2JiQWsyU0JBVGR3IiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd~WyJuRm1OWl9IczB3WWNoOFdkeTdnQUNRIiwgImlkIiwgImRpZDpleGFtcGxlOmMyNzZlMTJlYzIxZWJmZWIxZjcxMmViYzZmMSJd~"<br>]</span></p>
+    <h3 id="sd-jwt-claim-Wobxt7GgUmEZJhBIdi2oSrh3xhKjjNWkDgskx3DI6kg">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">Wobxt7GgUmEZJhBIdi2oSrh3xhKjjNWkDgskx3DI6kg</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJFUWRUZEprS3Fjd3RrMkVVMUxkOTZnIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdnArc2Qtand0LCBleUpoYkdjaU9pSkZVek00TkNJc0ltdHBaQ0k2SWxWUlRWOWZibEUwVXpaQ1R6aHVVVFJ1VDA1WWVIQjRhSFJvYjNsT2VHSTFNMHhaWjFsNkxUSkJRbk1pTENKMGVYQWlPaUoyY0N0c1pDdHFjMjl1SzNOa0xXcDNkQ0lzSW1OMGVTSTZJblp3SzJ4a0sycHpiMjRpZlEuZXlKQVkyOXVkR1Y0ZENJNld5Sm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdmRqSWlMQ0pvZEhSd2N6b3ZMM2QzZHk1M015NXZjbWN2Ym5NdlkzSmxaR1Z1ZEdsaGJITXZaWGhoYlhCc1pYTXZkaklpWFN3aWRtVnlhV1pwWVdKc1pVTnlaV1JsYm5ScFlXd2lPbHQ3SWtCamIyNTBaWGgwSWpwYkltaDBkSEJ6T2k4dmQzZDNMbmN6TG05eVp5OXVjeTlqY21Wa1pXNTBhV0ZzY3k5Mk1pSXNJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OWxlR0Z0Y0d4bGN5OTJNaUpkTENKcGMzTjFaWElpT2lKb2RIUndjem92TDNWdWFYWmxjbk5wZEhrdVpYaGhiWEJzWlM5cGMzTjFaWEp6THpVMk5UQTBPU0lzSW5aaGJHbGtSbkp2YlNJNklqSXdNVEF0TURFdE1ERlVNVGs2TWpNNk1qUmFJaXdpWTNKbFpHVnVkR2xoYkZOMVltcGxZM1FpT25zaVlXeDFiVzVwVDJZaU9uc2libUZ0WlNJNklrVjRZVzF3YkdVZ1ZXNXBkbVZ5YzJsMGVTSXNJbDl6WkNJNld5Sm9lazlMUnpVMmNESTVjMUJ5VEdGRE5VRTRSbmRGZFVjelZVMDVkVWxaVTFwMWNVOVljekpsVkdKQklsMTlMQ0pmYzJRaU9sc2lXVmRYVm1WRFJuZHhRbWs0V0RCcVNGOWpWME5XV1UxNlNUTmhPSEJqVEVWWVJXWmljRk5TUVZsbmR5SmRmU3dpWDNOa0lqcGJJakpKWmpoaGFVczRSRVp3VldKNGRFYzFjR013ZWw5U2FGSnpibTF5YkdGUk1FaHpjVGs0V0ZOeVlXc2lMQ0pVZURaNFpXWk1WVWRVWlVwZllXdFZVRmRHZUhOdmJVaG9iR3RXVm5wZk56Vm9hVlo2ZVdweVltVnpJbDE5WFN3aVgzTmtJanBiSWpkMmFubDBWVk4zWkVKME1YUTVSa3RsT1ZGZlMzSklSWGhGV0d4clRFRmFUekJLTTBKcGQyMDBkbGtpWFN3aVgzTmtYMkZzWnlJNkluTm9ZUzB5TlRZaUxDSnBZWFFpT2pFM01EWTFOakk0TkRrc0ltVjRjQ0k2TVRjek9ERTROVEkwT1N3aVkyNW1JanA3SW1wM2F5STZleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TXpnMElpd2lZV3huSWpvaVJWTXpPRFFpTENKNElqb2lkV3RFZDFVMlp6bFFVVlJGVVdoWWFFZ3lja1JaTm5kTVFsZzNVSEZsVWpaQmNHbGhWSEJFVVhvd2NsOHRkRGw2VVhOeGVtNTRaMGhFY0U1b2VrWmxReUlzSW5raU9pSk1RbmhWWW5CVmRGTkdNVlZLVlRWcFluSklka3BJTmpCVVNHNVlNazF4YTB4SFpHbHRVMWwwVUdSNFJsa3hPRWRoY2xkaVMzRlpWMGRqVWtaSFZFOUJJbjE5ZlEua1lENjNZdEJOWW5MVVR3NlN6ZjF2c19VZzNVQlhoUHdDeXFwTm1QblBEYTNyWFpRaFFMZEIxQmdhb084emdRLWMzQjQxZnhhWE1uTEhZVjktQjIwdWJvU3BKUDBCLTJWcmU5MTdlUXQxY1NEc3dER0FfWXR2bjRCU3FZVkJCMkp-V3lKRk1rRnNSemhzWTJwMFFWRnJjbGxJYmpsSWJuVlJJaXdnSW5SNWNHVWlMQ0FpVm1WeWFXWnBZV0pzWlZCeVpYTmxiblJoZEdsdmJpSmR-V3lJNU5sZFlNRFJuZW5vNGNWWnpPVlpMVTJ3d1lUVm5JaXdnSW1sa0lpd2dJbWgwZEhBNkx5OTFibWwyWlhKemFYUjVMbVY0WVcxd2JHVXZZM0psWkdWdWRHbGhiSE12TVRnM01pSmR-V3lKYWVrVTJWRlZhYW10SE1XMURXWEJLTUVobmMwbDNJaXdnSW5SNWNHVWlMQ0JiSWxabGNtbG1hV0ZpYkdWRGNtVmtaVzUwYVdGc0lpd2dJa1Y0WVcxd2JHVkJiSFZ0Ym1sRGNtVmtaVzUwYVdGc0lsMWR-V3lJdFEzTnNTMjVHWkdGWWIySmlRV3N5VTBKQlZHUjNJaXdnSW1sa0lpd2dJbVJwWkRwbGVHRnRjR3hsT21WaVptVmlNV1kzTVRKbFltTTJaakZqTWpjMlpURXlaV015TVNKZH5XeUp1Um0xT1dsOUljekIzV1dOb09GZGtlVGRuUVVOUklpd2dJbWxrSWl3Z0ltUnBaRHBsZUdGdGNHeGxPbU15TnpabE1USmxZekl4WldKbVpXSXhaamN4TW1WaVl6Wm1NU0pkfiJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"EQdTdJkKqcwtk2EU1Ld96g",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vp+sd-jwt,&nbsp;eyJhbGciOiJFUzM4NCIsImtpZCI6IlVRTV9fblE0UzZCTzhuUTRuT05YeHB4aHRob3lOeGI1M0xZZ1l6LTJBQnMiLCJ0eXAiOiJ2cCtsZCtqc29uK3NkLWp3dCIsImN0eSI6InZwK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiYWx1bW5pT2YiOnsibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSIsIl9zZCI6WyJoek9LRzU2cDI5c1ByTGFDNUE4RndFdUczVU05dUlZU1p1cU9YczJlVGJBIl19LCJfc2QiOlsiWVdXVmVDRndxQmk4WDBqSF9jV0NWWU16STNhOHBjTEVYRWZicFNSQVlndyJdfSwiX3NkIjpbIjJJZjhhaUs4REZwVWJ4dEc1cGMwel9SaFJzbm1ybGFRMEhzcTk4WFNyYWsiLCJUeDZ4ZWZMVUdUZUpfYWtVUFdGeHNvbUhobGtWVnpfNzVoaVZ6eWpyYmVzIl19XSwiX3NkIjpbIjd2anl0VVN3ZEJ0MXQ5RktlOVFfS3JIRXhFWGxrTEFaTzBKM0Jpd200dlkiXSwiX3NkX2FsZyI6InNoYS0yNTYiLCJpYXQiOjE3MDY1NjI4NDksImV4cCI6MTczODE4NTI0OSwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwiYWxnIjoiRVMzODQiLCJ4IjoidWtEd1U2ZzlQUVRFUWhYaEgyckRZNndMQlg3UHFlUjZBcGlhVHBEUXowcl8tdDl6UXNxem54Z0hEcE5oekZlQyIsInkiOiJMQnhVYnBVdFNGMVVKVTVpYnJIdkpINjBUSG5YMk1xa0xHZGltU1l0UGR4RlkxOEdhcldiS3FZV0djUkZHVE9BIn19fQ.kYD63YtBNYnLUTw6Szf1vs_Ug3UBXhPwCyqpNmPnPDa3rXZQhQLdB1BgaoO8zgQ-c3B41fxaXMnLHYV9-B20uboSpJP0B-2Vre917eQt1cSDswDGA_Ytvn4BSqYVBB2J~WyJFMkFsRzhsY2p0QVFrcllIbjlIbnVRIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd~WyI5NldYMDRneno4cVZzOVZLU2wwYTVnIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJaekU2VFVaamtHMW1DWXBKMEhnc0l3IiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyItQ3NsS25GZGFYb2JiQWsyU0JBVGR3IiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd~WyJuRm1OWl9IczB3WWNoOFdkeTdnQUNRIiwgImlkIiwgImRpZDpleGFtcGxlOmMyNzZlMTJlYzIxZWJmZWIxZjcxMmViYzZmMSJd~"<br>]</span></p>
 </div>
 </div>
     </div>
@@ -2325,7 +2291,7 @@ li.sd-jwt-tab {
 </pre>
 <strong>application/vc+cose</strong>
 <div class="cose-text">
-d28444a1013822a059029e7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c226964223a22687474703a2f2f756e69766572736974792e6578616d706c652f63726564656e7469616c732f33373332222c2274797065223a5b2256657269666961626c6543726564656e7469616c222c224578616d706c6544656772656543726564656e7469616c222c224578616d706c65506572736f6e43726564656e7469616c225d2c22697373756572223a2268747470733a2f2f756e69766572736974792e6578616d706c652f697373756572732f3134222c2276616c696446726f6d223a22323031302d30312d30315431393a32333a32345a222c2263726564656e7469616c5375626a656374223a7b226964223a226469643a6578616d706c653a656266656231663731326562633666316332373665313265633231222c22646567726565223a7b2274797065223a224578616d706c6542616368656c6f72446567726565222c226e616d65223a2242616368656c6f72206f6620536369656e636520616e642041727473227d2c22616c756d6e694f66223a7b226e616d65223a224578616d706c6520556e6976657273697479227d7d2c2263726564656e7469616c536368656d61223a5b7b226964223a2268747470733a2f2f6578616d706c652e6f72672f6578616d706c65732f6465677265652e6a736f6e222c2274797065223a224a736f6e536368656d61227d2c7b226964223a2268747470733a2f2f6578616d706c652e6f72672f6578616d706c65732f616c756d6e692e6a736f6e222c2274797065223a224a736f6e536368656d61227d5d7d58405e8def02de73d12afc98b8ceecb087b66fa039b7e37b300a367112c488d4963e698caf4ae833a32c00febc9bab8cbdeb3bb9cc99102961bff388f9fc9c263943
+d28444a1013822a059029e7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c226964223a22687474703a2f2f756e69766572736974792e6578616d706c652f63726564656e7469616c732f33373332222c2274797065223a5b2256657269666961626c6543726564656e7469616c222c224578616d706c6544656772656543726564656e7469616c222c224578616d706c65506572736f6e43726564656e7469616c225d2c22697373756572223a2268747470733a2f2f756e69766572736974792e6578616d706c652f697373756572732f3134222c2276616c696446726f6d223a22323031302d30312d30315431393a32333a32345a222c2263726564656e7469616c5375626a656374223a7b226964223a226469643a6578616d706c653a656266656231663731326562633666316332373665313265633231222c22646567726565223a7b2274797065223a224578616d706c6542616368656c6f72446567726565222c226e616d65223a2242616368656c6f72206f6620536369656e636520616e642041727473227d2c22616c756d6e694f66223a7b226e616d65223a224578616d706c6520556e6976657273697479227d7d2c2263726564656e7469616c536368656d61223a5b7b226964223a2268747470733a2f2f6578616d706c652e6f72672f6578616d706c65732f6465677265652e6a736f6e222c2274797065223a224a736f6e536368656d61227d2c7b226964223a2268747470733a2f2f6578616d706c652e6f72672f6578616d706c65732f616c756d6e692e6a736f6e222c2274797065223a224a736f6e536368656d61227d5d7d5840be50900a466b077ece4d0bfe1e96588e048e43b6f45fbc3fb3e659a1b3f8b4431678db4d352bb933ab9aeb9010aea13bf177c775d7927ff074e3f86402fe3a97
 </div>
     </div>
 </div></div></div></div>
@@ -2421,7 +2387,7 @@ d28444a1013822a059029e7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
 </pre>
 <strong>application/vp+cose</strong>
 <div class="cose-text">
-d28444a1013822a0590d1c7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c2274797065223a2256657269666961626c6550726573656e746174696f6e222c2276657269666961626c6543726564656e7469616c223a5b7b2240636f6e74657874223a2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c226964223a22646174613a6170706c69636174696f6e2f76632b73642d6a77742c65794a72615751694f694a4665456872516b31584f575a74596d7432566a49324e6d3153634856514d6e4e565756394f583056585355347862474677565870504f484a76496977695957786e496a6f6952564d794e54596966512e65794a66633252665957786e496a6f69633268684c5449314e694973496b426a623235305a586830496a7062496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a57353061574673637939324d694973496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a573530615746736379396c654746746347786c637939324d694a644c434a7063334e315a5849694f694a6f64485277637a6f764c33567561585a6c636e4e7064486b755a586868625842735a53397063334e315a584a7a4c7a55324e5441304f534973496e5a6862476c6b526e4a7662534936496a49774d5441744d4445744d4446554d546b364d6a4d364d6a52614969776959334a6c5a47567564476c6862464e6a614756745953493665794a66633251694f6c73694e574a4265444d746548426d5157785653305a4a4f584e754d326857513231775232747263556c7a576d4d7a4c5578694d7a4e6d576d706961794973496c706a51585a494d44687364454a795355706d535768304f46397453314266597a4e73634735594d574e48636c6c74564738775a316c436554676958583073496d4e795a57526c626e52705957785464574a715a574e30496a7037496d526c5a334a6c5a53493665794a755957316c496a6f69516d466a61475673623349676232596755324e705a57356a5a534268626d516751584a3063794973496c397a5a43493657794a53543151334d556c3064544e4d4e6c5658574656716279316f5756644a516a593362485650546b5645556c4e436147784556454e7856553952496c31394c434a66633251694f6c7369545556755a584e6e4d6c6850556b356a59334e4354575661587a45324d444a6e655451775569303057554a32566c4977654645346230593459794a646653776958334e6b496a7062496b566c63324a696179316d63475a7764325a4d4f58644f637a4678636a5a30615534335a6e45745358517a57564d3256335a43626c3969574738694c434a61623149315a475268636b64745a6b31354e45687556307856616b3555526e4655526a4e59526a5a706446426e5a6e6c47516b685658334656496c31392e677733706178626b4c6a706938435473795270584b6243377470566130713273574b53442d5f646362755a314c705a56336f513849667a636d32624538525933666d4a6762757941396762504c3373514261547a6b67207e57794a5365555178566c423456484276626d745065585a70637a6b746132393349697767496d6c6b49697767496d6830644841364c793931626d6c325a584a7a615852354c6d5634595731776247557659334a6c5a47567564476c6862484d764d5467334d694a647e57794a66566a643165546433617931524d33565a64325a705a304e765755564249697767496e5235634755694c434262496c5a6c636d6c6d6157466962475644636d566b5a5735306157467349697767496b5634595731776247564262485674626d6c44636d566b5a57353061574673496c31647e57794a68617a64714d546c6e59564d7452444a4c5832687a593352565a474e5249697767496d6c6b49697767496d68306448427a4f6938765a586868625842735a533576636d63765a586868625842735a584d765a47566e636d566c4c6d707a6232346958517e57794a55546a42586158565a526b6858576b56325a445a4951554a485153316e49697767496e5235634755694c434169536e4e76626c4e6a6147567459534a647e57794a564d6e427a4d6b785956455256625668334d4463785256426d5255706e49697767496d6c6b49697767496d52705a44706c654746746347786c4f6a45794d794a647e57794a735130343265544e4561544e44556b395658334a75587a52454e57526e49697767496e5235634755694c434169516d466a6147567362334a455a5764795a57556958517e3b646174613a6170706c69636174696f6e2f76632b73642d6a77742c65794a72615751694f694a4665456872516b31584f575a74596d7432566a49324e6d3153634856514d6e4e565756394f583056585355347862474677565870504f484a76496977695957786e496a6f6952564d794e54596966512e65794a66633252665957786e496a6f69633268684c5449314e694973496b426a623235305a586830496a7062496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a57353061574673637939324d694973496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a573530615746736379396c654746746347786c637939324d694a644c434a7063334e315a5849694f694a6f64485277637a6f764c33567561585a6c636e4e7064486b755a586868625842735a53397063334e315a584a7a4c7a55324e5441304f534973496e5a6862476c6b526e4a7662534936496a49774d5441744d4445744d4446554d546b364d6a4d364d6a52614969776959334a6c5a47567564476c6862464e6a614756745953493665794a66633251694f6c73694e574a4265444d746548426d5157785653305a4a4f584e754d326857513231775232747263556c7a576d4d7a4c5578694d7a4e6d576d706961794973496c706a51585a494d44687364454a795355706d535768304f46397453314266597a4e73634735594d574e48636c6c74564738775a316c436554676958583073496d4e795a57526c626e52705957785464574a715a574e30496a7037496d526c5a334a6c5a53493665794a755957316c496a6f69516d466a61475673623349676232596755324e705a57356a5a534268626d516751584a3063794973496c397a5a43493657794a53543151334d556c3064544e4d4e6c5658574656716279316f5756644a516a593362485650546b5645556c4e436147784556454e7856553952496c31394c434a66633251694f6c7369545556755a584e6e4d6c6850556b356a59334e4354575661587a45324d444a6e655451775569303057554a32566c4977654645346230593459794a646653776958334e6b496a7062496b566c63324a696179316d63475a7764325a4d4f58644f637a4678636a5a30615534335a6e45745358517a57564d3256335a43626c3969574738694c434a61623149315a475268636b64745a6b31354e45687556307856616b3555526e4655526a4e59526a5a706446426e5a6e6c47516b685658334656496c31392e677733706178626b4c6a706938435473795270584b6243377470566130713273574b53442d5f646362755a314c705a56336f513849667a636d32624538525933666d4a6762757941396762504c3373514261547a6b67207e57794a5365555178566c423456484276626d745065585a70637a6b746132393349697767496d6c6b49697767496d6830644841364c793931626d6c325a584a7a615852354c6d5634595731776247557659334a6c5a47567564476c6862484d764d5467334d694a647e57794a66566a643165546433617931524d33565a64325a705a304e765755564249697767496e5235634755694c434262496c5a6c636d6c6d6157466962475644636d566b5a5735306157467349697767496b5634595731776247564262485674626d6c44636d566b5a57353061574673496c31647e57794a68617a64714d546c6e59564d7452444a4c5832687a593352565a474e5249697767496d6c6b49697767496d68306448427a4f6938765a586868625842735a533576636d63765a586868625842735a584d765a47566e636d566c4c6d707a6232346958517e57794a55546a42586158565a526b6858576b56325a445a4951554a485153316e49697767496e5235634755694c434169536e4e76626c4e6a6147567459534a647e57794a564d6e427a4d6b785956455256625668334d4463785256426d5255706e49697767496d6c6b49697767496d52705a44706c654746746347786c4f6a45794d794a647e57794a735130343265544e4561544e44556b395658334a75587a52454e57526e49697767496e5235634755694c434169516d466a6147567362334a455a5764795a57556958517e222c2274797065223a22456e76656c6f70656456657269666961626c6543726564656e7469616c227d5d7d5840023eb9d5683e3046fde1af6d383d5f323964114f86fb4dfe1fe65bd548c9b8425da15138df1241973f1dafc4301c8aa3a0311b3e370c5b7d18082b81fcc6f0bb
+d28444a1013822a0590d1c7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c2274797065223a2256657269666961626c6550726573656e746174696f6e222c2276657269666961626c6543726564656e7469616c223a5b7b2240636f6e74657874223a2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c226964223a22646174613a6170706c69636174696f6e2f76632b73642d6a77742c65794a72615751694f694a4665456872516b31584f575a74596d7432566a49324e6d3153634856514d6e4e565756394f583056585355347862474677565870504f484a76496977695957786e496a6f6952564d794e54596966512e65794a66633252665957786e496a6f69633268684c5449314e694973496b426a623235305a586830496a7062496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a57353061574673637939324d694973496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a573530615746736379396c654746746347786c637939324d694a644c434a7063334e315a5849694f694a6f64485277637a6f764c33567561585a6c636e4e7064486b755a586868625842735a53397063334e315a584a7a4c7a55324e5441304f534973496e5a6862476c6b526e4a7662534936496a49774d5441744d4445744d4446554d546b364d6a4d364d6a52614969776959334a6c5a47567564476c6862464e6a614756745953493665794a66633251694f6c73694e574a4265444d746548426d5157785653305a4a4f584e754d326857513231775232747263556c7a576d4d7a4c5578694d7a4e6d576d706961794973496c706a51585a494d44687364454a795355706d535768304f46397453314266597a4e73634735594d574e48636c6c74564738775a316c436554676958583073496d4e795a57526c626e52705957785464574a715a574e30496a7037496d526c5a334a6c5a53493665794a755957316c496a6f69516d466a61475673623349676232596755324e705a57356a5a534268626d516751584a3063794973496c397a5a43493657794a53543151334d556c3064544e4d4e6c5658574656716279316f5756644a516a593362485650546b5645556c4e436147784556454e7856553952496c31394c434a66633251694f6c7369545556755a584e6e4d6c6850556b356a59334e4354575661587a45324d444a6e655451775569303057554a32566c4977654645346230593459794a646653776958334e6b496a7062496b566c63324a696179316d63475a7764325a4d4f58644f637a4678636a5a30615534335a6e45745358517a57564d3256335a43626c3969574738694c434a61623149315a475268636b64745a6b31354e45687556307856616b3555526e4655526a4e59526a5a706446426e5a6e6c47516b685658334656496c31392e677733706178626b4c6a706938435473795270584b6243377470566130713273574b53442d5f646362755a314c705a56336f513849667a636d32624538525933666d4a6762757941396762504c3373514261547a6b67207e57794a5365555178566c423456484276626d745065585a70637a6b746132393349697767496d6c6b49697767496d6830644841364c793931626d6c325a584a7a615852354c6d5634595731776247557659334a6c5a47567564476c6862484d764d5467334d694a647e57794a66566a643165546433617931524d33565a64325a705a304e765755564249697767496e5235634755694c434262496c5a6c636d6c6d6157466962475644636d566b5a5735306157467349697767496b5634595731776247564262485674626d6c44636d566b5a57353061574673496c31647e57794a68617a64714d546c6e59564d7452444a4c5832687a593352565a474e5249697767496d6c6b49697767496d68306448427a4f6938765a586868625842735a533576636d63765a586868625842735a584d765a47566e636d566c4c6d707a6232346958517e57794a55546a42586158565a526b6858576b56325a445a4951554a485153316e49697767496e5235634755694c434169536e4e76626c4e6a6147567459534a647e57794a564d6e427a4d6b785956455256625668334d4463785256426d5255706e49697767496d6c6b49697767496d52705a44706c654746746347786c4f6a45794d794a647e57794a735130343265544e4561544e44556b395658334a75587a52454e57526e49697767496e5235634755694c434169516d466a6147567362334a455a5764795a57556958517e3b646174613a6170706c69636174696f6e2f76632b73642d6a77742c65794a72615751694f694a4665456872516b31584f575a74596d7432566a49324e6d3153634856514d6e4e565756394f583056585355347862474677565870504f484a76496977695957786e496a6f6952564d794e54596966512e65794a66633252665957786e496a6f69633268684c5449314e694973496b426a623235305a586830496a7062496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a57353061574673637939324d694973496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a573530615746736379396c654746746347786c637939324d694a644c434a7063334e315a5849694f694a6f64485277637a6f764c33567561585a6c636e4e7064486b755a586868625842735a53397063334e315a584a7a4c7a55324e5441304f534973496e5a6862476c6b526e4a7662534936496a49774d5441744d4445744d4446554d546b364d6a4d364d6a52614969776959334a6c5a47567564476c6862464e6a614756745953493665794a66633251694f6c73694e574a4265444d746548426d5157785653305a4a4f584e754d326857513231775232747263556c7a576d4d7a4c5578694d7a4e6d576d706961794973496c706a51585a494d44687364454a795355706d535768304f46397453314266597a4e73634735594d574e48636c6c74564738775a316c436554676958583073496d4e795a57526c626e52705957785464574a715a574e30496a7037496d526c5a334a6c5a53493665794a755957316c496a6f69516d466a61475673623349676232596755324e705a57356a5a534268626d516751584a3063794973496c397a5a43493657794a53543151334d556c3064544e4d4e6c5658574656716279316f5756644a516a593362485650546b5645556c4e436147784556454e7856553952496c31394c434a66633251694f6c7369545556755a584e6e4d6c6850556b356a59334e4354575661587a45324d444a6e655451775569303057554a32566c4977654645346230593459794a646653776958334e6b496a7062496b566c63324a696179316d63475a7764325a4d4f58644f637a4678636a5a30615534335a6e45745358517a57564d3256335a43626c3969574738694c434a61623149315a475268636b64745a6b31354e45687556307856616b3555526e4655526a4e59526a5a706446426e5a6e6c47516b685658334656496c31392e677733706178626b4c6a706938435473795270584b6243377470566130713273574b53442d5f646362755a314c705a56336f513849667a636d32624538525933666d4a6762757941396762504c3373514261547a6b67207e57794a5365555178566c423456484276626d745065585a70637a6b746132393349697767496d6c6b49697767496d6830644841364c793931626d6c325a584a7a615852354c6d5634595731776247557659334a6c5a47567564476c6862484d764d5467334d694a647e57794a66566a643165546433617931524d33565a64325a705a304e765755564249697767496e5235634755694c434262496c5a6c636d6c6d6157466962475644636d566b5a5735306157467349697767496b5634595731776247564262485674626d6c44636d566b5a57353061574673496c31647e57794a68617a64714d546c6e59564d7452444a4c5832687a593352565a474e5249697767496d6c6b49697767496d68306448427a4f6938765a586868625842735a533576636d63765a586868625842735a584d765a47566e636d566c4c6d707a6232346958517e57794a55546a42586158565a526b6858576b56325a445a4951554a485153316e49697767496e5235634755694c434169536e4e76626c4e6a6147567459534a647e57794a564d6e427a4d6b785956455256625668334d4463785256426d5255706e49697767496d6c6b49697767496d52705a44706c654746746347786c4f6a45794d794a647e57794a735130343265544e4561544e44556b395658334a75587a52454e57526e49697767496e5235634755694c434169516d466a6147567362334a455a5764795a57556958517e222c2274797065223a22456e76656c6f70656456657269666961626c6543726564656e7469616c227d5d7d584048aa5ace527e2bf29b91fb5e84434f101d848b930c0ff9e5ddd82c9b3e2087351b47d26ce2f4c8a0101b2586c9e33d9f830d100a77be54c15a8cb1a51ad68291
 </div>
     </div>
 </div></div></div></div>
@@ -2455,7 +2421,7 @@ d28444a1013822a0590d1c7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
 </pre>
 <strong>application/vp+cose</strong>
 <div class="cose-text">
-d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c2274797065223a22456e76656c6f70656456657269666961626c6550726573656e746174696f6e222c226964223a22646174613a6170706c69636174696f6e2f76702b73642d6a77742c65794a68624763694f694a46557a4d344e434973496d74705a434936496c565254563966626c4530557a5a43547a68755554527554303559654842346148526f62336c4f654749314d30785a5a316c364c544a42516e4d694c434a30655841694f694a32634374735a437471633239754b334e6b4c57703364434973496d4e3065534936496e5a774b32786b4b32707a6232346966512e65794a4159323975644756346443493657794a6f64485277637a6f764c336433647935334d793576636d6376626e4d7659334a6c5a47567564476c6862484d76646a49694c434a6f64485277637a6f764c336433647935334d793576636d6376626e4d7659334a6c5a47567564476c6862484d765a586868625842735a584d76646a496958537769646d567961575a7059574a735a554e795a57526c626e5270595777694f6c7437496b426a623235305a586830496a7062496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a57353061574673637939324d694973496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a573530615746736379396c654746746347786c637939324d694a644c434a7063334e315a5849694f694a6f64485277637a6f764c33567561585a6c636e4e7064486b755a586868625842735a53397063334e315a584a7a4c7a55324e5441304f534973496e5a6862476c6b526e4a7662534936496a49774d5441744d4445744d4446554d546b364d6a4d364d6a52614969776959334a6c5a47567564476c6862464e31596d706c593351694f6e73695957783162573570543259694f6e7369626d46745a534936496b5634595731776247556756573570646d567963326c3065534973496c397a5a43493657794a6f656b394c527a55326344493563314279544746444e554534526e64466455637a5655303564556c5a5531703163553959637a4a6c56474a42496c31394c434a66633251694f6c736957566458566d5644526e6478516d6b34574442715346396a56304e575755313653544e684f48426a5445565952575a6963464e5351566c6e64794a646653776958334e6b496a7062496a4a4a5a6a68686155733452455a7756574a346445633163474d77656c395361464a7a626d3179624746524d45687a63546b3457464e79595773694c434a5565445a345a575a4d565564555a557066595774565546644765484e766255686f62477457566e70664e7a566f61565a3665577079596d567a496c31395853776958334e6b496a7062496a6432616e6c3056564e335a454a304d585135526b746c4f56466653334a49525868465747787254454661547a424b4d304a7064323030646c6b695853776958334e6b583246735a794936496e4e6f595330794e5459694c434a70595851694f6a45334d4459314e6a49344e446b73496d5634634349364d54637a4f4445344e5449304f5377695932356d496a7037496d70336179493665794a7264486b694f694a4651794973496d4e7964694936496c41744d7a6730496977695957786e496a6f6952564d7a4f4451694c434a34496a6f6964577445643155325a7a6c51555652465557685961456779636b525a4e6e644d516c67335548466c556a5a4263476c685648424555586f77636c387464446c3655584e78656d35345a3068456345356f656b5a6c51794973496e6b694f694a4d516e6856596e425664464e474d56564b56545670596e4a49646b70494e6a4255534735594d6b3178613078485a476c7455316c3055475234526c6b784f456468636c64695333465a5630646a556b5a4856453942496e313966512e6b594436335974424e596e4c55547736537a663176735f556733554258685077437971704e6d506e5044613372585a5168514c6442314267616f4f387a67512d6333423431667861584d6e4c485956392d42323075626f53704a5030422d325672653931376551743163534473774447415f5974766e3442537159564242324a7e57794a464d6b4673527a68735932703051564672636c6c49626a6c49626e565249697767496e5235634755694c434169566d567961575a7059574a735a5642795a584e6c626e526864476c7662694a647e577949354e6c64594d44526e656e6f3463565a7a4f565a4c553277775954566e49697767496d6c6b49697767496d6830644841364c793931626d6c325a584a7a615852354c6d5634595731776247557659334a6c5a47567564476c6862484d764d5467334d694a647e57794a61656b553256465661616d74484d5731445758424b4d45686e63306c3349697767496e5235634755694c434262496c5a6c636d6c6d6157466962475644636d566b5a5735306157467349697767496b5634595731776247564262485674626d6c44636d566b5a57353061574673496c31647e5779497451334e73533235475a47465962324a695157737955304a425647523349697767496d6c6b49697767496d52705a44706c654746746347786c4f6d56695a6d56694d5759334d544a6c596d4d325a6a466a4d6a63325a5445795a574d794d534a647e57794a75526d314f576c3949637a423357574e6f4f46646b6554646e51554e5249697767496d6c6b49697767496d52705a44706c654746746347786c4f6d4d794e7a5a6c4d544a6c597a49785a574a6d5a5749785a6a63784d6d5669597a5a6d4d534a647e222c2276657269666961626c6543726564656e7469616c223a5b5d7d5840d817f59e15a04f41995c28dbb1beb0ceae8f4e23daeb2135a6e492320e64d6af49fbe9ce1755e45a549f72fe5c149424de7a8fb8dc24b6279be1301c69a1302d
+d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c2274797065223a22456e76656c6f70656456657269666961626c6550726573656e746174696f6e222c226964223a22646174613a6170706c69636174696f6e2f76702b73642d6a77742c65794a68624763694f694a46557a4d344e434973496d74705a434936496c565254563966626c4530557a5a43547a68755554527554303559654842346148526f62336c4f654749314d30785a5a316c364c544a42516e4d694c434a30655841694f694a32634374735a437471633239754b334e6b4c57703364434973496d4e3065534936496e5a774b32786b4b32707a6232346966512e65794a4159323975644756346443493657794a6f64485277637a6f764c336433647935334d793576636d6376626e4d7659334a6c5a47567564476c6862484d76646a49694c434a6f64485277637a6f764c336433647935334d793576636d6376626e4d7659334a6c5a47567564476c6862484d765a586868625842735a584d76646a496958537769646d567961575a7059574a735a554e795a57526c626e5270595777694f6c7437496b426a623235305a586830496a7062496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a57353061574673637939324d694973496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a573530615746736379396c654746746347786c637939324d694a644c434a7063334e315a5849694f694a6f64485277637a6f764c33567561585a6c636e4e7064486b755a586868625842735a53397063334e315a584a7a4c7a55324e5441304f534973496e5a6862476c6b526e4a7662534936496a49774d5441744d4445744d4446554d546b364d6a4d364d6a52614969776959334a6c5a47567564476c6862464e31596d706c593351694f6e73695957783162573570543259694f6e7369626d46745a534936496b5634595731776247556756573570646d567963326c3065534973496c397a5a43493657794a6f656b394c527a55326344493563314279544746444e554534526e64466455637a5655303564556c5a5531703163553959637a4a6c56474a42496c31394c434a66633251694f6c736957566458566d5644526e6478516d6b34574442715346396a56304e575755313653544e684f48426a5445565952575a6963464e5351566c6e64794a646653776958334e6b496a7062496a4a4a5a6a68686155733452455a7756574a346445633163474d77656c395361464a7a626d3179624746524d45687a63546b3457464e79595773694c434a5565445a345a575a4d565564555a557066595774565546644765484e766255686f62477457566e70664e7a566f61565a3665577079596d567a496c31395853776958334e6b496a7062496a6432616e6c3056564e335a454a304d585135526b746c4f56466653334a49525868465747787254454661547a424b4d304a7064323030646c6b695853776958334e6b583246735a794936496e4e6f595330794e5459694c434a70595851694f6a45334d4459314e6a49344e446b73496d5634634349364d54637a4f4445344e5449304f5377695932356d496a7037496d70336179493665794a7264486b694f694a4651794973496d4e7964694936496c41744d7a6730496977695957786e496a6f6952564d7a4f4451694c434a34496a6f6964577445643155325a7a6c51555652465557685961456779636b525a4e6e644d516c67335548466c556a5a4263476c685648424555586f77636c387464446c3655584e78656d35345a3068456345356f656b5a6c51794973496e6b694f694a4d516e6856596e425664464e474d56564b56545670596e4a49646b70494e6a4255534735594d6b3178613078485a476c7455316c3055475234526c6b784f456468636c64695333465a5630646a556b5a4856453942496e313966512e6b594436335974424e596e4c55547736537a663176735f556733554258685077437971704e6d506e5044613372585a5168514c6442314267616f4f387a67512d6333423431667861584d6e4c485956392d42323075626f53704a5030422d325672653931376551743163534473774447415f5974766e3442537159564242324a7e57794a464d6b4673527a68735932703051564672636c6c49626a6c49626e565249697767496e5235634755694c434169566d567961575a7059574a735a5642795a584e6c626e526864476c7662694a647e577949354e6c64594d44526e656e6f3463565a7a4f565a4c553277775954566e49697767496d6c6b49697767496d6830644841364c793931626d6c325a584a7a615852354c6d5634595731776247557659334a6c5a47567564476c6862484d764d5467334d694a647e57794a61656b553256465661616d74484d5731445758424b4d45686e63306c3349697767496e5235634755694c434262496c5a6c636d6c6d6157466962475644636d566b5a5735306157467349697767496b5634595731776247564262485674626d6c44636d566b5a57353061574673496c31647e5779497451334e73533235475a47465962324a695157737955304a425647523349697767496d6c6b49697767496d52705a44706c654746746347786c4f6d56695a6d56694d5759334d544a6c596d4d325a6a466a4d6a63325a5445795a574d794d534a647e57794a75526d314f576c3949637a423357574e6f4f46646b6554646e51554e5249697767496d6c6b49697767496d52705a44706c654746746347786c4f6d4d794e7a5a6c4d544a6c597a49785a574a6d5a5749785a6a63784d6d5669597a5a6d4d534a647e222c2276657269666961626c6543726564656e7469616c223a5b5d7d58403e5b7774a6fd70c0736455e8f28c3809df399f132d5e5e66f390c7632812bd718705cb2af5acdcfb9193f274814e9fd12a872d7fbf5c44a5a0cfed3f3ef798b4
 </div>
     </div>
 </div></div></div></div>
@@ -2604,32 +2570,8 @@ d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
           </p>
         </section>
       </section>
-      <section id="well-known-uris-0"><div class="header-wrapper"><h3 id="well-known-uris"><bdi class="secno">4.2 </bdi>Well-Known URIs</h3><a class="self-link" href="#well-known-uris" aria-label="Permalink for Section 4.2"></a></div>
-        
-        <section id="jwt-issuer-0"><div class="header-wrapper"><h4 id="jwt-issuer"><bdi class="secno">4.2.1 </bdi>JWT Issuer</h4><a class="self-link" href="#jwt-issuer" aria-label="Permalink for Section 4.2.1"></a></div>
-          
-          <p>
-            When the <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a> value is a URL using the HTTPS scheme,
-            <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a> metadata including the <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-public-key" class="internalDFN" id="ref-for-dfn-public-key-1">public keys</a> can
-            be retrieved using the mechanism defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt-vc" title="SD-JWT-based Verifiable Credentials (SD-JWT VC)">SD-JWT-VC</a></cite>].
-          </p>
-          <div class="issue" id="issue-container-number-1"><div role="heading" class="issue-title marker" id="h-issue" aria-level="5"><span>Issue 1</span><span class="issue-label">: (AT RISK) Feature depends on demonstration of independent implementations</span></div><p class="">
-            This normative statement depends on the IETF OAuth working group
-            draft [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt-vc" title="SD-JWT-based Verifiable Credentials (SD-JWT VC)">SD-JWT-VC</a></cite>]. This feature is at risk and will be removed
-            from the specification if at least two independent, interoperable
-            implementations are not demonstrated.
-          </p></div>
-          <div class="example" id="example-a-kid-as-a-url-with-a-jwk-thumbprint-uri">
-        <div class="marker">
-    <a class="self-link" href="#example-a-kid-as-a-url-with-a-jwk-thumbprint-uri">Example<bdi> 10</bdi></a><span class="example-title">: A kid as a URL with a JWK Thumbprint URI</span>
-  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
-  <span class="hljs-attr">"alg"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EdDSA"</span><span class="hljs-punctuation">,</span>
-  <span class="hljs-attr">"kid"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://vendor.example/issuers/42/keys/urn:ietf:params:oauth:jwk-thumbprint:sha-256:NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"</span>
-<span class="hljs-punctuation">}</span></code></pre>
-      </div>
-        </section>
-      </section>
-      <section id="using-controlled-identifier-documents-0"><div class="header-wrapper"><h3 id="using-controlled-identifier-documents"><bdi class="secno">4.3 </bdi>Using Controlled Identifier Documents</h3><a class="self-link" href="#using-controlled-identifier-documents" aria-label="Permalink for Section 4.3"></a></div>
+      
+      <section id="using-controlled-identifier-documents-0"><div class="header-wrapper"><h3 id="using-controlled-identifier-documents"><bdi class="secno">4.2 </bdi>Using Controlled Identifier Documents</h3><a class="self-link" href="#using-controlled-identifier-documents" aria-label="Permalink for Section 4.2"></a></div>
         
         <p>
           When using <a data-link-type="dfn|abstract-op" href="#dfn-controlled-identifier-document" class="internalDFN" id="ref-for-dfn-controlled-identifier-document-1">controlled identifier documents</a> with this specification,
@@ -2664,7 +2606,7 @@ d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
         </p>
         <div class="example" id="example-an-issuer-identified-by-a-controlled-identifier-document-identifier">
         <div class="marker">
-    <a class="self-link" href="#example-an-issuer-identified-by-a-controlled-identifier-document-identifier">Example<bdi> 11</bdi></a><span class="example-title">: An issuer identified by a controlled identifier document identifier</span>
+    <a class="self-link" href="#example-an-issuer-identified-by-a-controlled-identifier-document-identifier">Example<bdi> 10</bdi></a><span class="example-title">: An issuer identified by a controlled identifier document identifier</span>
   </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"issuer"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/issuers/565049"</span>
@@ -2674,7 +2616,7 @@ d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
       </div>
 <div class="example" id="example-a-kid-as-a-controlled-identifier-document-verification-method-identifier">
         <div class="marker">
-    <a class="self-link" href="#example-a-kid-as-a-controlled-identifier-document-verification-method-identifier">Example<bdi> 12</bdi></a><span class="example-title">: A kid as a controlled identifier document verification method identifier</span>
+    <a class="self-link" href="#example-a-kid-as-a-controlled-identifier-document-verification-method-identifier">Example<bdi> 11</bdi></a><span class="example-title">: A kid as a controlled identifier document verification method identifier</span>
   </div> <pre aria-busy="false"><code class="hljs">{
   "alg": "ES384",
   "kid": "https://university.example/issuers/565049#key-123
@@ -2688,7 +2630,7 @@ d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
         </p>
 <div class="example" id="example-a-holder-identified-by-a-controlled-identifier-document-identifier">
         <div class="marker">
-    <a class="self-link" href="#example-a-holder-identified-by-a-controlled-identifier-document-identifier">Example<bdi> 13</bdi></a><span class="example-title">: A holder identified by a controlled identifier document identifier</span>
+    <a class="self-link" href="#example-a-holder-identified-by-a-controlled-identifier-document-identifier">Example<bdi> 12</bdi></a><span class="example-title">: A holder identified by a controlled identifier document identifier</span>
   </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"holder"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
     <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/issuers/565049"</span>
@@ -2698,7 +2640,7 @@ d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
       </div>
 <div class="example" id="example-a-kid-as-a-controlled-identifier-document-verification-method-identifier-0">
         <div class="marker">
-    <a class="self-link" href="#example-a-kid-as-a-controlled-identifier-document-verification-method-identifier-0">Example<bdi> 14</bdi></a><span class="example-title">: A kid as a controlled identifier document verification method identifier</span>
+    <a class="self-link" href="#example-a-kid-as-a-controlled-identifier-document-verification-method-identifier-0">Example<bdi> 13</bdi></a><span class="example-title">: A kid as a controlled identifier document verification method identifier</span>
   </div> <pre aria-busy="false"><code class="hljs">{
   "alg": "ES384",
   "kid": "https://university.example/issuers/565049#key-123
@@ -3672,14 +3614,14 @@ d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
         
         <div class="example" id="example-a-minimal-controlled-identifier-document">
         <div class="marker">
-    <a class="self-link" href="#example-a-minimal-controlled-identifier-document">Example<bdi> 15</bdi></a><span class="example-title">: A minimal controlled identifier document</span>
+    <a class="self-link" href="#example-a-minimal-controlled-identifier-document">Example<bdi> 14</bdi></a><span class="example-title">: A minimal controlled identifier document</span>
   </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://vendor.example"</span><span class="hljs-punctuation">,</span>
 <span class="hljs-punctuation">}</span></code></pre>
       </div>
         <div class="example" id="example-a-controlled-identifier-document-with-verification-method">
         <div class="marker">
-    <a class="self-link" href="#example-a-controlled-identifier-document-with-verification-method">Example<bdi> 16</bdi></a><span class="example-title">: A controlled identifier document with verification method</span>
+    <a class="self-link" href="#example-a-controlled-identifier-document-with-verification-method">Example<bdi> 15</bdi></a><span class="example-title">: A controlled identifier document with verification method</span>
   </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/issuers/565049"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"verificationMethod"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span>
@@ -3698,7 +3640,7 @@ d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
       </div>
         <div class="example" id="example-a-controlled-identifier-document-with-verification-relationships">
         <div class="marker">
-    <a class="self-link" href="#example-a-controlled-identifier-document-with-verification-relationships">Example<bdi> 17</bdi></a><span class="example-title">: A controlled identifier document with verification relationships</span>
+    <a class="self-link" href="#example-a-controlled-identifier-document-with-verification-relationships">Example<bdi> 16</bdi></a><span class="example-title">: A controlled identifier document with verification relationships</span>
   </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/issuers/565049"</span><span class="hljs-punctuation">,</span>
   <span class="hljs-attr">"verificationMethod"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span>
@@ -3719,7 +3661,7 @@ d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
       </div>
         <div class="example" id="example-a-verifiable-credential-controlled-identifier-document">
         <div class="marker">
-    <a class="self-link" href="#example-a-verifiable-credential-controlled-identifier-document">Example<bdi> 18</bdi></a><span class="example-title">: A verifiable credential controlled identifier document</span>
+    <a class="self-link" href="#example-a-verifiable-credential-controlled-identifier-document">Example<bdi> 17</bdi></a><span class="example-title">: A verifiable credential controlled identifier document</span>
   </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
   <span class="hljs-attr">"@context"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
     <span class="hljs-string">"https://www.w3.org/ns/did/v1"</span><span class="hljs-punctuation">,</span>
@@ -3796,7 +3738,7 @@ d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
         
         <div class="example" id="example-a-revocable-credential-with-multiple-subjects">
         <div class="marker">
-    <a class="self-link" href="#example-a-revocable-credential-with-multiple-subjects">Example<bdi> 19</bdi></a><span class="example-title">: A revocable credential with multiple subjects</span>
+    <a class="self-link" href="#example-a-revocable-credential-with-multiple-subjects">Example<bdi> 18</bdi></a><span class="example-title">: A revocable credential with multiple subjects</span>
   </div> 
       <div class="vc-tabbed"><input type="radio" id="vc-tab10unsigned" name="vc-tabs10" checked=""><input type="radio" id="vc-tab10jose" name="vc-tabs10"><input type="radio" id="vc-tab10cose" name="vc-tabs10"><input type="radio" id="vc-tab10sd-jwt" name="vc-tabs10"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab10unsigned"><abbr title="Unsecured credential">Credential</abbr></label></li><li class="vc-tab"><label for="vc-tab10jose"><abbr title="Secured with JOSE">jose</abbr></label></li><li class="vc-tab"><label for="vc-tab10cose"><abbr title="Secured with COSE">cose</abbr></label></li><li class="vc-tab"><label for="vc-tab10sd-jwt"><abbr title="Secured with SD-JWT">sd-jwt</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 540px;"><pre class="nohighlight vc" data-vc-tabs="jose sd-jwt cose">{
   "@context": ["https://www.w3.org/ns/credentials/v2",
@@ -3870,7 +3812,7 @@ d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
 <div class="jwt-compact">
 <span class="jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
 .<span class="jwt-payload">eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9jcmVkZW50aWFscy8yMzg5NDY3MjM5NCIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJLOVVuaXRDcmVkZW50aWFsIl0sImlzc3VlciI6eyJpZCI6Imh0dHBzOi8vY29udG9zby5leGFtcGxlIn0sInZhbGlkRnJvbSI6IjIwMTUtMDQtMTZUMDU6MTE6MzIuNDMyWiIsImNyZWRlbnRpYWxTdGF0dXMiOnsiaWQiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9jcmVkZW50aWFscy9zdGF0dXMvNCMyNzM3NjIiLCJ0eXBlIjoiU3RhdHVzTGlzdDIwMjFFbnRyeSIsInN0YXR1c1B1cnBvc2UiOiJyZXZvY2F0aW9uIiwic3RhdHVzTGlzdEluZGV4IjoiMjczNzYyIiwic3RhdHVzTGlzdENyZWRlbnRpYWwiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9jcmVkZW50aWFscy9zdGF0dXMvNCJ9LCJjcmVkZW50aWFsU3ViamVjdCI6W3siaWQiOiJkaWQ6ZXhhbXBsZToxMzEyMzg3NjQxIiwidHlwZSI6IlBlcnNvbiJ9LHsiaWQiOiJkaWQ6ZXhhbXBsZTo2Mzg4ODIzMSIsInR5cGUiOiJEb2cifV19</span>
-.<span class="jwt-signature">2nCCKfLd1xSpBDpuEdo3_jSBqwUIZfG57xDMmwNmGAx58rQyW7kwq0ySx1boOxhgMyfRZTzFiHwtkHA0lADlcA</span>
+.<span class="jwt-signature">yQi8SfQIk9NoQJfJGJnBjFXe9kXZMMS7GvX1o_BztgC4jMMQoQiLTo2nPH_o6OP1IszRuW_M3ubRZs3WEoiZVw</span>
 </div>
 </div>
     </div>
@@ -3913,110 +3855,110 @@ d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
 </pre>
 <strong>application/vc+cose</strong>
 <div class="cose-text">
-d28444a1013822a059027c7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f63726564656e7469616c732f3233383934363732333934222c2274797065223a5b2256657269666961626c6543726564656e7469616c222c224b39556e697443726564656e7469616c225d2c22697373756572223a7b226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c65227d2c2276616c696446726f6d223a22323031352d30342d31365430353a31313a33322e3433325a222c2263726564656e7469616c537461747573223a7b226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f63726564656e7469616c732f7374617475732f3423323733373632222c2274797065223a225374617475734c69737432303231456e747279222c22737461747573507572706f7365223a227265766f636174696f6e222c227374617475734c697374496e646578223a22323733373632222c227374617475734c69737443726564656e7469616c223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f63726564656e7469616c732f7374617475732f34227d2c2263726564656e7469616c5375626a656374223a5b7b226964223a226469643a6578616d706c653a31333132333837363431222c2274797065223a22506572736f6e227d2c7b226964223a226469643a6578616d706c653a3633383838323331222c2274797065223a22446f67227d5d7d5840631cba48a4f4f3942b8574ac576ca3becd1cb14ffc5bdeec456915129bfc491abd3931391a5c8ef1e1108591274cc6676941d99bf6efd6d3f650b54e930a01ee
+d28444a1013822a059027c7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f63726564656e7469616c732f3233383934363732333934222c2274797065223a5b2256657269666961626c6543726564656e7469616c222c224b39556e697443726564656e7469616c225d2c22697373756572223a7b226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c65227d2c2276616c696446726f6d223a22323031352d30342d31365430353a31313a33322e3433325a222c2263726564656e7469616c537461747573223a7b226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f63726564656e7469616c732f7374617475732f3423323733373632222c2274797065223a225374617475734c69737432303231456e747279222c22737461747573507572706f7365223a227265766f636174696f6e222c227374617475734c697374496e646578223a22323733373632222c227374617475734c69737443726564656e7469616c223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f63726564656e7469616c732f7374617475732f34227d2c2263726564656e7469616c5375626a656374223a5b7b226964223a226469643a6578616d706c653a31333132333837363431222c2274797065223a22506572736f6e227d2c7b226964223a226469643a6578616d706c653a3633383838323331222c2274797065223a22446f67227d5d7d58400a6163b3d6e0157f54f5075c112326aa0bfadaeae67c9a49e5028c893529adb474569b9c17eaf9d507f2932e73182867de46a7808be1650ef1ac1f75d685f075
 </div>
     </div>
 </div></div><div class="vc-tab-content" style="min-height: 540px;"><div>
 
 <div class="sd-jwt-tabbed">
-    <input type="radio" id="sd-jwt-10-iinktqp-encoded" name="sd-jwt-10-iinktqp-tabs" checked="checked" tabindex="0">
-    <input type="radio" id="sd-jwt-10-iinktqp-decoded" name="sd-jwt-10-iinktqp-tabs" tabindex="0">
-    <input type="radio" id="sd-jwt-10-iinktqp-disclosures" name="sd-jwt-10-iinktqp-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-10-wsqgrg5-encoded" name="sd-jwt-10-wsqgrg5-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="sd-jwt-10-wsqgrg5-decoded" name="sd-jwt-10-wsqgrg5-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-10-wsqgrg5-disclosures" name="sd-jwt-10-wsqgrg5-tabs" tabindex="0">
     <ul class="sd-jwt-tabs">
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-10-iinktqp-encoded">Encoded</label>
+        <label for="sd-jwt-10-wsqgrg5-encoded">Encoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-10-iinktqp-decoded">Decoded</label>
+        <label for="sd-jwt-10-wsqgrg5-decoded">Decoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-10-iinktqp-disclosures">Issuer Disclosures</label>
+        <label for="sd-jwt-10-wsqgrg5-disclosures">Issuer Disclosures</label>
       </li>
     </ul>
-    <div class="sd-jwt-tab-content" id="sd-jwt-10-iinktqp-content-encoded">
+    <div class="sd-jwt-tab-content" id="sd-jwt-10-wsqgrg5-content-encoded">
       
 <div class="sd-jwt-compact">
 <span class="sd-jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
-.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1NjU5NzksImV4cCI6MTc0Njc3NTU3OSwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjp7Il9zZCI6WyIxSXJZbWlEdTB0czZrRHJReGl2Q29vWTkzN3JRRmU2QVJxRkpjNWRsQmVnIl19LCJ2YWxpZEZyb20iOiIyMDE1LTA0LTE2VDA1OjExOjMyLjQzMloiLCJjcmVkZW50aWFsU3RhdHVzIjp7InN0YXR1c1B1cnBvc2UiOiJyZXZvY2F0aW9uIiwic3RhdHVzTGlzdEluZGV4IjoiMjczNzYyIiwic3RhdHVzTGlzdENyZWRlbnRpYWwiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9jcmVkZW50aWFscy9zdGF0dXMvNCIsIl9zZCI6WyI2d3UxM09ETVplWFItd2JaYkV2R0liczZvRzRDcEpFTGUydmk5Qm0yVk5jIiwiZC1ZaEtIeVh3TjZfN3k3aHQzSFhBWXBmWlBSNHF1RWNIU3FTMmNpSGNNZyJdfSwiY3JlZGVudGlhbFN1YmplY3QiOlt7Il9zZCI6WyJGUUxGSlVFOFNiczg0VXRyVXE4eXRYQ3pleUlTc1E5NzVzZ3ZPdm9rWldvIiwiT093dlFHbnFrMzJvWmVSdFpfbE1zNVRKbXRzU1B6OE5naGpxN3FXdGpJayJdfSx7Il9zZCI6WyJLazZacDFSN0NoaGVsNVFESzVVaWMzM2RTNlRwQm1lLUJHMFo3ZTkwU1pJIiwiZDNRUTR0MU5SX2hyOU9qQVYzT0pvek9DMkVSbWhrTVMwSWdvZUJHVXZSYyJdfV0sIl9zZCI6WyJUejdWaTBjSHY1SUtpc3FtRXlkX2JFYjRpTk9aRjM3U2loX1haVWduQW9vIiwielFvTGJLSXJZdHdmVHo0MWRudmFGQkhBZU51TTBRczJNQUExdEdOcE5NayJdfQ</span>
-.<span class="sd-jwt-signature">ErZqDE7lZt75i64nSqE5pC95vkLsNG9bP12ZrM0RS7nypW3EPYS4g46scjGS-IZ8zmZXnerqLOnQc-cc40GyPg</span>
-~<span class="sd-jwt-disclosure">WyJaZmM1VUdWOXlxNkF0RmJUcGdNc3p3IiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzLzIzODk0NjcyMzk0Il0</span>~<span class="sd-jwt-disclosure">WyJYMmhmenNabTdkTkU2dWtFdkxuV0lnIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIks5VW5pdENyZWRlbnRpYWwiXV0</span>~<span class="sd-jwt-disclosure">WyJkWlBPZ1pnZnhFazBUdklSMVpmdnhBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlIl0</span>~<span class="sd-jwt-disclosure">WyJNYmtGMUFrOGxRSVdiSzcwYWtJZUZ3IiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzL3N0YXR1cy80IzI3Mzc2MiJd</span>~<span class="sd-jwt-disclosure">WyJqaGhGaXNyZTBjWDMzYjJwcm9TSkpBIiwgInR5cGUiLCAiU3RhdHVzTGlzdDIwMjFFbnRyeSJd</span>~<span class="sd-jwt-disclosure">WyJ6cEdPMVBKNVZnTmVfOHVlREVsTy1RIiwgImlkIiwgImRpZDpleGFtcGxlOjEzMTIzODc2NDEiXQ</span>~<span class="sd-jwt-disclosure">WyJPVU1OMkk0ZTVKMmVWUlhEVHJ5ZG9RIiwgInR5cGUiLCAiUGVyc29uIl0</span>~<span class="sd-jwt-disclosure">WyJkSlhGXy1VT1VubFVCX0UzcWhZQXNBIiwgImlkIiwgImRpZDpleGFtcGxlOjYzODg4MjMxIl0</span>~<span class="sd-jwt-disclosure">WyJTTWNwR1ctOTJfaFNqSnlWa2JiNDdRIiwgInR5cGUiLCAiRG9nIl0</span>~
+.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1OTQ3NzIsImV4cCI6MTc0NjgwNDM3MiwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjp7Il9zZCI6WyJtU2cwa1pDNzdYNmpVVkhxMklJWU55Z1NsWEtLVnpUU2RoRldvTll5eE9BIl19LCJ2YWxpZEZyb20iOiIyMDE1LTA0LTE2VDA1OjExOjMyLjQzMloiLCJjcmVkZW50aWFsU3RhdHVzIjp7InN0YXR1c1B1cnBvc2UiOiJyZXZvY2F0aW9uIiwic3RhdHVzTGlzdEluZGV4IjoiMjczNzYyIiwic3RhdHVzTGlzdENyZWRlbnRpYWwiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9jcmVkZW50aWFscy9zdGF0dXMvNCIsIl9zZCI6WyJtdjZDZXh1LWZ3UGRMVm81WllIN3ljUzhtRkdUUVZNeFRocDJud0VDQlQ0IiwidFFhbnRYLWhoU3BPQU5PVi0xeEtGX0dSb2Y1TG5tNkpiUEtxYm9MdDdSQSJdfSwiY3JlZGVudGlhbFN1YmplY3QiOlt7Il9zZCI6WyJTTXhGcmxPY3N1UHlWTjVMUkJiVlRMWjZ4TVFxYVVCTkJTNjdrTF9YZF93IiwiVkdONDR1NXNWUWduY0VJZmdFTEplWlI5YnBlVEdjOFpBY01tVjZNUXR0ZyJdfSx7Il9zZCI6WyJNQmVfN0hLajAtUDJaZnR0dzV2WWRKMHhVZTN4dHBpMndpZGJTbndfWk9nIiwiZWMxeVVZMEM3NUo3cGd5TXpPNUR3OTBwRFVyM2ZYN1o4R3Q4d1VBSVl6SSJdfV0sIl9zZCI6WyJGSVdneTM5VXp6WjVfYU9LVjNwbzZFeWpYbUJOOWM4b0lRMmpLZV9GdGIwIiwiRm1EY2RlbUlzcGRtUU1NZXVTLTRONEo1d0NGb2JCQnVpdVVlbEdzV012VSJdfQ</span>
+.<span class="sd-jwt-signature">iQnJDPmi4pn3fMLecrbwAqfUc0UXJWzUd4J20mUX3rRJSp74r2gRjrd1OATFkVjLsSyBAOBk3xbP5tc9nq9D7A</span>
+~<span class="sd-jwt-disclosure">WyI0SWQ0aFVoUzMxQThXelBRTlhPUWJBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzLzIzODk0NjcyMzk0Il0</span>~<span class="sd-jwt-disclosure">WyJJSFNyZnVZR0YtcWk5OXcySWJkYUJBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIks5VW5pdENyZWRlbnRpYWwiXV0</span>~<span class="sd-jwt-disclosure">WyJDeEpTQmlKeDVtdVgzZkhSRmZDYlBRIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlIl0</span>~<span class="sd-jwt-disclosure">WyJuQVhZQ29yTUNGaGRJMDhZNzh5ckNBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzL3N0YXR1cy80IzI3Mzc2MiJd</span>~<span class="sd-jwt-disclosure">WyI1aUJCSmdual9pMkpQZHdRTTVzRlh3IiwgInR5cGUiLCAiU3RhdHVzTGlzdDIwMjFFbnRyeSJd</span>~<span class="sd-jwt-disclosure">WyJBNzFORTByODBmN3ZCVkNrcmU0N01BIiwgImlkIiwgImRpZDpleGFtcGxlOjEzMTIzODc2NDEiXQ</span>~<span class="sd-jwt-disclosure">WyJHaFg4N1lJMzg0cjV5b0hXOENTOEJ3IiwgInR5cGUiLCAiUGVyc29uIl0</span>~<span class="sd-jwt-disclosure">WyJhQWxrLVhrQ0RCaFItN1Z5NnBXZmNnIiwgImlkIiwgImRpZDpleGFtcGxlOjYzODg4MjMxIl0</span>~<span class="sd-jwt-disclosure">WyJzLTFSWGdUWVVQWGJNZ2JLMHVaX0NRIiwgInR5cGUiLCAiRG9nIl0</span>~
 </div>
     </div>
-    <div class="sd-jwt-tab-content" id="sd-jwt-10-iinktqp-content-decoded">
+    <div class="sd-jwt-tab-content" id="sd-jwt-10-wsqgrg5-content-decoded">
       <pre class="header-value">{<br>&nbsp;&nbsp;"kid":&nbsp;"ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",<br>&nbsp;&nbsp;"alg":&nbsp;"ES256"<br>}</pre>
-      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745565979,<br>&nbsp;&nbsp;"exp":&nbsp;1746775579,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"issuer":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"1IrYmiDu0ts6kDrQxivCooY937rQFe6ARqFJc5dlBeg"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"validFrom":&nbsp;"2015-04-16T05:11:32.432Z",<br>&nbsp;&nbsp;"credentialStatus":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"statusPurpose":&nbsp;"revocation",<br>&nbsp;&nbsp;&nbsp;&nbsp;"statusListIndex":&nbsp;"273762",<br>&nbsp;&nbsp;&nbsp;&nbsp;"statusListCredential":&nbsp;"https://contoso.example/credentials/status/4",<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"6wu13ODMZeXR-wbZbEvGIbs6oG4CpJELe2vi9Bm2VNc",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"d-YhKHyXwN6_7y7ht3HXAYpfZPR4quEcHSqS2ciHcMg"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"credentialSubject":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"FQLFJUE8Sbs84UtrUq8ytXCzeyISsQ975sgvOvokZWo",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"OOwvQGnqk32oZeRtZ_lMs5TJmtsSPz8Nghjq7qWtjIk"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Kk6Zp1R7Chhel5QDK5Uic33dS6TpBme-BG0Z7e90SZI",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"d3QQ4t1NR_hr9OjAV3OJozOC2ERmhkMS0IgoeBGUvRc"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"Tz7Vi0cHv5IKisqmEyd_bEb4iNOZF37Sih_XZUgnAoo",<br>&nbsp;&nbsp;&nbsp;&nbsp;"zQoLbKIrYtwfTz41dnvaFBHAeNuM0Qs2MAA1tGNpNMk"<br>&nbsp;&nbsp;]<br>}</pre>
+      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745594772,<br>&nbsp;&nbsp;"exp":&nbsp;1746804372,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"issuer":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"mSg0kZC77X6jUVHq2IIYNygSlXKKVzTSdhFWoNYyxOA"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"validFrom":&nbsp;"2015-04-16T05:11:32.432Z",<br>&nbsp;&nbsp;"credentialStatus":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"statusPurpose":&nbsp;"revocation",<br>&nbsp;&nbsp;&nbsp;&nbsp;"statusListIndex":&nbsp;"273762",<br>&nbsp;&nbsp;&nbsp;&nbsp;"statusListCredential":&nbsp;"https://contoso.example/credentials/status/4",<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"mv6Cexu-fwPdLVo5ZYH7ycS8mFGTQVMxThp2nwECBT4",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"tQantX-hhSpOANOV-1xKF_GRof5Lnm6JbPKqboLt7RA"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"credentialSubject":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"SMxFrlOcsuPyVN5LRBbVTLZ6xMQqaUBNBS67kL_Xd_w",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"VGN44u5sVQgncEIfgELJeZR9bpeTGc8ZAcMmV6MQttg"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"MBe_7HKj0-P2Zfttw5vYdJ0xUe3xtpi2widbSnw_ZOg",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"ec1yUY0C75J7pgyMzO5Dw90pDUr3fX7Z8Gt8wUAIYzI"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"FIWgy39UzzZ5_aOKV3po6EyjXmBN9c8oIQ2jKe_Ftb0",<br>&nbsp;&nbsp;&nbsp;&nbsp;"FmDcdemIspdmQMMeuS-4N4J5wCFobBBuiuUelGsWMvU"<br>&nbsp;&nbsp;]<br>}</pre>
     </div>
-    <div class="sd-jwt-tab-content" id="sd-jwt-10-iinktqp-content-disclosures">
+    <div class="sd-jwt-tab-content" id="sd-jwt-10-wsqgrg5-content-disclosures">
       <div class="disclosures">
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-zQoLbKIrYtwfTz41dnvaFBHAeNuM0Qs2MAA1tGNpNMk">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">zQoLbKIrYtwfTz41dnvaFBHAeNuM0Qs2MAA1tGNpNMk</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJaZmM1VUdWOXlxNkF0RmJUcGdNc3p3IiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzLzIzODk0NjcyMzk0Il0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"Zfc5UGV9yq6AtFbTpgMszw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example/credentials/23894672394"<br>]</span></p>
+    <h3 id="sd-jwt-claim-FIWgy39UzzZ5_aOKV3po6EyjXmBN9c8oIQ2jKe_Ftb0">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">FIWgy39UzzZ5_aOKV3po6EyjXmBN9c8oIQ2jKe_Ftb0</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyI0SWQ0aFVoUzMxQThXelBRTlhPUWJBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzLzIzODk0NjcyMzk0Il0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"4Id4hUhS31A8WzPQNXOQbA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example/credentials/23894672394"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-Tz7Vi0cHv5IKisqmEyd_bEb4iNOZF37Sih_XZUgnAoo">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">Tz7Vi0cHv5IKisqmEyd_bEb4iNOZF37Sih_XZUgnAoo</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJYMmhmenNabTdkTkU2dWtFdkxuV0lnIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIks5VW5pdENyZWRlbnRpYWwiXV0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"X2hfzsZm7dNE6ukEvLnWIg",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"VerifiableCredential",<br>&nbsp;&nbsp;&nbsp;&nbsp;"K9UnitCredential"<br>&nbsp;&nbsp;]<br>]</span></p>
+    <h3 id="sd-jwt-claim-FmDcdemIspdmQMMeuS-4N4J5wCFobBBuiuUelGsWMvU">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">FmDcdemIspdmQMMeuS-4N4J5wCFobBBuiuUelGsWMvU</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJJSFNyZnVZR0YtcWk5OXcySWJkYUJBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIks5VW5pdENyZWRlbnRpYWwiXV0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"IHSrfuYGF-qi99w2IbdaBA",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"VerifiableCredential",<br>&nbsp;&nbsp;&nbsp;&nbsp;"K9UnitCredential"<br>&nbsp;&nbsp;]<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-1IrYmiDu0ts6kDrQxivCooY937rQFe6ARqFJc5dlBeg">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">1IrYmiDu0ts6kDrQxivCooY937rQFe6ARqFJc5dlBeg</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJkWlBPZ1pnZnhFazBUdklSMVpmdnhBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlIl0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"dZPOgZgfxEk0TvIR1ZfvxA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example"<br>]</span></p>
+    <h3 id="sd-jwt-claim-mSg0kZC77X6jUVHq2IIYNygSlXKKVzTSdhFWoNYyxOA">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">mSg0kZC77X6jUVHq2IIYNygSlXKKVzTSdhFWoNYyxOA</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJDeEpTQmlKeDVtdVgzZkhSRmZDYlBRIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"CxJSBiJx5muX3fHRFfCbPQ",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-6wu13ODMZeXR-wbZbEvGIbs6oG4CpJELe2vi9Bm2VNc">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">6wu13ODMZeXR-wbZbEvGIbs6oG4CpJELe2vi9Bm2VNc</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJNYmtGMUFrOGxRSVdiSzcwYWtJZUZ3IiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzL3N0YXR1cy80IzI3Mzc2MiJd</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"MbkF1Ak8lQIWbK70akIeFw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example/credentials/status/4#273762"<br>]</span></p>
+    <h3 id="sd-jwt-claim-mv6Cexu-fwPdLVo5ZYH7ycS8mFGTQVMxThp2nwECBT4">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">mv6Cexu-fwPdLVo5ZYH7ycS8mFGTQVMxThp2nwECBT4</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJuQVhZQ29yTUNGaGRJMDhZNzh5ckNBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzL3N0YXR1cy80IzI3Mzc2MiJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"nAXYCorMCFhdI08Y78yrCA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example/credentials/status/4#273762"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-d-YhKHyXwN6_7y7ht3HXAYpfZPR4quEcHSqS2ciHcMg">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">d-YhKHyXwN6_7y7ht3HXAYpfZPR4quEcHSqS2ciHcMg</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJqaGhGaXNyZTBjWDMzYjJwcm9TSkpBIiwgInR5cGUiLCAiU3RhdHVzTGlzdDIwMjFFbnRyeSJd</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"jhhFisre0cX33b2proSJJA",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"StatusList2021Entry"<br>]</span></p>
+    <h3 id="sd-jwt-claim-tQantX-hhSpOANOV-1xKF_GRof5Lnm6JbPKqboLt7RA">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">tQantX-hhSpOANOV-1xKF_GRof5Lnm6JbPKqboLt7RA</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyI1aUJCSmdual9pMkpQZHdRTTVzRlh3IiwgInR5cGUiLCAiU3RhdHVzTGlzdDIwMjFFbnRyeSJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"5iBBJgnj_i2JPdwQM5sFXw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"StatusList2021Entry"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-OOwvQGnqk32oZeRtZ_lMs5TJmtsSPz8Nghjq7qWtjIk">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">OOwvQGnqk32oZeRtZ_lMs5TJmtsSPz8Nghjq7qWtjIk</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ6cEdPMVBKNVZnTmVfOHVlREVsTy1RIiwgImlkIiwgImRpZDpleGFtcGxlOjEzMTIzODc2NDEiXQ</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"zpGO1PJ5VgNe_8ueDElO-Q",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"did:example:1312387641"<br>]</span></p>
+    <h3 id="sd-jwt-claim-SMxFrlOcsuPyVN5LRBbVTLZ6xMQqaUBNBS67kL_Xd_w">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">SMxFrlOcsuPyVN5LRBbVTLZ6xMQqaUBNBS67kL_Xd_w</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJBNzFORTByODBmN3ZCVkNrcmU0N01BIiwgImlkIiwgImRpZDpleGFtcGxlOjEzMTIzODc2NDEiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"A71NE0r80f7vBVCkre47MA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"did:example:1312387641"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-FQLFJUE8Sbs84UtrUq8ytXCzeyISsQ975sgvOvokZWo">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">FQLFJUE8Sbs84UtrUq8ytXCzeyISsQ975sgvOvokZWo</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJPVU1OMkk0ZTVKMmVWUlhEVHJ5ZG9RIiwgInR5cGUiLCAiUGVyc29uIl0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"OUMN2I4e5J2eVRXDTrydoQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"Person"<br>]</span></p>
+    <h3 id="sd-jwt-claim-VGN44u5sVQgncEIfgELJeZR9bpeTGc8ZAcMmV6MQttg">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">VGN44u5sVQgncEIfgELJeZR9bpeTGc8ZAcMmV6MQttg</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJHaFg4N1lJMzg0cjV5b0hXOENTOEJ3IiwgInR5cGUiLCAiUGVyc29uIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"GhX87YI384r5yoHW8CS8Bw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"Person"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-Kk6Zp1R7Chhel5QDK5Uic33dS6TpBme-BG0Z7e90SZI">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">Kk6Zp1R7Chhel5QDK5Uic33dS6TpBme-BG0Z7e90SZI</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJkSlhGXy1VT1VubFVCX0UzcWhZQXNBIiwgImlkIiwgImRpZDpleGFtcGxlOjYzODg4MjMxIl0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"dJXF_-UOUnlUB_E3qhYAsA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"did:example:63888231"<br>]</span></p>
+    <h3 id="sd-jwt-claim-MBe_7HKj0-P2Zfttw5vYdJ0xUe3xtpi2widbSnw_ZOg">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">MBe_7HKj0-P2Zfttw5vYdJ0xUe3xtpi2widbSnw_ZOg</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJhQWxrLVhrQ0RCaFItN1Z5NnBXZmNnIiwgImlkIiwgImRpZDpleGFtcGxlOjYzODg4MjMxIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"aAlk-XkCDBhR-7Vy6pWfcg",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"did:example:63888231"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-d3QQ4t1NR_hr9OjAV3OJozOC2ERmhkMS0IgoeBGUvRc">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">d3QQ4t1NR_hr9OjAV3OJozOC2ERmhkMS0IgoeBGUvRc</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJTTWNwR1ctOTJfaFNqSnlWa2JiNDdRIiwgInR5cGUiLCAiRG9nIl0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"SMcpGW-92_hSjJyVkbb47Q",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"Dog"<br>]</span></p>
+    <h3 id="sd-jwt-claim-ec1yUY0C75J7pgyMzO5Dw90pDUr3fX7Z8Gt8wUAIYzI">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">ec1yUY0C75J7pgyMzO5Dw90pDUr3fX7Z8Gt8wUAIYzI</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJzLTFSWGdUWVVQWGJNZ2JLMHVaX0NRIiwgInR5cGUiLCAiRG9nIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"s-1RXgTYUPXbMgbK0uZ_CQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"Dog"<br>]</span></p>
 </div>
 </div>
     </div>
@@ -4025,7 +3967,7 @@ d28444a1013822a059027c7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
 </div></div></div></div>
         <div class="example" id="example-a-credential-with-a-schema">
         <div class="marker">
-    <a class="self-link" href="#example-a-credential-with-a-schema">Example<bdi> 20</bdi></a><span class="example-title">: A credential with a schema</span>
+    <a class="self-link" href="#example-a-credential-with-a-schema">Example<bdi> 19</bdi></a><span class="example-title">: A credential with a schema</span>
   </div> 
       <div class="vc-tabbed"><input type="radio" id="vc-tab11unsigned" name="vc-tabs11" checked=""><input type="radio" id="vc-tab11jose" name="vc-tabs11"><input type="radio" id="vc-tab11cose" name="vc-tabs11"><input type="radio" id="vc-tab11sd-jwt" name="vc-tabs11"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab11unsigned"><abbr title="Unsecured credential">Credential</abbr></label></li><li class="vc-tab"><label for="vc-tab11jose"><abbr title="Secured with JOSE">jose</abbr></label></li><li class="vc-tab"><label for="vc-tab11cose"><abbr title="Secured with COSE">cose</abbr></label></li><li class="vc-tab"><label for="vc-tab11sd-jwt"><abbr title="Secured with SD-JWT">sd-jwt</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 410px;"><pre class="nohighlight vc" data-vc-tabs="jose sd-jwt cose">{
   "@context": [
@@ -4083,7 +4025,7 @@ d28444a1013822a059027c7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
 <div class="jwt-compact">
 <span class="jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
 .<span class="jwt-payload">eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9jcmVkZW50aWFscy8zNTMyNzI1NSIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJLWUNFeGFtcGxlIl0sImlzc3VlciI6ImRpZDp3ZWI6Y29udG9zby5leGFtcGxlIiwidmFsaWRGcm9tIjoiMjAxOS0wNS0yNVQwMzoxMDoxNi45OTJaIiwidmFsaWRVbnRpbCI6IjIwMjctMDUtMjVUMDM6MTA6MTYuOTkyWiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiaWQiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9iYWZ5YmVpZ2R5ci4uLmxxYWJmM29jbGd0cXk1NWZiemRpIiwidHlwZSI6Ikpzb25TY2hlbWEifSwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZToxMjMxNTg4IiwidHlwZSI6IlBlcnNvbiJ9fQ</span>
-.<span class="jwt-signature">hGoe60DdeGw1QK5Ni59upvSP5-DdXQcpJHqDXHTgIzyuEK5bL0w5pjyMQg3pboNF6TEoGEb122YIMuPs9QYedA</span>
+.<span class="jwt-signature">L7mcUXK-zs1mpGF1iuelE0rr_2RYE5_BorKyYhvv4F5pezJgzH0mv6z-IC-ZXp9ZG1R1Y5k02BvHFX7_Ef5e3A</span>
 </div>
 </div>
     </div>
@@ -4116,86 +4058,86 @@ d28444a1013822a059027c7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
 </pre>
 <strong>application/vc+cose</strong>
 <div class="cose-text">
-d28444a1013822a05901e47b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f63726564656e7469616c732f3335333237323535222c2274797065223a5b2256657269666961626c6543726564656e7469616c222c224b59434578616d706c65225d2c22697373756572223a226469643a7765623a636f6e746f736f2e6578616d706c65222c2276616c696446726f6d223a22323031392d30352d32355430333a31303a31362e3939325a222c2276616c6964556e74696c223a22323032372d30352d32355430333a31303a31362e3939325a222c2263726564656e7469616c536368656d61223a7b226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f62616679626569676479722e2e2e6c71616266336f636c67747179353566627a6469222c2274797065223a224a736f6e536368656d61227d2c2263726564656e7469616c5375626a656374223a7b226964223a226469643a6578616d706c653a31323331353838222c2274797065223a22506572736f6e227d7d584092951e60aa5f26b98270c1c6d4186fd04f54d25ebeac4f490ec06439459cb61519a7bd0629de08912816e9273970bca368cb742b3f25d47925d3b92b58f9831e
+d28444a1013822a05901e47b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f63726564656e7469616c732f3335333237323535222c2274797065223a5b2256657269666961626c6543726564656e7469616c222c224b59434578616d706c65225d2c22697373756572223a226469643a7765623a636f6e746f736f2e6578616d706c65222c2276616c696446726f6d223a22323031392d30352d32355430333a31303a31362e3939325a222c2276616c6964556e74696c223a22323032372d30352d32355430333a31303a31362e3939325a222c2263726564656e7469616c536368656d61223a7b226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f62616679626569676479722e2e2e6c71616266336f636c67747179353566627a6469222c2274797065223a224a736f6e536368656d61227d2c2263726564656e7469616c5375626a656374223a7b226964223a226469643a6578616d706c653a31323331353838222c2274797065223a22506572736f6e227d7d5840d89478bd15d530c2cb8af5ad917d257590979cd5f51552effc65552df35326cd08cce2b16f8f6a14166e2b7d62e64c9ef5ab7d4fd6304629c974949299049081
 </div>
     </div>
 </div></div><div class="vc-tab-content" style="min-height: 410px;"><div>
 
 <div class="sd-jwt-tabbed">
-    <input type="radio" id="sd-jwt-11-ibdtjwb-encoded" name="sd-jwt-11-ibdtjwb-tabs" checked="checked" tabindex="0">
-    <input type="radio" id="sd-jwt-11-ibdtjwb-decoded" name="sd-jwt-11-ibdtjwb-tabs" tabindex="0">
-    <input type="radio" id="sd-jwt-11-ibdtjwb-disclosures" name="sd-jwt-11-ibdtjwb-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-11-9rr0j6c-encoded" name="sd-jwt-11-9rr0j6c-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="sd-jwt-11-9rr0j6c-decoded" name="sd-jwt-11-9rr0j6c-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-11-9rr0j6c-disclosures" name="sd-jwt-11-9rr0j6c-tabs" tabindex="0">
     <ul class="sd-jwt-tabs">
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-11-ibdtjwb-encoded">Encoded</label>
+        <label for="sd-jwt-11-9rr0j6c-encoded">Encoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-11-ibdtjwb-decoded">Decoded</label>
+        <label for="sd-jwt-11-9rr0j6c-decoded">Decoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-11-ibdtjwb-disclosures">Issuer Disclosures</label>
+        <label for="sd-jwt-11-9rr0j6c-disclosures">Issuer Disclosures</label>
       </li>
     </ul>
-    <div class="sd-jwt-tab-content" id="sd-jwt-11-ibdtjwb-content-encoded">
+    <div class="sd-jwt-tab-content" id="sd-jwt-11-9rr0j6c-content-encoded">
       
 <div class="sd-jwt-compact">
 <span class="sd-jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
-.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1NjU5NzksImV4cCI6MTc0Njc3NTU3OSwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiZGlkOndlYjpjb250b3NvLmV4YW1wbGUiLCJ2YWxpZEZyb20iOiIyMDE5LTA1LTI1VDAzOjEwOjE2Ljk5MloiLCJ2YWxpZFVudGlsIjoiMjAyNy0wNS0yNVQwMzoxMDoxNi45OTJaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiMFhteThmeTQ1aDBweDNFczNNZDR0NFRsbzdid0VWSE1yVUQ2djNweDE5WSIsIjl4WVVoWUpXVTZaWFNJR3hZVlN6cmoxcnhJemlCejZqakRSTWdHSEEzaDAiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Il9zZCI6WyJCa2JJVlRBM3U0RDlsdWNnOU9kQlRnVlI2UlNFSkZjLXpVR2lWQ2xsdTQ0IiwidVZjZ19MNldmS1hyTEJnTi05WGpKTUZ4MWR5VlVyRTRxamJ3QzJIaDNHZyJdfSwiX3NkIjpbIlVXT2tTdlljSmlkQ3lhbVl4SVUwQlpRaVIwSlZTa0pvOVUzTHpuZHFseWsiLCJuNmdQUXp6LVZyRG14ZXBUWE9OdUNNcTBqWGgySEJTMTdEZXlsTU1IU3VJIl19</span>
-.<span class="sd-jwt-signature">-kfP3LH0xRqFbmO6V90TBeiMc3ZqehP3Ow9utyRUAlyLnOfuTb6wU934PMsr5fKOJMRwxbweC3HDkgjz1_EPKA</span>
-~<span class="sd-jwt-disclosure">WyJ2aUdHenlGMFJkdExCTDFLOVlxU3hBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzLzM1MzI3MjU1Il0</span>~<span class="sd-jwt-disclosure">WyJvcDBwM1IwMkNTcW8wdEdRdkpFT1lBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIktZQ0V4YW1wbGUiXV0</span>~<span class="sd-jwt-disclosure">WyJQTHc3RnhOTHRBMEdMaWtCcl9sM0dBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2JhZnliZWlnZHlyLi4ubHFhYmYzb2NsZ3RxeTU1ZmJ6ZGkiXQ</span>~<span class="sd-jwt-disclosure">WyJrdkRrWkpERjZpNEN4NVlHbUxRWTFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span>~<span class="sd-jwt-disclosure">WyJSNERfV0FnSFU4WGRzRkx5eUxFaThnIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMzE1ODgiXQ</span>~<span class="sd-jwt-disclosure">WyJ1NVRZOFpsUlp4Q3JHck1GeENlTlBBIiwgInR5cGUiLCAiUGVyc29uIl0</span>~
+.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1OTQ3NzIsImV4cCI6MTc0NjgwNDM3MiwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiZGlkOndlYjpjb250b3NvLmV4YW1wbGUiLCJ2YWxpZEZyb20iOiIyMDE5LTA1LTI1VDAzOjEwOjE2Ljk5MloiLCJ2YWxpZFVudGlsIjoiMjAyNy0wNS0yNVQwMzoxMDoxNi45OTJaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiSGlhclpVRzdOVkhlVHhNSmZMRkdRTi0zdm1mZDdqVUN6d213NFhid2FCNCIsIktTeTlKVGljY1BQcHBvN2tuVTRaU3FxalpubzM1UnotOVJOTjBZNUVwbmciXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Il9zZCI6WyJBdmplbXo3U3JsQklPcFhUb2tJU1lONGlWNkVIQ21LTDRHSk1fOU9qUHJnIiwiYWVTMGtVVEZBanZvSVBQSVRnQl9CcDg4dm9lM2ZuSHFyQ3Z4LUNKckgxOCJdfSwiX3NkIjpbIjFqaV8zOWllbnBoWEVzck9LeHB1ZGc0MEFBQi1pUTlHQzhCRHNQcTJWMWciLCJVRTlSNmt0cG5XVTBya2Y3cXBGaE9WYTE0Z2M3SDc4d2U5d1FfbEUxSVdzIl19</span>
+.<span class="sd-jwt-signature">y-E31PUTem9cL6n-E6nVIx5h9a8OpnrSBZ3N2Ggn5PncgPqnMROBPzp-tIhS3yfwZnQQfQnEOAuAWhz-M392xA</span>
+~<span class="sd-jwt-disclosure">WyIxZ3Mxd3lXd002RC1tVWl3U1pnYjJBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzLzM1MzI3MjU1Il0</span>~<span class="sd-jwt-disclosure">WyJNLWlDZmZjZGdod1BFSXV2Wk9NODh3IiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIktZQ0V4YW1wbGUiXV0</span>~<span class="sd-jwt-disclosure">WyJ6TV9PQXNIMV9WMXBpZV9fU09QX3BBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2JhZnliZWlnZHlyLi4ubHFhYmYzb2NsZ3RxeTU1ZmJ6ZGkiXQ</span>~<span class="sd-jwt-disclosure">WyJnNzFUcFFIbHNoQUZjX2FhNDlTaWZ3IiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span>~<span class="sd-jwt-disclosure">WyJ1cUZTLWZobTBkaWlTa1BjYVlFMXhRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMzE1ODgiXQ</span>~<span class="sd-jwt-disclosure">WyJsRU5IX0ZBc253eVJkYnFSSHBkT2l3IiwgInR5cGUiLCAiUGVyc29uIl0</span>~
 </div>
     </div>
-    <div class="sd-jwt-tab-content" id="sd-jwt-11-ibdtjwb-content-decoded">
+    <div class="sd-jwt-tab-content" id="sd-jwt-11-9rr0j6c-content-decoded">
       <pre class="header-value">{<br>&nbsp;&nbsp;"kid":&nbsp;"ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",<br>&nbsp;&nbsp;"alg":&nbsp;"ES256"<br>}</pre>
-      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745565979,<br>&nbsp;&nbsp;"exp":&nbsp;1746775579,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"issuer":&nbsp;"did:web:contoso.example",<br>&nbsp;&nbsp;"validFrom":&nbsp;"2019-05-25T03:10:16.992Z",<br>&nbsp;&nbsp;"validUntil":&nbsp;"2027-05-25T03:10:16.992Z",<br>&nbsp;&nbsp;"credentialSchema":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"0Xmy8fy45h0px3Es3Md4t4Tlo7bwEVHMrUD6v3px19Y",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"9xYUhYJWU6ZXSIGxYVSzrj1rxIziBz6jjDRMgGHA3h0"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"credentialSubject":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"BkbIVTA3u4D9lucg9OdBTgVR6RSEJFc-zUGiVCllu44",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"uVcg_L6WfKXrLBgN-9XjJMFx1dyVUrE4qjbwC2Hh3Gg"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"UWOkSvYcJidCyamYxIU0BZQiR0JVSkJo9U3Lzndqlyk",<br>&nbsp;&nbsp;&nbsp;&nbsp;"n6gPQzz-VrDmxepTXONuCMq0jXh2HBS17DeylMMHSuI"<br>&nbsp;&nbsp;]<br>}</pre>
+      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745594772,<br>&nbsp;&nbsp;"exp":&nbsp;1746804372,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"issuer":&nbsp;"did:web:contoso.example",<br>&nbsp;&nbsp;"validFrom":&nbsp;"2019-05-25T03:10:16.992Z",<br>&nbsp;&nbsp;"validUntil":&nbsp;"2027-05-25T03:10:16.992Z",<br>&nbsp;&nbsp;"credentialSchema":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"HiarZUG7NVHeTxMJfLFGQN-3vmfd7jUCzwmw4XbwaB4",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"KSy9JTiccPPppo7knU4ZSqqjZno35Rz-9RNN0Y5Epng"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"credentialSubject":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Avjemz7SrlBIOpXTokISYN4iV6EHCmKL4GJM_9OjPrg",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"aeS0kUTFAjvoIPPITgB_Bp88voe3fnHqrCvx-CJrH18"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"1ji_39ienphXEsrOKxpudg40AAB-iQ9GC8BDsPq2V1g",<br>&nbsp;&nbsp;&nbsp;&nbsp;"UE9R6ktpnWU0rkf7qpFhOVa14gc7H78we9wQ_lE1IWs"<br>&nbsp;&nbsp;]<br>}</pre>
     </div>
-    <div class="sd-jwt-tab-content" id="sd-jwt-11-ibdtjwb-content-disclosures">
+    <div class="sd-jwt-tab-content" id="sd-jwt-11-9rr0j6c-content-disclosures">
       <div class="disclosures">
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-UWOkSvYcJidCyamYxIU0BZQiR0JVSkJo9U3Lzndqlyk">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">UWOkSvYcJidCyamYxIU0BZQiR0JVSkJo9U3Lzndqlyk</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ2aUdHenlGMFJkdExCTDFLOVlxU3hBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzLzM1MzI3MjU1Il0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"viGGzyF0RdtLBL1K9YqSxA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example/credentials/35327255"<br>]</span></p>
+    <h3 id="sd-jwt-claim-1ji_39ienphXEsrOKxpudg40AAB-iQ9GC8BDsPq2V1g">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">1ji_39ienphXEsrOKxpudg40AAB-iQ9GC8BDsPq2V1g</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyIxZ3Mxd3lXd002RC1tVWl3U1pnYjJBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzLzM1MzI3MjU1Il0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"1gs1wyWwM6D-mUiwSZgb2A",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example/credentials/35327255"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-n6gPQzz-VrDmxepTXONuCMq0jXh2HBS17DeylMMHSuI">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">n6gPQzz-VrDmxepTXONuCMq0jXh2HBS17DeylMMHSuI</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJvcDBwM1IwMkNTcW8wdEdRdkpFT1lBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIktZQ0V4YW1wbGUiXV0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"op0p3R02CSqo0tGQvJEOYA",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"VerifiableCredential",<br>&nbsp;&nbsp;&nbsp;&nbsp;"KYCExample"<br>&nbsp;&nbsp;]<br>]</span></p>
+    <h3 id="sd-jwt-claim-UE9R6ktpnWU0rkf7qpFhOVa14gc7H78we9wQ_lE1IWs">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">UE9R6ktpnWU0rkf7qpFhOVa14gc7H78we9wQ_lE1IWs</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJNLWlDZmZjZGdod1BFSXV2Wk9NODh3IiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIktZQ0V4YW1wbGUiXV0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"M-iCffcdghwPEIuvZOM88w",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"VerifiableCredential",<br>&nbsp;&nbsp;&nbsp;&nbsp;"KYCExample"<br>&nbsp;&nbsp;]<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-9xYUhYJWU6ZXSIGxYVSzrj1rxIziBz6jjDRMgGHA3h0">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">9xYUhYJWU6ZXSIGxYVSzrj1rxIziBz6jjDRMgGHA3h0</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJQTHc3RnhOTHRBMEdMaWtCcl9sM0dBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2JhZnliZWlnZHlyLi4ubHFhYmYzb2NsZ3RxeTU1ZmJ6ZGkiXQ</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"PLw7FxNLtA0GLikBr_l3GA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example/bafybeigdyr...lqabf3oclgtqy55fbzdi"<br>]</span></p>
+    <h3 id="sd-jwt-claim-HiarZUG7NVHeTxMJfLFGQN-3vmfd7jUCzwmw4XbwaB4">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">HiarZUG7NVHeTxMJfLFGQN-3vmfd7jUCzwmw4XbwaB4</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ6TV9PQXNIMV9WMXBpZV9fU09QX3BBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2JhZnliZWlnZHlyLi4ubHFhYmYzb2NsZ3RxeTU1ZmJ6ZGkiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"zM_OAsH1_V1pie__SOP_pA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example/bafybeigdyr...lqabf3oclgtqy55fbzdi"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-0Xmy8fy45h0px3Es3Md4t4Tlo7bwEVHMrUD6v3px19Y">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">0Xmy8fy45h0px3Es3Md4t4Tlo7bwEVHMrUD6v3px19Y</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJrdkRrWkpERjZpNEN4NVlHbUxRWTFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"kvDkZJDF6i4Cx5YGmLQY1A",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"JsonSchema"<br>]</span></p>
+    <h3 id="sd-jwt-claim-KSy9JTiccPPppo7knU4ZSqqjZno35Rz-9RNN0Y5Epng">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">KSy9JTiccPPppo7knU4ZSqqjZno35Rz-9RNN0Y5Epng</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJnNzFUcFFIbHNoQUZjX2FhNDlTaWZ3IiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"g71TpQHlshAFc_aa49Sifw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"JsonSchema"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-uVcg_L6WfKXrLBgN-9XjJMFx1dyVUrE4qjbwC2Hh3Gg">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">uVcg_L6WfKXrLBgN-9XjJMFx1dyVUrE4qjbwC2Hh3Gg</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJSNERfV0FnSFU4WGRzRkx5eUxFaThnIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMzE1ODgiXQ</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"R4D_WAgHU8XdsFLyyLEi8g",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"did:example:1231588"<br>]</span></p>
+    <h3 id="sd-jwt-claim-aeS0kUTFAjvoIPPITgB_Bp88voe3fnHqrCvx-CJrH18">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">aeS0kUTFAjvoIPPITgB_Bp88voe3fnHqrCvx-CJrH18</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ1cUZTLWZobTBkaWlTa1BjYVlFMXhRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMzE1ODgiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"uqFS-fhm0diiSkPcaYE1xQ",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"did:example:1231588"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-BkbIVTA3u4D9lucg9OdBTgVR6RSEJFc-zUGiVCllu44">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">BkbIVTA3u4D9lucg9OdBTgVR6RSEJFc-zUGiVCllu44</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ1NVRZOFpsUlp4Q3JHck1GeENlTlBBIiwgInR5cGUiLCAiUGVyc29uIl0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"u5TY8ZlRZxCrGrMFxCeNPA",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"Person"<br>]</span></p>
+    <h3 id="sd-jwt-claim-Avjemz7SrlBIOpXTokISYN4iV6EHCmKL4GJM_9OjPrg">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">Avjemz7SrlBIOpXTokISYN4iV6EHCmKL4GJM_9OjPrg</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJsRU5IX0ZBc253eVJkYnFSSHBkT2l3IiwgInR5cGUiLCAiUGVyc29uIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"lENH_FAsnwyRdbqRHpdOiw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"Person"<br>]</span></p>
 </div>
 </div>
     </div>
@@ -4207,7 +4149,7 @@ d28444a1013822a05901e47b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
         
         <div class="example" id="example-presentation">
         <div class="marker">
-    <a class="self-link" href="#example-presentation">Example<bdi> 21</bdi></a><span class="example-title">: Presentation</span>
+    <a class="self-link" href="#example-presentation">Example<bdi> 20</bdi></a><span class="example-title">: Presentation</span>
   </div> 
       <div class="vc-tabbed"><input type="radio" id="vc-tab12unsigned" name="vc-tabs12" checked=""><input type="radio" id="vc-tab12jose" name="vc-tabs12"><input type="radio" id="vc-tab12cose" name="vc-tabs12"><input type="radio" id="vc-tab12sd-jwt" name="vc-tabs12"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab12unsigned"><abbr title="Unsecured presentation">Presentation</abbr></label></li><li class="vc-tab"><label for="vc-tab12jose"><abbr title="Secured with JOSE">jose</abbr></label></li><li class="vc-tab"><label for="vc-tab12cose"><abbr title="Secured with COSE">cose</abbr></label></li><li class="vc-tab"><label for="vc-tab12sd-jwt"><abbr title="Secured with SD-JWT">sd-jwt</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 518px;"><pre class="nohighlight vc" data-vc-tabs="jose sd-jwt cose">{
   "@context": [
@@ -4272,7 +4214,7 @@ d28444a1013822a05901e47b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
 <div class="jwt-compact">
 <span class="jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
 .<span class="jwt-payload">eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidHlwZSI6IlZlcmlmaWFibGVQcmVzZW50YXRpb24iLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6W3siQGNvbnRleHQiOiJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJpZCI6ImRhdGE6YXBwbGljYXRpb24vdmMrY29zZTtiYXNlNjR1cmwsWW1GelpUWTBMREJ2VWtWdkxpNHVLMUU5UFEiLCJ0eXBlIjoiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwifSx7IkBjb250ZXh0IjoiaHR0cHM6Ly93d3cudzMub3JnL25zL2NyZWRlbnRpYWxzL3YyIiwiaWQiOiJkYXRhOmFwcGxpY2F0aW9uL3ZjK2p3dCxleVZqVi4uLlJNalU7ZGF0YTphcHBsaWNhdGlvbi92Yytqd3QsZXlWalYuLi5STWpVIiwidHlwZSI6IkVudmVsb3BlZFZlcmlmaWFibGVDcmVkZW50aWFsIn0seyJAY29udGV4dCI6Imh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImlkIjoiZGF0YTphcHBsaWNhdGlvbi92YytzZC1qd3QsZXlWalYuLi5STWpVfjtkYXRhOmFwcGxpY2F0aW9uL3ZjK3NkLWp3dCxleVZqVi4uLlJNalV-IiwidHlwZSI6IkVudmVsb3BlZFZlcmlmaWFibGVDcmVkZW50aWFsIn1dfQ</span>
-.<span class="jwt-signature">lWpzCZhXFKC0smk_TAHhNu4ozpx5wQMQC24alnXvlqOamhXtF1x4nBD2rBq1JGOqZm5PmbbkyWC9tQlIMd49FA</span>
+.<span class="jwt-signature">_D2fLzqkl79rrfiNjLKc7yQOb-wa1eu4L5quq82DqDlyWJsGju5rkc6RWWfKT_vv27fth8uh7oEWwPDr9RAhTQ</span>
 </div>
 </div>
     </div>
@@ -4307,94 +4249,94 @@ d28444a1013822a05901e47b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
 </pre>
 <strong>application/vp+cose</strong>
 <div class="cose-text">
-d28444a1013822a05902a77b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c2274797065223a2256657269666961626c6550726573656e746174696f6e222c2276657269666961626c6543726564656e7469616c223a5b7b2240636f6e74657874223a2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c226964223a22646174613a6170706c69636174696f6e2f76632b636f73653b62617365363475726c2c57573147656c70555754424d52454a3256577457646b78704e48564c4d555535554645222c2274797065223a22456e76656c6f70656456657269666961626c6543726564656e7469616c227d2c7b2240636f6e74657874223a2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c226964223a22646174613a6170706c69636174696f6e2f76632b6a77742c6579566a562e2e2e524d6a553b646174613a6170706c69636174696f6e2f76632b6a77742c6579566a562e2e2e524d6a55222c2274797065223a22456e76656c6f70656456657269666961626c6543726564656e7469616c227d2c7b2240636f6e74657874223a2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c226964223a22646174613a6170706c69636174696f6e2f76632b73642d6a77742c6579566a562e2e2e524d6a557e3b646174613a6170706c69636174696f6e2f76632b73642d6a77742c6579566a562e2e2e524d6a557e222c2274797065223a22456e76656c6f70656456657269666961626c6543726564656e7469616c227d5d7d5840d25d3e6717f55ed57a2dcc76dc4da803374f3f25c52cd838a9e097e731b68fa1decded49c2cea80f5ac5d88fff29a4f9cc59379975c27ebe094598af9fc6b054
+d28444a1013822a05902a77b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c2274797065223a2256657269666961626c6550726573656e746174696f6e222c2276657269666961626c6543726564656e7469616c223a5b7b2240636f6e74657874223a2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c226964223a22646174613a6170706c69636174696f6e2f76632b636f73653b62617365363475726c2c57573147656c70555754424d52454a3256577457646b78704e48564c4d555535554645222c2274797065223a22456e76656c6f70656456657269666961626c6543726564656e7469616c227d2c7b2240636f6e74657874223a2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c226964223a22646174613a6170706c69636174696f6e2f76632b6a77742c6579566a562e2e2e524d6a553b646174613a6170706c69636174696f6e2f76632b6a77742c6579566a562e2e2e524d6a55222c2274797065223a22456e76656c6f70656456657269666961626c6543726564656e7469616c227d2c7b2240636f6e74657874223a2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c226964223a22646174613a6170706c69636174696f6e2f76632b73642d6a77742c6579566a562e2e2e524d6a557e3b646174613a6170706c69636174696f6e2f76632b73642d6a77742c6579566a562e2e2e524d6a557e222c2274797065223a22456e76656c6f70656456657269666961626c6543726564656e7469616c227d5d7d58406b63ff0e996d534bb83c906ddd9a8d1d0a286cc9e9336b3da94ddfceb9af09ff91fefd01807e8f5c3835f5131f7b7f97b300cc28cf3826369f5d290e34270712
 </div>
     </div>
 </div></div><div class="vc-tab-content" style="min-height: 518px;"><div>
 
 <div class="sd-jwt-tabbed">
-    <input type="radio" id="sd-jwt-12-iufi6qs-encoded" name="sd-jwt-12-iufi6qs-tabs" checked="checked" tabindex="0">
-    <input type="radio" id="sd-jwt-12-iufi6qs-decoded" name="sd-jwt-12-iufi6qs-tabs" tabindex="0">
-    <input type="radio" id="sd-jwt-12-iufi6qs-disclosures" name="sd-jwt-12-iufi6qs-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-12-4z1tfnr-encoded" name="sd-jwt-12-4z1tfnr-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="sd-jwt-12-4z1tfnr-decoded" name="sd-jwt-12-4z1tfnr-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-12-4z1tfnr-disclosures" name="sd-jwt-12-4z1tfnr-tabs" tabindex="0">
     <ul class="sd-jwt-tabs">
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-12-iufi6qs-encoded">Encoded</label>
+        <label for="sd-jwt-12-4z1tfnr-encoded">Encoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-12-iufi6qs-decoded">Decoded</label>
+        <label for="sd-jwt-12-4z1tfnr-decoded">Decoded</label>
       </li>
       <li class="sd-jwt-tab">
-        <label for="sd-jwt-12-iufi6qs-disclosures">Issuer Disclosures</label>
+        <label for="sd-jwt-12-4z1tfnr-disclosures">Issuer Disclosures</label>
       </li>
     </ul>
-    <div class="sd-jwt-tab-content" id="sd-jwt-12-iufi6qs-content-encoded">
+    <div class="sd-jwt-tab-content" id="sd-jwt-12-4z1tfnr-content-encoded">
       
 <div class="sd-jwt-compact">
 <span class="sd-jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
-.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1NjU5NzksImV4cCI6MTc0Njc3NTU3OSwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjoiaHR0cHM6Ly93d3cudzMub3JnL25zL2NyZWRlbnRpYWxzL3YyIiwiX3NkIjpbIkt0NzJ5Nlk1bUtlZ3RxQWh6M1lScEtuQ0xnUnFjX3p2UGZMaWNhY29XUm8iLCJ2MHlsVEkyeUVpbk9QbUxtaGVRREpnY2FLNzVjZ1JodVB3cGpSV3lGOG5VIl19LHsiQGNvbnRleHQiOiJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJfc2QiOlsiLV85QkJuX0RrN2xtNjdiVFJSRTB0ZlVvMDFrLS1iMjNuQ1p0T0VpTTdmYyIsIlc1Uk9xa1BtejVqOHU4Zl9lMldydzJrZWVwb040ZFVmc3d3TGVyd0RqZTAiXX0seyJAY29udGV4dCI6Imh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsIl9zZCI6WyJGbjhUTXlYdWh4UUgxaFlXVXdraUlZVlBQZzdfWE5vRjVoN29RYk1nSkVnIiwiajFlTVVlSzNPSzhOaGEzeDdnRm9TaGV6Smwtek9TaFJXSDVhTFNNYkZTWSJdfV0sIl9zZCI6WyJNZVF5WUt6Y3FsZUhzME14MXdWZXJVdlEwdW01VjZVdktPTnJ6Vk5wMlZjIl19</span>
-.<span class="sd-jwt-signature">xYP0pDpzMX5vqi5_xSfE3NO-yVLYfWMBkVGubBJkseDuRb-8mQrFIBHr_RNWojPNSn1zg7FeMycyqe8R3E0EQg</span>
-~<span class="sd-jwt-disclosure">WyJ5SGpwaEVvcC1PRzVoYUJodi1OYUJ3IiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span>~<span class="sd-jwt-disclosure">WyJkNENleVE0UzQzMm9nVGhQRElSQUpnIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrY29zZTtiYXNlNjR1cmwsIFdXMUdlbHBVV1RCTVJFSjJWV3RXZGt4cE5IVkxNVVU1VUZFIl0</span>~<span class="sd-jwt-disclosure">WyJzN2hMaG9TN24zV0lYV3R0ejRuWDB3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span>~<span class="sd-jwt-disclosure">WyJQZ0ZGTC1ERlpSX1pCdTRsb1dXZUN3IiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrand0LCBleVZqVi4uLlJNalU7ZGF0YTphcHBsaWNhdGlvbi92Yytqd3QsIGV5VmpWLi4uUk1qVSJd</span>~<span class="sd-jwt-disclosure">WyJYZGlvVk9TTWUzSHBiNHUyeFZJR1lnIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span>~<span class="sd-jwt-disclosure">WyJWaVIzaDJ5b0lYQ2tvb3FaVkZMSzJnIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleVZqVi4uLlJNalV-O2RhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleVZqVi4uLlJNalV-Il0</span>~<span class="sd-jwt-disclosure">WyJVZkpvYTJHYUlOUXJFbS0zY05LX3RRIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span>~
+.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1OTQ3NzIsImV4cCI6MTc0NjgwNDM3MiwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjoiaHR0cHM6Ly93d3cudzMub3JnL25zL2NyZWRlbnRpYWxzL3YyIiwiX3NkIjpbIkNXMnNYREtVdTJZQ2U0bG83clN6WlNGa1hhNG8xT19TQ2FlUnBlTGZQVWciLCJmaFpSeDdlZXZGNW9YV0l1OHhwUWo1dUN4N21VWnZfbXAtTkt6WnI3M0Z3Il19LHsiQGNvbnRleHQiOiJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJfc2QiOlsiMGhfM2Myb3NlZ2x1UGdMUFBuMFR5T2c0TlJWRWFQdnQyMzRBQWU1c242ayIsIk9IbHhSNTYzTENhMThyd0xuNXY5RWJMTGZBd3M3dEZfb29aM3ZlZlRwenciXX0seyJAY29udGV4dCI6Imh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsIl9zZCI6WyJiZXppN0lySTlEOGc2N0Vpa3dtMkJoNjVpSS1MZW9CX1M5NXRuNmdEWnlNIiwiaFpnNlpxQlg4dFVqMzRpZUxnU0M3SjBiNUpFN3NYaG5TMm94OXpDTUZMYyJdfV0sIl9zZCI6WyJ4Nlk2cDFwWkduVzF6aHZ6RjliV1RsWXlFSk9yTDd5NWsySGVSSmFYR0lvIl19</span>
+.<span class="sd-jwt-signature">-BhSlghbRw896hU-9XHB6wf6C3PrZ-pW0IZr8QW7CabHrxytjSQe78NsvMadUZw0afYfDJogqFfjzNapl1evOg</span>
+~<span class="sd-jwt-disclosure">WyJVRExLMVB5MXRhbi1fT2NSV2VxWkFRIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span>~<span class="sd-jwt-disclosure">WyJKazJ5OTZlcTB6QXlDbGttd0luQ3lBIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrY29zZTtiYXNlNjR1cmwsIFdXMUdlbHBVV1RCTVJFSjJWV3RXZGt4cE5IVkxNVVU1VUZFIl0</span>~<span class="sd-jwt-disclosure">WyJCSDVfaGZ0SHFXR1pNd2puNFJWc0J3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span>~<span class="sd-jwt-disclosure">WyJWVFVsV01mbWV3Wlg5NDVyc1J5Uk9BIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrand0LCBleVZqVi4uLlJNalU7ZGF0YTphcHBsaWNhdGlvbi92Yytqd3QsIGV5VmpWLi4uUk1qVSJd</span>~<span class="sd-jwt-disclosure">WyJ6QVA2UUJDdVN2ZVhuSWg3RUVQeml3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span>~<span class="sd-jwt-disclosure">WyJ0eF85eXpwQzlrRE82dkZsLVFyT0lBIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleVZqVi4uLlJNalV-O2RhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleVZqVi4uLlJNalV-Il0</span>~<span class="sd-jwt-disclosure">WyJMWVdtZW5EVWQ2WDduSjNtMnY4d0R3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span>~
 </div>
     </div>
-    <div class="sd-jwt-tab-content" id="sd-jwt-12-iufi6qs-content-decoded">
+    <div class="sd-jwt-tab-content" id="sd-jwt-12-4z1tfnr-content-decoded">
       <pre class="header-value">{<br>&nbsp;&nbsp;"kid":&nbsp;"ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",<br>&nbsp;&nbsp;"alg":&nbsp;"ES256"<br>}</pre>
-      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745565979,<br>&nbsp;&nbsp;"exp":&nbsp;1746775579,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"verifiableCredential":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"@context":&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Kt72y6Y5mKegtqAhz3YRpKnCLgRqc_zvPfLicacoWRo",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"v0ylTI2yEinOPmLmheQDJgcaK75cgRhuPwpjRWyF8nU"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"@context":&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"-_9BBn_Dk7lm67bTRRE0tfUo01k--b23nCZtOEiM7fc",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"W5ROqkPmz5j8u8f_e2Wrw2keepoN4dUfswwLerwDje0"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"@context":&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Fn8TMyXuhxQH1hYWUwkiIYVPPg7_XNoF5h7oQbMgJEg",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"j1eMUeK3OK8Nha3x7gFoShezJl-zOShRWH5aLSMbFSY"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"MeQyYKzcqleHs0Mx1wVerUvQ0um5V6UvKONrzVNp2Vc"<br>&nbsp;&nbsp;]<br>}</pre>
+      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745594772,<br>&nbsp;&nbsp;"exp":&nbsp;1746804372,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"verifiableCredential":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"@context":&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"CW2sXDKUu2YCe4lo7rSzZSFkXa4o1O_SCaeRpeLfPUg",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"fhZRx7eevF5oXWIu8xpQj5uCx7mUZv_mp-NKzZr73Fw"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"@context":&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"0h_3c2osegluPgLPPn0TyOg4NRVEaPvt234AAe5sn6k",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"OHlxR563LCa18rwLn5v9EbLLfAws7tF_ooZ3vefTpzw"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"@context":&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"bezi7IrI9D8g67Eikwm2Bh65iI-LeoB_S95tn6gDZyM",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"hZg6ZqBX8tUj34ieLgSC7J0b5JE7sXhnS2ox9zCMFLc"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"x6Y6p1pZGnW1zhvzF9bWTlYyEJOrL7y5k2HeRJaXGIo"<br>&nbsp;&nbsp;]<br>}</pre>
     </div>
-    <div class="sd-jwt-tab-content" id="sd-jwt-12-iufi6qs-content-disclosures">
+    <div class="sd-jwt-tab-content" id="sd-jwt-12-4z1tfnr-content-disclosures">
       <div class="disclosures">
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-MeQyYKzcqleHs0Mx1wVerUvQ0um5V6UvKONrzVNp2Vc">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">MeQyYKzcqleHs0Mx1wVerUvQ0um5V6UvKONrzVNp2Vc</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ5SGpwaEVvcC1PRzVoYUJodi1OYUJ3IiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"yHjphEop-OG5haBhv-NaBw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"VerifiablePresentation"<br>]</span></p>
+    <h3 id="sd-jwt-claim-x6Y6p1pZGnW1zhvzF9bWTlYyEJOrL7y5k2HeRJaXGIo">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">x6Y6p1pZGnW1zhvzF9bWTlYyEJOrL7y5k2HeRJaXGIo</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJVRExLMVB5MXRhbi1fT2NSV2VxWkFRIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"UDLK1Py1tan-_OcRWeqZAQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"VerifiablePresentation"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-Kt72y6Y5mKegtqAhz3YRpKnCLgRqc_zvPfLicacoWRo">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">Kt72y6Y5mKegtqAhz3YRpKnCLgRqc_zvPfLicacoWRo</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJkNENleVE0UzQzMm9nVGhQRElSQUpnIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrY29zZTtiYXNlNjR1cmwsIFdXMUdlbHBVV1RCTVJFSjJWV3RXZGt4cE5IVkxNVVU1VUZFIl0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"d4CeyQ4S432ogThPDIRAJg",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vc+cose;base64url,&nbsp;WW1GelpUWTBMREJ2VWtWdkxpNHVLMUU5UFE"<br>]</span></p>
+    <h3 id="sd-jwt-claim-fhZRx7eevF5oXWIu8xpQj5uCx7mUZv_mp-NKzZr73Fw">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">fhZRx7eevF5oXWIu8xpQj5uCx7mUZv_mp-NKzZr73Fw</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJKazJ5OTZlcTB6QXlDbGttd0luQ3lBIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrY29zZTtiYXNlNjR1cmwsIFdXMUdlbHBVV1RCTVJFSjJWV3RXZGt4cE5IVkxNVVU1VUZFIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"Jk2y96eq0zAyClkmwInCyA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vc+cose;base64url,&nbsp;WW1GelpUWTBMREJ2VWtWdkxpNHVLMUU5UFE"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-v0ylTI2yEinOPmLmheQDJgcaK75cgRhuPwpjRWyF8nU">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">v0ylTI2yEinOPmLmheQDJgcaK75cgRhuPwpjRWyF8nU</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJzN2hMaG9TN24zV0lYV3R0ejRuWDB3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"s7hLhoS7n3WIXWttz4nX0w",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiableCredential"<br>]</span></p>
+    <h3 id="sd-jwt-claim-CW2sXDKUu2YCe4lo7rSzZSFkXa4o1O_SCaeRpeLfPUg">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">CW2sXDKUu2YCe4lo7rSzZSFkXa4o1O_SCaeRpeLfPUg</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJCSDVfaGZ0SHFXR1pNd2puNFJWc0J3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"BH5_hftHqWGZMwjn4RVsBw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiableCredential"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim--_9BBn_Dk7lm67bTRRE0tfUo01k--b23nCZtOEiM7fc">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">-_9BBn_Dk7lm67bTRRE0tfUo01k--b23nCZtOEiM7fc</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJQZ0ZGTC1ERlpSX1pCdTRsb1dXZUN3IiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrand0LCBleVZqVi4uLlJNalU7ZGF0YTphcHBsaWNhdGlvbi92Yytqd3QsIGV5VmpWLi4uUk1qVSJd</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"PgFFL-DFZR_ZBu4loWWeCw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vc+jwt,&nbsp;eyVjV...RMjU;data:application/vc+jwt,&nbsp;eyVjV...RMjU"<br>]</span></p>
+    <h3 id="sd-jwt-claim-OHlxR563LCa18rwLn5v9EbLLfAws7tF_ooZ3vefTpzw">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">OHlxR563LCa18rwLn5v9EbLLfAws7tF_ooZ3vefTpzw</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJWVFVsV01mbWV3Wlg5NDVyc1J5Uk9BIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrand0LCBleVZqVi4uLlJNalU7ZGF0YTphcHBsaWNhdGlvbi92Yytqd3QsIGV5VmpWLi4uUk1qVSJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"VTUlWMfmewZX945rsRyROA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vc+jwt,&nbsp;eyVjV...RMjU;data:application/vc+jwt,&nbsp;eyVjV...RMjU"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-W5ROqkPmz5j8u8f_e2Wrw2keepoN4dUfswwLerwDje0">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">W5ROqkPmz5j8u8f_e2Wrw2keepoN4dUfswwLerwDje0</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJYZGlvVk9TTWUzSHBiNHUyeFZJR1lnIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"XdioVOSMe3Hpb4u2xVIGYg",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiableCredential"<br>]</span></p>
+    <h3 id="sd-jwt-claim-0h_3c2osegluPgLPPn0TyOg4NRVEaPvt234AAe5sn6k">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">0h_3c2osegluPgLPPn0TyOg4NRVEaPvt234AAe5sn6k</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ6QVA2UUJDdVN2ZVhuSWg3RUVQeml3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"zAP6QBCuSveXnIh7EEPziw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiableCredential"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-j1eMUeK3OK8Nha3x7gFoShezJl-zOShRWH5aLSMbFSY">Claim: <span class="claim-name">id</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">j1eMUeK3OK8Nha3x7gFoShezJl-zOShRWH5aLSMbFSY</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJWaVIzaDJ5b0lYQ2tvb3FaVkZMSzJnIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleVZqVi4uLlJNalV-O2RhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleVZqVi4uLlJNalV-Il0</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"ViR3h2yoIXCkooqZVFLK2g",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vc+sd-jwt,&nbsp;eyVjV...RMjU~;data:application/vc+sd-jwt,&nbsp;eyVjV...RMjU~"<br>]</span></p>
+    <h3 id="sd-jwt-claim-bezi7IrI9D8g67Eikwm2Bh65iI-LeoB_S95tn6gDZyM">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">bezi7IrI9D8g67Eikwm2Bh65iI-LeoB_S95tn6gDZyM</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ0eF85eXpwQzlrRE82dkZsLVFyT0lBIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleVZqVi4uLlJNalV-O2RhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleVZqVi4uLlJNalV-Il0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"tx_9yzpC9kDO6vFl-QrOIA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vc+sd-jwt,&nbsp;eyVjV...RMjU~;data:application/vc+sd-jwt,&nbsp;eyVjV...RMjU~"<br>]</span></p>
 </div>
 
 
 <div class="disclosure">
-    <h3 id="sd-jwt-claim-Fn8TMyXuhxQH1hYWUwkiIYVPPg7_XNoF5h7oQbMgJEg">Claim: <span class="claim-name">type</span></h3>
-    <p><strong>SHA-256 Hash:</strong> <span class="hash">Fn8TMyXuhxQH1hYWUwkiIYVPPg7_XNoF5h7oQbMgJEg</span></p>
-    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJVZkpvYTJHYUlOUXJFbS0zY05LX3RRIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span></p>
-    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"UfJoa2GaINQrEm-3cNK_tQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiableCredential"<br>]</span></p>
+    <h3 id="sd-jwt-claim-hZg6ZqBX8tUj34ieLgSC7J0b5JE7sXhnS2ox9zCMFLc">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">hZg6ZqBX8tUj34ieLgSC7J0b5JE7sXhnS2ox9zCMFLc</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJMWVdtZW5EVWQ2WDduSjNtMnY4d0R3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"LYWmenDUd6X7nJ3m2v8wDw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiableCredential"<br>]</span></p>
 </div>
 </div>
     </div>
@@ -4406,17 +4348,17 @@ d28444a1013822a05902a77b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
         
         <div class="example" id="example-a-simple-uri-encoded-sd-jwt-verifiable-credential">
         <div class="marker">
-    <a class="self-link" href="#example-a-simple-uri-encoded-sd-jwt-verifiable-credential">Example<bdi> 22</bdi></a><span class="example-title">: A simple URI-encoded SD-JWT Verifiable Credential</span>
+    <a class="self-link" href="#example-a-simple-uri-encoded-sd-jwt-verifiable-credential">Example<bdi> 21</bdi></a><span class="example-title">: A simple URI-encoded SD-JWT Verifiable Credential</span>
   </div> <pre aria-busy="false"><code class="hljs">data:application/vc+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlNJM1JITm91aDhvODFOT09OUFFVQUw3RWdaLWtJNl94ajlvUkV2WDF4T3ciLCJ0eXAiOiJ2YytsZCtqc29uK3NkLWp3dCIsImN0eSI6InZjK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiX3NkIjpbIkU3dU1sSWFyS29iYXJTdEZGRjctZm5qaV9sQVdnM3BGMkV5dVc4dWFYakUiLCJYelRaSVgyNGdDSWxSQVFHclFoNU5FRm1XWkQtZ3Z3dkIybzB5Y0FwNFZzIl19LCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJfc2QiOlsiT3oxUEZIMG0tWk9TdEhwUVZyeGlmVlpKRzhvNmlQQmNnLVZ2SXQwd2plcyJdfSwiX3NkIjpbIkVZQ1daMTZZMHB5X1VNNzRHU3NVYU9zT19mdDExTlVSaFFUTS1TT1lFTVEiXX0sIl9zZCI6WyJqT055NnZUbGNvVlAzM25oSTdERGN3ekVka3d2R3VVRXlLUjdrWEVLd3VVIiwid21BdHpwc0dRbDJveS1PY2JrSEVZcE8xb3BoX3VYcWVWVTRKekF0aFFibyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vdW5pdmVyc2l0eS5leGFtcGxlL2lzc3VlcnMvNTY1MDQ5IiwiaWF0IjoxNjk3Mjg5OTk2LCJleHAiOjE3Mjg5MTIzOTYsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6InZFdV84WGxZT0ZFU2hTcVRpZ2JSYWduZ0ZGM1p5U0xrclNHekh3azFBT1loanhlazVhV21HY2UwZU05S0pWOEIiLCJ5IjoiRUpNY2czWXBzUTB3M2RLNHlVa25QczE1Z0lsY2Yyay03dzFKLTNlYlBiOERENmQtUkhBeGUwMDkzSWpfdTRCOSJ9fX0.rYzbxb6j1dwop8_s491iArVVJNm6A6C3b742gOm_qYO3zdkyQU4_VxxOSJ8ECcmWj2r5KyiCNC1ojfO4Yms-zBsjt7PoMYpYWBplsqXpiIvnehmM7D0eOLi40uHXki0X~WyJSWTg1YTZNMmEwX3VDWlFTVGZmTFdRIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJMeG5GYTBXVm8wRUluVy1QdS1fd1dRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJUQVdrakpCaVpxdC1rVU54X1EweUJBIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJTd2xuZFpPZzZEZ1ZERFp5X0RvYVFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJuSnJlU3E1Nzg3RGZMSDJCbU03cXFRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyIxMjNNd3hNcHRiek02YUk2aW03ME1RIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~</code></pre>
       </div>
         <div class="example" id="example-a-simple-uri-encoded-sd-jwt-verifiable-presentation">
         <div class="marker">
-    <a class="self-link" href="#example-a-simple-uri-encoded-sd-jwt-verifiable-presentation">Example<bdi> 23</bdi></a><span class="example-title">: A simple URI-encoded SD-JWT Verifiable Presentation</span>
+    <a class="self-link" href="#example-a-simple-uri-encoded-sd-jwt-verifiable-presentation">Example<bdi> 22</bdi></a><span class="example-title">: A simple URI-encoded SD-JWT Verifiable Presentation</span>
   </div> <pre aria-busy="false"><code class="hljs">data:application/vp+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlNJM1JITm91aDhvODFOT09OUFFVQUw3RWdaLWtJNl94ajlvUkV2WDF4T3ciLCJ0eXAiOiJ2YytsZCtqc29uK3NkLWp3dCIsImN0eSI6InZjK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiX3NkIjpbIkU3dU1sSWFyS29iYXJTdEZGRjctZm5qaV9sQVdnM3BGMkV5dVc4dWFYakUiLCJYelRaSVgyNGdDSWxSQVFHclFoNU5FRm1XWkQtZ3Z3dkIybzB5Y0FwNFZzIl19LCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJfc2QiOlsiT3oxUEZIMG0tWk9TdEhwUVZyeGlmVlpKRzhvNmlQQmNnLVZ2SXQwd2plcyJdfSwiX3NkIjpbIkVZQ1daMTZZMHB5X1VNNzRHU3NVYU9zT19mdDExTlVSaFFUTS1TT1lFTVEiXX0sIl9zZCI6WyJqT055NnZUbGNvVlAzM25oSTdERGN3ekVka3d2R3VVRXlLUjdrWEVLd3VVIiwid21BdHpwc0dRbDJveS1PY2JrSEVZcE8xb3BoX3VYcWVWVTRKekF0aFFibyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vdW5pdmVyc2l0eS5leGFtcGxlL2lzc3VlcnMvNTY1MDQ5IiwiaWF0IjoxNjk3Mjg5OTk2LCJleHAiOjE3Mjg5MTIzOTYsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6InZFdV84WGxZT0ZFU2hTcVRpZ2JSYWduZ0ZGM1p5U0xrclNHekh3azFBT1loanhlazVhV21HY2UwZU05S0pWOEIiLCJ5IjoiRUpNY2czWXBzUTB3M2RLNHlVa25QczE1Z0lsY2Yyay03dzFKLTNlYlBiOERENmQtUkhBeGUwMDkzSWpfdTRCOSJ9fX0.rYzbxb6j1dwop8_s491iArVVJNm6A6C3b742gOm_qYO3zdkyQU4_VxxOSJ8ECcmWj2r5KyiCNC1ojfO4Yms-zBsjt7PoMYpYWBplsqXpiIvnehmM7D0eOLi40uHXki0X~WyJTd2xuZFpPZzZEZ1ZERFp5X0RvYVFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyIxMjNNd3hNcHRiek02YUk2aW03ME1RIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~WyJMeG5GYTBXVm8wRUluVy1QdS1fd1dRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJSWTg1YTZNMmEwX3VDWlFTVGZmTFdRIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~eyJhbGciOiJFUzM4NCIsInR5cCI6ImtiK2p3dCJ9.eyJub25jZSI6IkVmeTROTFJPX3ZvSkszdDIzcUNfQlEiLCJhdWQiOiJodHRwczovL3ZlcmlmaWVyLmV4YW1wbGUiLCJpYXQiOjE2OTcyODk5OTZ9.6G-1nVcrDKFzR6BdbcFHcbtassEb8NZ7ZavTYz3SJ-e4pXleXs0tNcCkUCwMI70gsuOY0AXzeDPbHjp5GKyLDVuNWgWCt3Wo2VSaCwUkyfLyvhkCsmkF9kvFhMIOhp1i~</code></pre>
       </div>
         <div class="example" id="example-a-simple-uri-encoded-cose-verifiable-presentation">
         <div class="marker">
-    <a class="self-link" href="#example-a-simple-uri-encoded-cose-verifiable-presentation">Example<bdi> 24</bdi></a><span class="example-title">: A simple URI-encoded COSE Verifiable Presentation</span>
+    <a class="self-link" href="#example-a-simple-uri-encoded-cose-verifiable-presentation">Example<bdi> 23</bdi></a><span class="example-title">: A simple URI-encoded COSE Verifiable Presentation</span>
   </div> <pre aria-busy="false"><code class="hljs">data:application/vp+cose;base64,0oREoQE4IqBZDSJ7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJ0eXBlIjoiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiIsInZlcmlmaWFibGVDcmVkZW50aWFsIjpbeyJAY29udGV4dCI6Imh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImlkIjoiZGF0YTphcHBsaWNhdGlvbi92Yy1sZCtzZC1qd3QsZXlKcmFXUWlPaUpGZUVoclFrMVhPV1p0WW10MlZqSTJObTFTY0hWUU1uTlZXVjlPWDBWWFNVNHhiR0Z3VlhwUE9ISnZJaXdpWVd4bklqb2lSVk15TlRZaWZRLmV5SmZjMlJmWVd4bklqb2ljMmhoTFRJMU5pSXNJa0JqYjI1MFpYaDBJanBiSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk5dWN5OWpjbVZrWlc1MGFXRnNjeTkyTWlJc0ltaDBkSEJ6T2k4dmQzZDNMbmN6TG05eVp5OXVjeTlqY21Wa1pXNTBhV0ZzY3k5bGVHRnRjR3hsY3k5Mk1pSmRMQ0pwYzNOMVpYSWlPaUpvZEhSd2N6b3ZMM1Z1YVhabGNuTnBkSGt1WlhoaGJYQnNaUzlwYzNOMVpYSnpMelUyTlRBME9TSXNJblpoYkdsa1JuSnZiU0k2SWpJd01UQXRNREV0TURGVU1UazZNak02TWpSYUlpd2lZM0psWkdWdWRHbGhiRk5qYUdWdFlTSTZleUpmYzJRaU9sc2lOV0pCZURNdGVIQm1RV3hWUzBaSk9YTnVNMmhXUTIxd1IydHJjVWx6V21NekxVeGlNek5tV21waWF5SXNJbHBqUVhaSU1EaHNkRUp5U1VwbVNXaDBPRjl0UzFCZll6TnNjRzVZTVdOSGNsbHRWRzh3WjFsQ2VUZ2lYWDBzSW1OeVpXUmxiblJwWVd4VGRXSnFaV04wSWpwN0ltUmxaM0psWlNJNmV5SnVZVzFsSWpvaVFtRmphR1ZzYjNJZ2IyWWdVMk5wWlc1alpTQmhibVFnUVhKMGN5SXNJbDl6WkNJNld5SlNUMVEzTVVsMGRUTk1ObFZYV0ZWcWJ5MW9XVmRKUWpZM2JIVlBUa1ZFVWxOQ2FHeEVWRU54VlU5UklsMTlMQ0pmYzJRaU9sc2lUVVZ1WlhObk1saFBVazVqWTNOQ1RXVmFYekUyTURKbmVUUXdVaTAwV1VKMlZsSXdlRkU0YjBZNFl5SmRmU3dpWDNOa0lqcGJJa1ZsYzJKaWF5MW1jR1p3ZDJaTU9YZE9jekZ4Y2paMGFVNDNabkV0U1hReldWTTJWM1pDYmw5aVdHOGlMQ0phYjFJMVpHUmhja2R0WmsxNU5FaHVWMHhWYWs1VVJuRlVSak5ZUmpacGRGQm5abmxHUWtoVlgzRlZJbDE5Lmd3M3BheGJrTGpwaThDVHN5UnBYS2JDN3RwVmEwcTJzV0tTRC1fZGNidVoxTHBaVjNvUThJZnpjbTJiRThSWTNmbUpnYnV5QTlnYlBMM3NRQmFUemtnIH5XeUpTZVVReFZsQjRWSEJ2Ym10UGVYWnBjemt0YTI5M0lpd2dJbWxrSWl3Z0ltaDBkSEE2THk5MWJtbDJaWEp6YVhSNUxtVjRZVzF3YkdVdlkzSmxaR1Z1ZEdsaGJITXZNVGczTWlKZH5XeUpmVmpkMWVUZDNheTFSTTNWWmQyWnBaME52V1VWQklpd2dJblI1Y0dVaUxDQmJJbFpsY21sbWFXRmliR1ZEY21Wa1pXNTBhV0ZzSWl3Z0lrVjRZVzF3YkdWQmJIVnRibWxEY21Wa1pXNTBhV0ZzSWwxZH5XeUpoYXpkcU1UbG5ZVk10UkRKTFgyaHpZM1JWWkdOUklpd2dJbWxrSWl3Z0ltaDBkSEJ6T2k4dlpYaGhiWEJzWlM1dmNtY3ZaWGhoYlhCc1pYTXZaR1ZuY21WbExtcHpiMjRpWFF+V3lKVVRqQlhhWFZaUmtoWFdrVjJaRFpJUVVKSFFTMW5JaXdnSW5SNWNHVWlMQ0FpU25OdmJsTmphR1Z0WVNKZH5XeUpWTW5Cek1reFlWRVJWYlZoM01EY3hSVkJtUlVwbklpd2dJbWxrSWl3Z0ltUnBaRHBsZUdGdGNHeGxPakV5TXlKZH5XeUpzUTA0MmVUTkVhVE5EVWs5VlgzSnVYelJFTldSbklpd2dJblI1Y0dVaUxDQWlRbUZqYUdWc2IzSkVaV2R5WldVaVhRfjtkYXRhOmFwcGxpY2F0aW9uL3ZjLWxkK3NkLWp3dCxleUpyYVdRaU9pSkZlRWhyUWsxWE9XWnRZbXQyVmpJMk5tMVNjSFZRTW5OVldWOU9YMFZYU1U0eGJHRndWWHBQT0hKdklpd2lZV3huSWpvaVJWTXlOVFlpZlEuZXlKZmMyUmZZV3huSWpvaWMyaGhMVEkxTmlJc0lrQmpiMjUwWlhoMElqcGJJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OTJNaUlzSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk5dWN5OWpjbVZrWlc1MGFXRnNjeTlsZUdGdGNHeGxjeTkyTWlKZExDSnBjM04xWlhJaU9pSm9kSFJ3Y3pvdkwzVnVhWFpsY25OcGRIa3VaWGhoYlhCc1pTOXBjM04xWlhKekx6VTJOVEEwT1NJc0luWmhiR2xrUm5KdmJTSTZJakl3TVRBdE1ERXRNREZVTVRrNk1qTTZNalJhSWl3aVkzSmxaR1Z1ZEdsaGJGTmphR1Z0WVNJNmV5SmZjMlFpT2xzaU5XSkJlRE10ZUhCbVFXeFZTMFpKT1hOdU0yaFdRMjF3UjJ0cmNVbHpXbU16TFV4aU16Tm1XbXBpYXlJc0lscGpRWFpJTURoc2RFSnlTVXBtU1doME9GOXRTMUJmWXpOc2NHNVlNV05IY2xsdFZHOHdaMWxDZVRnaVhYMHNJbU55WldSbGJuUnBZV3hUZFdKcVpXTjBJanA3SW1SbFozSmxaU0k2ZXlKdVlXMWxJam9pUW1GamFHVnNiM0lnYjJZZ1UyTnBaVzVqWlNCaGJtUWdRWEowY3lJc0lsOXpaQ0k2V3lKU1QxUTNNVWwwZFROTU5sVlhXRlZxYnkxb1dWZEpRalkzYkhWUFRrVkVVbE5DYUd4RVZFTnhWVTlSSWwxOUxDSmZjMlFpT2xzaVRVVnVaWE5uTWxoUFVrNWpZM05DVFdWYVh6RTJNREpuZVRRd1VpMDBXVUoyVmxJd2VGRTRiMFk0WXlKZGZTd2lYM05rSWpwYklrVmxjMkppYXkxbWNHWndkMlpNT1hkT2N6RnhjalowYVU0M1puRXRTWFF6V1ZNMlYzWkNibDlpV0c4aUxDSmFiMUkxWkdSaGNrZHRaazE1TkVodVYweFZhazVVUm5GVVJqTllSalpwZEZCblpubEdRa2hWWDNGVklsMTkuZ3czcGF4YmtManBpOENUc3lScFhLYkM3dHBWYTBxMnNXS1NELV9kY2J1WjFMcFpWM29ROElmemNtMmJFOFJZM2ZtSmdidXlBOWdiUEwzc1FCYVR6a2cgfld5SlNlVVF4VmxCNFZIQnZibXRQZVhacGN6a3RhMjkzSWl3Z0ltbGtJaXdnSW1oMGRIQTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2WTNKbFpHVnVkR2xoYkhNdk1UZzNNaUpkfld5SmZWamQxZVRkM2F5MVJNM1ZaZDJacFowTnZXVVZCSWl3Z0luUjVjR1VpTENCYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdnSWtWNFlXMXdiR1ZCYkhWdGJtbERjbVZrWlc1MGFXRnNJbDFkfld5SmhhemRxTVRsbllWTXRSREpMWDJoelkzUlZaR05SSWl3Z0ltbGtJaXdnSW1oMGRIQnpPaTh2WlhoaGJYQnNaUzV2Y21jdlpYaGhiWEJzWlhNdlpHVm5jbVZsTG1wemIyNGlYUX5XeUpVVGpCWGFYVlpSa2hYV2tWMlpEWklRVUpIUVMxbklpd2dJblI1Y0dVaUxDQWlTbk52YmxOamFHVnRZU0pkfld5SlZNbkJ6TWt4WVZFUlZiVmgzTURjeFJWQm1SVXBuSWl3Z0ltbGtJaXdnSW1ScFpEcGxlR0Z0Y0d4bE9qRXlNeUpkfld5SnNRMDQyZVRORWFUTkRVazlWWDNKdVh6UkVOV1JuSWl3Z0luUjVjR1VpTENBaVFtRmphR1ZzYjNKRVpXZHlaV1VpWFF+IiwidHlwZSI6IkVudmVsb3BlZFZlcmlmaWFibGVDcmVkZW50aWFsIn1dfVhA4c9H+cu0VfS8NsItpzbB1mpvjP5y2DCxTCW+bY6/4SNPCaeP+uR+JRpJ+GzVNz7/W7ZlHoXguhgBBjWhlnhh+Q==</code></pre>
       </div>
       </section>
@@ -4429,7 +4371,7 @@ d28444a1013822a05902a77b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
         </p>
         <div class="example" id="example-a-cose-sign-1-protected-header-for-a-verifiable-credential">
         <div class="marker">
-    <a class="self-link" href="#example-a-cose-sign-1-protected-header-for-a-verifiable-credential">Example<bdi> 25</bdi></a><span class="example-title">: A COSE Sign 1 Protected Header for a Verifiable Credential</span>
+    <a class="self-link" href="#example-a-cose-sign-1-protected-header-for-a-verifiable-credential">Example<bdi> 24</bdi></a><span class="example-title">: A COSE Sign 1 Protected Header for a Verifiable Credential</span>
   </div> <pre aria-busy="false"><code class="hljs javascript">{                                   <span class="hljs-regexp">/ Protected                     /</span>
   <span class="hljs-number">1</span>: -<span class="hljs-number">35</span>,                           <span class="hljs-regexp">/ Algorithm                     /</span>
   <span class="hljs-number">3</span>: application/vc,                <span class="hljs-regexp">/ Content type                  /</span>
@@ -4442,7 +4384,7 @@ d28444a1013822a05902a77b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
       </div>
         <div class="example" id="example-a-cose-sign-1-protected-header-for-a-verifiable-presentation">
         <div class="marker">
-    <a class="self-link" href="#example-a-cose-sign-1-protected-header-for-a-verifiable-presentation">Example<bdi> 26</bdi></a><span class="example-title">: A COSE Sign 1 Protected Header for a Verifiable Presentation</span>
+    <a class="self-link" href="#example-a-cose-sign-1-protected-header-for-a-verifiable-presentation">Example<bdi> 25</bdi></a><span class="example-title">: A COSE Sign 1 Protected Header for a Verifiable Presentation</span>
   </div> <pre aria-busy="false"><code class="hljs javascript">{                                   <span class="hljs-regexp">/ Protected                     /</span>
   <span class="hljs-number">1</span>: -<span class="hljs-number">35</span>,                           <span class="hljs-regexp">/ Algorithm                     /</span>
   <span class="hljs-number">3</span>: application/vp,                <span class="hljs-regexp">/ Content type                  /</span>
@@ -4455,7 +4397,7 @@ d28444a1013822a05902a77b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e
       </div>
         <div class="example" id="example-a-cose-sign-1-with-an-attached-payload">
         <div class="marker">
-    <a class="self-link" href="#example-a-cose-sign-1-with-an-attached-payload">Example<bdi> 27</bdi></a><span class="example-title">: A COSE Sign 1 with an attached payload</span>
+    <a class="self-link" href="#example-a-cose-sign-1-with-an-attached-payload">Example<bdi> 26</bdi></a><span class="example-title">: A COSE Sign 1 with an attached payload</span>
   </div> <pre aria-busy="false"><code class="hljs javascript"><span class="hljs-number">18</span>(                                 <span class="hljs-regexp">/ COSE Sign 1                   /</span>
     [
       h<span class="hljs-string">'a4013822...3a343536'</span>,       <span class="hljs-regexp">/ Protected Header              /</span>
@@ -4561,8 +4503,6 @@ Updated many examples.
       <a href="https://www.rfc-editor.org/rfc/rfc9596"><cite>CBOR Object Signing and Encryption (COSE) "typ" (type) Header Parameter</cite></a>. M.B. Jones; O. Steele.  IETF. June 2024. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9596">https://www.rfc-editor.org/rfc/rfc9596</a>
     </dd><dt id="bib-sd-jwt">[SD-JWT]</dt><dd>
       <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt"><cite>Selective Disclosure for JWTs (SD-JWT)</cite></a>. Daniel Fett; Kristina Yasuda; Brian Campbell.  IETF. Internet-Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt">https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt</a>
-    </dd><dt id="bib-sd-jwt-vc">[SD-JWT-VC]</dt><dd>
-      <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc"><cite>SD-JWT-based Verifiable Credentials (SD-JWT VC)</cite></a>. Oliver Terbu; Daniel Fett; Brian Campbell.  IETF. Internet-Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc">https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc</a>
     </dd><dt id="bib-url">[URL]</dt><dd>
       <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
     </dd><dt id="bib-vc-data-model-2.0">[VC-DATA-MODEL-2.0]</dt><dd>
@@ -4721,10 +4661,8 @@ Updated many examples.
       </div>
       <p><b>Referenced in:</b></p>
       <ul>
-    <li>
-      <a href="#ref-for-dfn-public-key-1" title="§ 4.2.1 JWT Issuer">§ 4.2.1 JWT Issuer</a> 
-    </li>
-  </ul>
+      <li>Not referenced in this document.</li>
+    </ul>
     </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-private-key" aria-label="Links in this document to definition: private key">
       <span class="caret"></span>
       <div>
@@ -4772,7 +4710,7 @@ Updated many examples.
       <p><b>Referenced in:</b></p>
       <ul>
     <li>
-      <a href="#ref-for-dfn-controlled-identifier-document-1" title="§ 4.3 Using Controlled Identifier Documents">§ 4.3 Using Controlled Identifier Documents</a> <a href="#ref-for-dfn-controlled-identifier-document-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-controlled-identifier-document-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-controlled-identifier-document-4" title="Reference 4">(4)</a> 
+      <a href="#ref-for-dfn-controlled-identifier-document-1" title="§ 4.2 Using Controlled Identifier Documents">§ 4.2 Using Controlled Identifier Documents</a> <a href="#ref-for-dfn-controlled-identifier-document-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-controlled-identifier-document-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-controlled-identifier-document-4" title="Reference 4">(4)</a> 
     </li>
   </ul>
     </div><script id="respec-highlight-vars">(() => {

--- a/transitions/REC/index.html
+++ b/transitions/REC/index.html
@@ -1,0 +1,5097 @@
+<!DOCTYPE html><html lang="en"><head>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8">
+<meta name="generator" content="ReSpec 35.3.0">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<style>
+span.example-title{text-transform:none}
+:is(aside,div).example,div.illegal-example{padding:.5em;margin:1em 0;position:relative;clear:both}
+div.illegal-example{color:red}
+div.illegal-example p{color:#000}
+aside.example div.example{border-left-width:.1em;border-color:#999;background:#fff}
+</style>
+<style>
+.issue-label{text-transform:initial}
+.warning>p:first-child{margin-top:0}
+.warning{padding:.5em;border-left-width:.5em;border-left-style:solid}
+span.warning{padding:.1em .5em .15em}
+.issue.closed span.issue-number{text-decoration:line-through}
+.issue.closed span.issue-number::after{content:" (Closed)";font-size:smaller}
+.warning{border-color:#f11;border-color:var(--warning-border,#f11);border-width:.2em;border-style:solid;background:#fbe9e9;background:var(--warning-bg,#fbe9e9);color:#000;color:var(--text,#000)}
+.warning-title:before{content:"⚠";font-size:1.3em;float:left;padding-right:.3em;margin-top:-.3em}
+li.task-list-item{list-style:none}
+input.task-list-item-checkbox{margin:0 .35em .25em -1.6em;vertical-align:middle}
+.issue a.respec-gh-label{padding:5px;margin:0 2px 0 2px;font-size:10px;text-transform:none;text-decoration:none;font-weight:700;border-radius:4px;position:relative;bottom:2px;border:none;display:inline-block}
+</style>
+<style>
+dfn{cursor:pointer}
+.dfn-panel{position:absolute;z-index:35;min-width:300px;max-width:500px;padding:.5em .75em;margin-top:.6em;font-family:"Helvetica Neue",sans-serif;font-size:small;background:#fff;background:var(--indextable-hover-bg,#fff);color:#000;color:var(--text,#000);box-shadow:0 1em 3em -.4em rgba(0,0,0,.3),0 0 1px 1px rgba(0,0,0,.05);box-shadow:0 1em 3em -.4em var(--tocsidebar-shadow,rgba(0,0,0,.3)),0 0 1px 1px var(--tocsidebar-shadow,rgba(0,0,0,.05));border-radius:2px}
+.dfn-panel:not(.docked)>.caret{position:absolute;top:-9px}
+.dfn-panel:not(.docked)>.caret::after,.dfn-panel:not(.docked)>.caret::before{content:"";position:absolute;border:10px solid transparent;border-top:0;border-bottom:10px solid #fff;border-bottom-color:var(--indextable-hover-bg,#fff);top:0}
+.dfn-panel:not(.docked)>.caret::before{border-bottom:9px solid #a2a9b1;border-bottom-color:var(--indextable-hover-bg,#a2a9b1)}
+.dfn-panel *{margin:0}
+.dfn-panel b{display:block;color:#000;color:var(--text,#000);margin-top:.25em}
+.dfn-panel ul a[href]{color:#333;color:var(--text,#333)}
+.dfn-panel>div{display:flex}
+.dfn-panel a.self-link{font-weight:700;margin-right:auto}
+.dfn-panel .marker{padding:.1em;margin-left:.5em;border-radius:.2em;text-align:center;white-space:nowrap;font-size:90%;color:#040b1c}
+.dfn-panel .marker.dfn-exported{background:#d1edfd;box-shadow:0 0 0 .125em #1ca5f940}
+.dfn-panel .marker.idl-block{background:#8ccbf2;box-shadow:0 0 0 .125em #0670b161}
+.dfn-panel a:not(:hover){text-decoration:none!important;border-bottom:none!important}
+.dfn-panel a[href]:hover{border-bottom-width:1px}
+.dfn-panel ul{padding:0}
+.dfn-panel li{margin-left:1em}
+.dfn-panel.docked{position:fixed;left:.5em;top:unset;bottom:2em;margin:0 auto;max-width:calc(100vw - .75em * 2 - .5em - .2em * 2);max-height:30vh;overflow:auto}
+</style>
+    
+    
+<title>Securing Verifiable Credentials using JOSE and COSE</title>
+    
+<style id="respec-mainstyle">
+@keyframes pop{
+0%{transform:scale(1,1)}
+25%{transform:scale(1.25,1.25);opacity:.75}
+100%{transform:scale(1,1)}
+}
+a.internalDFN{color:inherit;border-bottom:1px solid #99c;text-decoration:none}
+a.externalDFN{color:inherit;border-bottom:1px dotted #ccc;text-decoration:none}
+a.bibref{text-decoration:none}
+.respec-offending-element:target{animation:pop .25s ease-in-out 0s 1}
+.respec-offending-element,a[href].respec-offending-element{text-decoration:red wavy underline}
+@supports not (text-decoration:red wavy underline){
+.respec-offending-element:not(pre){display:inline-block}
+.respec-offending-element{background:url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=) bottom repeat-x}
+}
+#references :target{background:#eaf3ff;animation:pop .4s ease-in-out 0s 1}
+cite .bibref{font-style:normal}
+a[href].orcid{padding-left:4px;padding-right:4px}
+a[href].orcid>svg{margin-bottom:-2px}
+ol.tof,ul.tof{list-style:none outside none}
+.caption{margin-top:.5em;font-style:italic}
+#issue-summary>ul{column-count:2}
+#issue-summary li{list-style:none;display:inline-block}
+details.respec-tests-details{margin-left:1em;display:inline-block;vertical-align:top}
+details.respec-tests-details>*{padding-right:2em}
+details.respec-tests-details[open]{z-index:999999;position:absolute;border:thin solid #cad3e2;border-radius:.3em;background-color:#fff;padding-bottom:.5em}
+details.respec-tests-details[open]>summary{border-bottom:thin solid #cad3e2;padding-left:1em;margin-bottom:1em;line-height:2em}
+details.respec-tests-details>ul{width:100%;margin-top:-.3em}
+details.respec-tests-details>li{padding-left:1em}
+.self-link:hover{opacity:1;text-decoration:none;background-color:transparent}
+aside.example .marker>a.self-link{color:inherit}
+.header-wrapper{display:flex;align-items:baseline}
+:is(h2,h3,h4,h5,h6):not(#toc>h2,#abstract>h2,#sotd>h2,.head>h2){position:relative;left:-.5em}
+:is(h2,h3,h4,h5,h6):not(#toch2)+a.self-link{color:inherit;order:-1;position:relative;left:-1.1em;font-size:1rem;opacity:.5}
+:is(h2,h3,h4,h5,h6)+a.self-link::before{content:"§";text-decoration:none;color:var(--heading-text)}
+:is(h2,h3)+a.self-link{top:-.2em}
+:is(h4,h5,h6)+a.self-link::before{color:#000}
+@media (max-width:767px){
+dd{margin-left:0}
+}
+@media print{
+.removeOnSave{display:none}
+}
+</style>
+    
+    
+  
+<meta name="color-scheme" content="light">
+<meta name="description" content="This specification defines how to secure credentials and presentations
+        conforming to the Verifiable Credential data model [VC-DATA-MODEL-2.0]
+        with JSON Object Signing and Encryption
+        (JOSE),
+        Selective Disclosure for JWTs [SD-JWT],
+        and CBOR Object Signing and Encryption (COSE) [RFC9052].
+        This enables the Verifiable Credential data model [VC-DATA-MODEL-2.0]
+        to be implemented with standards for signing and encryption that are
+        widely adopted.">
+<link rel="canonical" href="https://www.w3.org/TR/vc-jose-cose/">
+<script type="application/ld+json">{
+  "@context": [
+    "http://schema.org",
+    {
+      "@vocab": "http://schema.org/",
+      "@language": "en",
+      "w3p": "http://www.w3.org/2001/02pd/rec54#",
+      "foaf": "http://xmlns.com/foaf/0.1/",
+      "datePublished": {
+        "@type": "http://www.w3.org/2001/XMLSchema#date"
+      },
+      "inLanguage": {
+        "@language": null
+      },
+      "isBasedOn": {
+        "@type": "@id"
+      },
+      "license": {
+        "@type": "@id"
+      }
+    }
+  ],
+  "id": "https://www.w3.org/TR/vc-jose-cose/",
+  "type": [
+    "TechArticle",
+    "w3p:REC"
+  ],
+  "name": "Securing Verifiable Credentials using JOSE and COSE",
+  "inLanguage": "en",
+  "license": "https://www.w3.org/copyright/software-license-2023/",
+  "datePublished": "2025-05-15",
+  "copyrightHolder": {
+    "name": "World Wide Web Consortium",
+    "url": "https://www.w3.org/"
+  },
+  "discussionUrl": "https://github.com/w3c/vc-jose-cose/issues/",
+  "alternativeHeadline": "",
+  "isBasedOn": "https://www.w3.org/TR/2024/PR-vc-jose-cose-20241105/",
+  "description": "This specification defines how to secure credentials and presentations\n        conforming to the Verifiable Credential data model [VC-DATA-MODEL-2.0]\n        with JSON Object Signing and Encryption\n        (JOSE),\n        Selective Disclosure for JWTs [SD-JWT],\n        and CBOR Object Signing and Encryption (COSE) [RFC9052].\n        This enables the Verifiable Credential data model [VC-DATA-MODEL-2.0]\n        to be implemented with standards for signing and encryption that are\n        widely adopted.",
+  "editor": [
+    {
+      "type": "Person",
+      "name": "Michael Jones",
+      "url": "https://self-issued.info/",
+      "worksFor": {
+        "name": "Self-Issued Consulting"
+      }
+    },
+    {
+      "type": "Person",
+      "name": "Michael Prorock",
+      "worksFor": {
+        "name": "Mesur.io",
+        "url": "https://mesur.io/"
+      }
+    },
+    {
+      "type": "Person",
+      "name": "Gabe Cohen",
+      "url": "https://github.com/decentralgabe",
+      "worksFor": {
+        "name": "Invited Expert"
+      }
+    }
+  ],
+  "contributor": [],
+  "citation": [
+    {
+      "id": "https://www.w3.org/TR/vc-data-model-2.0/",
+      "type": "TechArticle",
+      "name": "Verifiable Credentials Data Model v2.0",
+      "url": "https://www.w3.org/TR/vc-data-model-2.0/",
+      "creator": [
+        {
+          "name": "Ivan Herman"
+        },
+        {
+          "name": "Michael Jones"
+        },
+        {
+          "name": "Manu Sporny"
+        },
+        {
+          "name": "Ted Thibodeau Jr"
+        },
+        {
+          "name": "Gabe Cohen"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc7515",
+      "type": "TechArticle",
+      "name": "JSON Web Signature (JWS)",
+      "url": "https://www.rfc-editor.org/rfc/rfc7515",
+      "creator": [
+        {
+          "name": "M. Jones"
+        },
+        {
+          "name": "J. Bradley"
+        },
+        {
+          "name": "N. Sakimura"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt",
+      "type": "TechArticle",
+      "name": "Selective Disclosure for JWTs (SD-JWT)",
+      "url": "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt",
+      "creator": [
+        {
+          "name": "Daniel Fett"
+        },
+        {
+          "name": "Kristina Yasuda"
+        },
+        {
+          "name": "Brian Campbell"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc9052",
+      "type": "TechArticle",
+      "name": "CBOR Object Signing and Encryption (COSE): Structures and Process",
+      "url": "https://www.rfc-editor.org/rfc/rfc9052",
+      "creator": [
+        {
+          "name": "J. Schaad"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc6838",
+      "type": "TechArticle",
+      "name": "Media Type Specifications and Registration Procedures",
+      "url": "https://www.rfc-editor.org/rfc/rfc6838",
+      "creator": [
+        {
+          "name": "N. Freed"
+        },
+        {
+          "name": "J. Klensin"
+        },
+        {
+          "name": "T. Hansen"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc8949",
+      "type": "TechArticle",
+      "name": "Concise Binary Object Representation (CBOR)",
+      "url": "https://www.rfc-editor.org/rfc/rfc8949",
+      "creator": [
+        {
+          "name": "C. Bormann"
+        },
+        {
+          "name": "P. Hoffman"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc7516",
+      "type": "TechArticle",
+      "name": "JSON Web Encryption (JWE)",
+      "url": "https://www.rfc-editor.org/rfc/rfc7516",
+      "creator": [
+        {
+          "name": "M. Jones"
+        },
+        {
+          "name": "J. Hildebrand"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc7519",
+      "type": "TechArticle",
+      "name": "JSON Web Token (JWT)",
+      "url": "https://www.rfc-editor.org/rfc/rfc7519",
+      "creator": [
+        {
+          "name": "M. Jones"
+        },
+        {
+          "name": "J. Bradley"
+        },
+        {
+          "name": "N. Sakimura"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc2397",
+      "type": "TechArticle",
+      "name": "The \"data\" URL scheme",
+      "url": "https://www.rfc-editor.org/rfc/rfc2397",
+      "creator": [
+        {
+          "name": "L. Masinter"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc7800",
+      "type": "TechArticle",
+      "name": "Proof-of-Possession Key Semantics for JSON Web Tokens (JWTs)",
+      "url": "https://www.rfc-editor.org/rfc/rfc7800",
+      "creator": [
+        {
+          "name": "M. Jones"
+        },
+        {
+          "name": "J. Bradley"
+        },
+        {
+          "name": "H. Tschofenig"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc8747",
+      "type": "TechArticle",
+      "name": "Proof-of-Possession Key Semantics for CBOR Web Tokens (CWTs)",
+      "url": "https://www.rfc-editor.org/rfc/rfc8747",
+      "creator": [
+        {
+          "name": "M. Jones"
+        },
+        {
+          "name": "L. Seitz"
+        },
+        {
+          "name": "G. Selander"
+        },
+        {
+          "name": "S. Erdtman"
+        },
+        {
+          "name": "H. Tschofenig"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc",
+      "type": "TechArticle",
+      "name": "SD-JWT-based Verifiable Credentials (SD-JWT VC)",
+      "url": "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc",
+      "creator": [
+        {
+          "name": "Oliver Terbu"
+        },
+        {
+          "name": "Daniel Fett"
+        },
+        {
+          "name": "Brian Campbell"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://url.spec.whatwg.org/",
+      "type": "TechArticle",
+      "name": "URL Standard",
+      "url": "https://url.spec.whatwg.org/",
+      "creator": [
+        {
+          "name": "Anne van Kesteren"
+        }
+      ],
+      "publisher": {
+        "name": "WHATWG"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc7638",
+      "type": "TechArticle",
+      "name": "JSON Web Key (JWK) Thumbprint",
+      "url": "https://www.rfc-editor.org/rfc/rfc7638",
+      "creator": [
+        {
+          "name": "M. Jones"
+        },
+        {
+          "name": "N. Sakimura"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc2119",
+      "type": "TechArticle",
+      "name": "Key words for use in RFCs to Indicate Requirement Levels",
+      "url": "https://www.rfc-editor.org/rfc/rfc2119",
+      "creator": [
+        {
+          "name": "S. Bradner"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc8174",
+      "type": "TechArticle",
+      "name": "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words",
+      "url": "https://www.rfc-editor.org/rfc/rfc8174",
+      "creator": [
+        {
+          "name": "B. Leiba"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/cid-1.0/",
+      "type": "TechArticle",
+      "name": "Controlled Identifiers v1.0",
+      "url": "https://www.w3.org/TR/cid-1.0/",
+      "creator": [
+        {
+          "name": "Michael Jones"
+        },
+        {
+          "name": "Manu Sporny"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/json-ld11/",
+      "type": "TechArticle",
+      "name": "JSON-LD 1.1",
+      "url": "https://www.w3.org/TR/json-ld11/",
+      "creator": [
+        {
+          "name": "Gregg Kellogg"
+        },
+        {
+          "name": "Pierre-Antoine Champin"
+        },
+        {
+          "name": "Dave Longley"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc9596",
+      "type": "TechArticle",
+      "name": "CBOR Object Signing and Encryption (COSE) \"typ\" (type) Header Parameter",
+      "url": "https://www.rfc-editor.org/rfc/rfc9596",
+      "creator": [
+        {
+          "name": "M.B. Jones"
+        },
+        {
+          "name": "O. Steele"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc8392",
+      "type": "TechArticle",
+      "name": "CBOR Web Token (CWT)",
+      "url": "https://www.rfc-editor.org/rfc/rfc8392",
+      "creator": [
+        {
+          "name": "M. Jones"
+        },
+        {
+          "name": "E. Wahlstroem"
+        },
+        {
+          "name": "S. Erdtman"
+        },
+        {
+          "name": "H. Tschofenig"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc7517",
+      "type": "TechArticle",
+      "name": "JSON Web Key (JWK)",
+      "url": "https://www.rfc-editor.org/rfc/rfc7517",
+      "creator": [
+        {
+          "name": "M. Jones"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/did-core/",
+      "type": "TechArticle",
+      "name": "Decentralized Identifiers (DIDs) v1.0",
+      "url": "https://www.w3.org/TR/did-core/",
+      "creator": [
+        {
+          "name": "Manu Sporny"
+        },
+        {
+          "name": "Amy Guy"
+        },
+        {
+          "name": "Markus Sabadello"
+        },
+        {
+          "name": "Drummond Reed"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc7159",
+      "type": "TechArticle",
+      "name": "The JavaScript Object Notation (JSON) Data Interchange Format",
+      "url": "https://www.rfc-editor.org/rfc/rfc7159",
+      "creator": [
+        {
+          "name": "T. Bray, Ed."
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.w3.org/TR/WCAG21/",
+      "type": "TechArticle",
+      "name": "Web Content Accessibility Guidelines (WCAG) 2.1",
+      "url": "https://www.w3.org/TR/WCAG21/",
+      "creator": [
+        {
+          "name": "Michael Cooper"
+        },
+        {
+          "name": "Andrew Kirkpatrick"
+        },
+        {
+          "name": "Joshue O'Connor"
+        },
+        {
+          "name": "Alastair Campbell"
+        }
+      ],
+      "publisher": {
+        "name": "W3C"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc7519",
+      "type": "TechArticle",
+      "name": "JSON Web Token (JWT)",
+      "url": "https://www.rfc-editor.org/rfc/rfc7519",
+      "creator": [
+        {
+          "name": "M. Jones"
+        },
+        {
+          "name": "J. Bradley"
+        },
+        {
+          "name": "N. Sakimura"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    },
+    {
+      "id": "https://www.rfc-editor.org/rfc/rfc7049",
+      "type": "TechArticle",
+      "name": "Concise Binary Object Representation (CBOR)",
+      "url": "https://www.rfc-editor.org/rfc/rfc7049",
+      "creator": [
+        {
+          "name": "C. Bormann"
+        },
+        {
+          "name": "P. Hoffman"
+        }
+      ],
+      "publisher": {
+        "name": "IETF"
+      }
+    }
+  ]
+}</script>
+<style>
+.hljs{--base:#fafafa;--mono-1:#383a42;--mono-2:#686b77;--mono-3:#717277;--hue-1:#0b76c5;--hue-2:#336ae3;--hue-3:#a626a4;--hue-4:#42803c;--hue-5:#ca4706;--hue-5-2:#c91243;--hue-6:#986801;--hue-6-2:#9a6a01}
+@media (prefers-color-scheme:dark){
+.hljs{--base:#282c34;--mono-1:#abb2bf;--mono-2:#818896;--mono-3:#5c6370;--hue-1:#56b6c2;--hue-2:#61aeee;--hue-3:#c678dd;--hue-4:#98c379;--hue-5:#e06c75;--hue-5-2:#be5046;--hue-6:#d19a66;--hue-6-2:#e6c07b}
+}
+.hljs{display:block;overflow-x:auto;padding:.5em;color:#383a42;color:var(--mono-1,#383a42);background:#fafafa;background:var(--base,#fafafa)}
+.hljs-comment,.hljs-quote{color:#717277;color:var(--mono-3,#717277);font-style:italic}
+.hljs-doctag,.hljs-formula,.hljs-keyword{color:#a626a4;color:var(--hue-3,#a626a4)}
+.hljs-deletion,.hljs-name,.hljs-section,.hljs-selector-tag,.hljs-subst{color:#ca4706;color:var(--hue-5,#ca4706);font-weight:700}
+.hljs-literal{color:#0b76c5;color:var(--hue-1,#0b76c5)}
+.hljs-addition,.hljs-attribute,.hljs-meta-string,.hljs-regexp,.hljs-string{color:#42803c;color:var(--hue-4,#42803c)}
+.hljs-built_in,.hljs-class .hljs-title{color:#9a6a01;color:var(--hue-6-2,#9a6a01)}
+.hljs-attr,.hljs-number,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-pseudo,.hljs-template-variable,.hljs-type,.hljs-variable{color:#986801;color:var(--hue-6,#986801)}
+.hljs-bullet,.hljs-link,.hljs-meta,.hljs-selector-id,.hljs-symbol,.hljs-title{color:#336ae3;color:var(--hue-2,#336ae3)}
+.hljs-emphasis{font-style:italic}
+.hljs-strong{font-weight:700}
+.hljs-link{text-decoration:underline}
+</style>
+<style>
+var:hover{text-decoration:underline;cursor:pointer}
+var.respec-hl{color:var(--color,#000);background-color:var(--bg-color);box-shadow:0 0 0 2px var(--bg-color)}
+@media (prefers-color-scheme:dark){
+var.respec-hl{filter:saturate(.9) brightness(.9)}
+}
+var.respec-hl-c1{--bg-color:#f4d200}
+var.respec-hl-c2{--bg-color:#ff87a2}
+var.respec-hl-c3{--bg-color:#96e885}
+var.respec-hl-c4{--bg-color:#3eeed2}
+var.respec-hl-c5{--bg-color:#eacfb6}
+var.respec-hl-c6{--bg-color:#82ddff}
+var.respec-hl-c7{--bg-color:#ffbcf2}
+@media print{
+var.respec-hl{background:0 0;color:#000;box-shadow:unset}
+}
+</style>
+<style>
+var{position:relative;cursor:pointer}
+var[data-type]::after,var[data-type]::before{position:absolute;left:50%;top:-6px;opacity:0;transition:opacity .4s;pointer-events:none}
+var[data-type]::before{content:"";transform:translateX(-50%);border-width:4px 6px 0 6px;border-style:solid;border-color:transparent;border-top-color:#222}
+var[data-type]::after{content:attr(data-type);transform:translateX(-50%) translateY(-100%);background:#222;text-align:center;font-family:"Dank Mono","Fira Code",monospace;font-style:normal;padding:6px;border-radius:3px;color:#daca88;text-indent:0;font-weight:400}
+var[data-type]:hover::after,var[data-type]:hover::before{opacity:1}
+</style>
+<style>
+
+.vc-tabbed {
+  overflow-x: hidden;
+  margin: 0 0;
+}
+
+.vc-tabbed [type="radio"] {
+  display: none;
+}
+
+.vc-tabs {
+  display: flex;
+  align-items: stretch;
+  list-style: none;
+  padding: 0;
+  border-bottom: 1px solid #ccc;
+}
+
+li.vc-tab {
+  margin: unset;
+}
+
+.vc-tab > label {
+  display: block;
+  margin-bottom: -1px;
+  padding: .4em .5em;
+  border: 1px solid #ccc;
+  border-top-right-radius: .4em;
+  border-top-left-radius: .4em;
+  background: #eee;
+  color: #666;
+  cursor: pointer;
+  transition: all 0.3s;
+}
+
+.vc-tab:hover label {
+  border-left-color: #333;
+  border-top-color: #333;
+  border-right-color: #333;
+  color: #333;
+}
+
+.vc-tab-content {
+  display: none;
+}
+.vc-tab-content > pre {
+  white-space: pre-wrap;
+}
+
+.vc-jose-cose-tabbed, .vc-jose-cose-tabbed-jwt,
+.vc-jose-cose-tabbed-sd-jwt, .vc-jose-cose-tabbed-cose,
+.sd-jwt-tabbed {
+  overflow-x: hidden;
+  margin: 0 0;
+}
+
+.vc-jose-cose-tabbed [type="radio"], .vc-jose-cose-tabbed-jwt [type="radio"],
+.vc-jose-cose-tabbed-sd-jwt [type="radio"],
+.vc-jose-cose-tabbed-cose [type="radio"],
+.sd-jwt-tabbed [type="radio"] {
+  display: none;
+}
+
+.vc-jose-cose-tabs, .vc-jose-cose-jwt-tabs, .vc-jose-cose-sd-jwt-tabs,
+.vc-jose-cose-cose-tabs,
+.sd-jwt-tabs {
+  display: flex;
+  align-items: stretch;
+  list-style: none;
+  padding: 0;
+  border-bottom: 1px solid #ccc;
+}
+
+li.vc-jose-cose-tab, li.vc-jose-cose-jwt-tab, li.vc-jose-cose-sd-jwt-tab,
+li.vc-jose-cose-cose-tab,
+li.sd-jwt-tab {
+  margin: 0 0;
+  margin-left: 8px;
+}
+
+.vc-jose-cose-tab>label, .vc-jose-cose-jwt-tab>label,
+.vc-jose-cose-sd-jwt-tab>label, .vc-jose-cose-cose-tab>label,
+.sd-jwt-tab>label {
+  display: block;
+  margin-bottom: -1px;
+  padding: .4em .5em;
+  border: 1px solid #ccc;
+  border-top-right-radius: .4em;
+  border-top-left-radius: .4em;
+  background: #eee;
+  color: #666;
+  cursor: pointer;
+  transition: all 0.3s;
+}
+
+.vc-jose-cose-tab:hover label, .vc-jose-cose-jwt-tab:hover label,
+.vc-jose-cose-sd-jwt-tab:hover label, .vc-jose-cose-cose-tab:hover label,
+.sd-jwt-tab:hover label {
+  border-left-color: #333;
+  border-top-color: #333;
+  border-right-color: #333;
+  color: #333;
+}
+
+.vc-jose-cose-tab-content,
+.sd-jwt-tab-content {
+  display: none;
+}
+
+.vc-tabbed [type="radio"]:nth-of-type(1):checked ~ .vc-tabs .vc-tab:nth-of-type(1) label,
+  .vc-tabbed [type="radio"]:nth-of-type(2):checked ~ .vc-tabs .vc-tab:nth-of-type(2) label,
+  .vc-tabbed [type="radio"]:nth-of-type(3):checked ~ .vc-tabs .vc-tab:nth-of-type(3) label,
+  .vc-tabbed [type="radio"]:nth-of-type(4):checked ~ .vc-tabs .vc-tab:nth-of-type(4) label,
+  .vc-tabbed [type="radio"]:nth-of-type(5):checked ~ .vc-tabs .vc-tab:nth-of-type(5) label,
+  .vc-tabbed [type="radio"]:nth-of-type(6):checked ~ .vc-tabs .vc-tab:nth-of-type(6) label,
+  .vc-tabbed [type="radio"]:nth-of-type(7):checked ~ .vc-tabs .vc-tab:nth-of-type(7) label,
+  .vc-tabbed [type="radio"]:nth-of-type(8):checked ~ .vc-tabs .vc-tab:nth-of-type(8) label,
+  .vc-tabbed [type="radio"]:nth-of-type(9):checked ~ .vc-tabs .vc-tab:nth-of-type(9) label,
+  .vc-tabbed [type="radio"]:nth-of-type(10):checked ~ .vc-tabs .vc-tab:nth-of-type(10) label {
+  border-bottom-color: #fff;
+  background: #fff;
+  color: #222;
+}
+
+.vc-tabbed [type="radio"]:nth-of-type(1):checked ~ .vc-tab-content:nth-of-type(1),
+  .vc-tabbed [type="radio"]:nth-of-type(2):checked ~ .vc-tab-content:nth-of-type(2),
+  .vc-tabbed [type="radio"]:nth-of-type(3):checked ~ .vc-tab-content:nth-of-type(3),
+  .vc-tabbed [type="radio"]:nth-of-type(4):checked ~ .vc-tab-content:nth-of-type(4),
+  .vc-tabbed [type="radio"]:nth-of-type(5):checked ~ .vc-tab-content:nth-of-type(5),
+  .vc-tabbed [type="radio"]:nth-of-type(6):checked ~ .vc-tab-content:nth-of-type(6),
+  .vc-tabbed [type="radio"]:nth-of-type(7):checked ~ .vc-tab-content:nth-of-type(7),
+  .vc-tabbed [type="radio"]:nth-of-type(8):checked ~ .vc-tab-content:nth-of-type(8),
+  .vc-tabbed [type="radio"]:nth-of-type(9):checked ~ .vc-tab-content:nth-of-type(9),
+  .vc-tabbed [type="radio"]:nth-of-type(10):checked ~ .vc-tab-content:nth-of-type(10),
+.sd-jwt-tabbed [type="radio"]:nth-of-type(1):checked ~ .sd-jwt-tab-content:nth-of-type(1),
+.sd-jwt-tabbed [type="radio"]:nth-of-type(2):checked ~ .sd-jwt-tab-content:nth-of-type(2),
+.sd-jwt-tabbed [type="radio"]:nth-of-type(3):checked ~ .sd-jwt-tab-content:nth-of-type(3) {
+  display: block;
+}
+
+.disclosure {
+  margin: 10px 0;
+  font-size: 12px;
+  line-height: 1.6;
+  padding: 5px;
+}
+
+.disclosure h3 {
+  margin: 0;
+  font-size: 14px;
+  padding-left: 5px;
+}
+
+.disclosure .claim-name {
+  color: #333;
+}
+
+.disclosure .hash,
+.disclosure .disclosure-value,
+.disclosure .contents {
+  color: #555;
+  word-wrap: break-word;
+  display: inline;
+}
+
+.disclosure p {
+  margin: 0;
+  padding-left: 5px;
+}
+
+.disclosure pre {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  margin: 0;
+  padding-left: 5px;
+  line-height: 1.6;
+  display: inline-block;
+}
+
+.header-value {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  margin: 0;
+  padding-left: 5px;
+  line-height: 1.6;
+  font-size: 12px;
+}
+
+.cose-text, .jose-text, .vc-jose-cose-jwt .text, .vc-jose-cose-sd-jwt .text,
+ .vc-jose-cose-cose .text {
+  font-family: monospace;
+  color: green;
+}
+
+.sd-jwt-compact, .jwt-compact, .vc-jose-cose-jwt .compact, .vc-jose-cose-sd-jwt
+ .compact, .vc-jose-cose-cose .compact {
+  background-color: rgba(0,0,0,.03);
+}
+
+.sd-jwt-header, .jwt-header, .vc-jose-cose-jwt .header, .vc-jose-cose-sd-jwt
+ .header, .vc-jose-cose-cose .header {
+  color: red;
+}
+
+.sd-jwt-payload, .jwt-payload, .vc-jose-cose-jwt .payload, .vc-jose-cose-sd-jwt
+ .payload, .vc-jose-cose-cose .payload {
+  color: green;
+}
+
+.sd-jwt-signature, .jwt-signature, .vc-jose-cose-jwt .signature,
+ .vc-jose-cose-sd-jwt .signature, .vc-jose-cose-cose .signature {
+  color: blue;
+}
+
+.sd-jwt-disclosure, .vc-jose-cose-jwt .disclosure, .vc-jose-cose-sd-jwt
+ .disclosure, .vc-jose-cose-cose .disclosure {
+  color: purple;
+}
+</style>
+<script id="initialUserConfig" type="application/json">{
+  "group": "vc",
+  "specStatus": "REC",
+  "crEnd": "2025-01-19",
+  "prEnd": "2025-04-17",
+  "shortName": "vc-jose-cose",
+  "implementationReportURI": "https://w3c.github.io/vc-jose-cose-test-suite/",
+  "errata": "https://w3c.github.io/vc-jose-cose/errata.html",
+  "previousPublishDate": "2024-11-05",
+  "previousMaturity": "PR",
+  "doJsonLd": true,
+  "github": "https://github.com/w3c/vc-jose-cose/",
+  "includePermalinks": false,
+  "edDraftURI": "https://w3c.github.io/vc-jose-cose/",
+  "editors": [
+    {
+      "name": "Michael Jones",
+      "url": "https://self-issued.info/",
+      "company": "Self-Issued Consulting",
+      "w3cid": 38745
+    },
+    {
+      "name": "Michael Prorock",
+      "company": "Mesur.io",
+      "companyURL": "https://mesur.io/",
+      "w3cid": 130636
+    },
+    {
+      "name": "Gabe Cohen",
+      "url": "https://github.com/decentralgabe",
+      "company": "Invited Expert",
+      "w3cid": 116851
+    }
+  ],
+  "authors": [],
+  "formerEditors": [],
+  "maxTocLevel": 3,
+  "inlineCSS": true,
+  "postProcess": [
+    null
+  ],
+  "license": "w3c-software-doc",
+  "xref": [
+    "INFRA",
+    "VC-DATA-MODEL-2.0",
+    "CID-1.0"
+  ],
+  "otherLinks": [
+    {
+      "key": "Related Documents",
+      "data": [
+        {
+          "value": "Verifiable Credentials Data Model v2.0",
+          "href": "https://www.w3.org/TR/vc-data-model-2.0/"
+        },
+        {
+          "value": "Controlled Identifiers 1.0",
+          "href": "https://www.w3.org/TR/cid-1.0/"
+        }
+      ]
+    }
+  ],
+  "localBiblio": {
+    "SD-JWT": {
+      "title": "Selective Disclosure for JWTs (SD-JWT)",
+      "href": "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt",
+      "authors": [
+        "Daniel Fett",
+        "Kristina Yasuda",
+        "Brian Campbell"
+      ],
+      "status": "Internet-Draft",
+      "publisher": "IETF",
+      "id": "sd-jwt"
+    },
+    "SD-JWT-VC": {
+      "title": "SD-JWT-based Verifiable Credentials (SD-JWT VC)",
+      "href": "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc",
+      "authors": [
+        "Oliver Terbu",
+        "Daniel Fett",
+        "Brian Campbell"
+      ],
+      "status": "Internet-Draft",
+      "publisher": "IETF",
+      "id": "sd-jwt-vc"
+    },
+    "JOSE-REGISTRIES": {
+      "title": "The JSON Object Signing and Encryption (JOSE) Registries",
+      "href": "https://www.iana.org/assignments/jose",
+      "authors": [
+        "The Internet Assigned Numbers Authority"
+      ],
+      "status": "REC",
+      "publisher": "The Internet Assigned Numbers Authority"
+    },
+    "SP-800-122": {
+      "title": "Guide to Protecting the Confidentiality of Personally Identifiable Information (PII)",
+      "href": "https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-122.pdf",
+      "authors": [
+        "Erika McCallister",
+        "Tim Grance",
+        "Karen Scarfone"
+      ],
+      "status": "Special Publication 800-122",
+      "publisher": "NIST"
+    }
+  },
+  "publishDate": "2025-05-15",
+  "publishISODate": "2025-05-15T00:00:00.000Z",
+  "generatedSubtitle": "W3C Recommendation 15 May 2025"
+}</script>
+<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/W3C-REC"></head>
+  <body class="h-entry" data-cite="INFRA VC-DATA-MODEL-2.0 CID-1.0"><div class="head">
+    <p class="logos"><a class="logo" href="https://www.w3.org/"><img crossorigin="" alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
+  </a></p>
+    <h1 id="title" class="title">Securing Verifiable Credentials using JOSE and COSE</h1> 
+    <p id="w3c-state"><a href="https://www.w3.org/standards/types#REC">W3C Recommendation</a> <time class="dt-published" datetime="2025-05-15">15 May 2025</time></p>
+    <details open="">
+      <summary>More details about this document</summary>
+      <dl>
+        <dt>This version:</dt><dd>
+                <a class="u-url" href="https://www.w3.org/TR/2025/REC-vc-jose-cose-20250515/">https://www.w3.org/TR/2025/REC-vc-jose-cose-20250515/</a>
+              </dd>
+        <dt>Latest published version:</dt><dd>
+                <a href="https://www.w3.org/TR/vc-jose-cose/">https://www.w3.org/TR/vc-jose-cose/</a>
+              </dd>
+        <dt>Latest editor's draft:</dt><dd><a href="https://w3c.github.io/vc-jose-cose/">https://w3c.github.io/vc-jose-cose/</a></dd>
+        <dt>History:</dt><dd>
+                    <a href="https://www.w3.org/standards/history/vc-jose-cose/">https://www.w3.org/standards/history/vc-jose-cose/</a>
+                  </dd><dd>
+                    <a href="https://github.com/w3c/vc-jose-cose/commits/">Commit history</a>
+                  </dd>
+        
+        <dt>Implementation report:</dt><dd>
+                <a href="https://w3c.github.io/vc-jose-cose-test-suite/">https://w3c.github.io/vc-jose-cose-test-suite/</a>
+              </dd>
+        
+        
+        
+        <dt>Editors:</dt><dd class="editor p-author h-card vcard" data-editor-id="38745">
+    <a class="u-url url p-name fn" href="https://self-issued.info/">Michael Jones</a> (<span class="p-org org h-org">Self-Issued Consulting</span>)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="130636">
+    <span class="p-name fn">Michael Prorock</span> (<a class="p-org org h-org" href="https://mesur.io/">Mesur.io</a>)
+  </dd><dd class="editor p-author h-card vcard" data-editor-id="116851">
+    <a class="u-url url p-name fn" href="https://github.com/decentralgabe">Gabe Cohen</a> (<span class="p-org org h-org">Invited Expert</span>)
+  </dd>
+        
+        
+        <dt>Feedback:</dt><dd>
+        <a href="https://github.com/w3c/vc-jose-cose/">GitHub w3c/vc-jose-cose</a>
+        (<a href="https://github.com/w3c/vc-jose-cose/pulls/">pull requests</a>,
+        <a href="https://github.com/w3c/vc-jose-cose/issues/new/choose">new issue</a>,
+        <a href="https://github.com/w3c/vc-jose-cose/issues/">open issues</a>)
+      </dd>
+        <dt>Errata:</dt><dd><a href="https://w3c.github.io/vc-jose-cose/errata.html">Errata exists</a>.</dd>
+        <dt>Related Documents</dt><dd>
+    <a href="https://www.w3.org/TR/vc-data-model-2.0/">Verifiable Credentials Data Model v2.0</a>
+  </dd><dd>
+    <a href="https://www.w3.org/TR/cid-1.0/">Controlled Identifiers 1.0</a>
+  </dd>
+      </dl>
+    </details>
+    <p>
+          See also
+          <a href="https://www.w3.org/Translations/?technology=vc-jose-cose">
+            <strong>translations</strong></a>.
+        </p>
+    
+    <p class="copyright">
+    <a href="https://www.w3.org/policies/#copyright">Copyright</a>
+    ©
+    2025
+    
+    <a href="https://www.w3.org/">World Wide Web Consortium</a>.
+    <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+    <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>,
+    <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a> and
+    <a rel="license" href="https://www.w3.org/copyright/software-license-2023/" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.
+  </p>
+    <hr title="Separator for header">
+  </div>
+    <section id="abstract" class="introductory"><h2>Abstract</h2>
+      <p>
+        This specification defines how to secure credentials and presentations
+        conforming to the Verifiable Credential data model [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>]
+        with JSON Object Signing and Encryption
+        (<a href="https://datatracker.ietf.org/wg/jose/about/">JOSE</a>),
+        Selective Disclosure for JWTs [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>],
+        and CBOR Object Signing and Encryption (COSE) [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>].
+        This enables the Verifiable Credential data model [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>]
+        to be implemented with standards for signing and encryption that are
+        widely adopted.
+      </p>
+    </section>
+    <section id="sotd" class="introductory"><h2>Status of This Document</h2><p><em>This section describes the status of this
+      document at the time of its publication. A list of current <abbr title="World Wide Web Consortium">W3C</abbr>
+      publications and the latest revision of this technical report can be found
+      in the
+      <a href="https://www.w3.org/TR/"><abbr title="World Wide Web Consortium">W3C</abbr> standards and drafts index</a> at
+      https://www.w3.org/TR/.</em></p>
+      <p>
+        The Working Group is actively seeking implementation feedback for this
+        specification. In order to exit the Candidate Recommendation phase, the
+        Working Group has set the requirement of at least two independent
+        implementations for each mandatory feature in the specification. For
+        details on the conformance testing process, see the test suite listed in
+        the <a href="https://w3c.github.io/vc-jose-cose-test-suite/">
+        implementation report</a>.
+      </p>
+    <p>
+    This document was published by the <a href="https://www.w3.org/groups/wg/vc">Verifiable Credentials Working Group</a> as
+    a Recommendation using the
+        <a href="https://www.w3.org/policies/process/20231103/#recs-and-notes">Recommendation track</a>. 
+  </p><p>
+      <abbr title="World Wide Web Consortium">W3C</abbr> recommends the wide deployment of this specification as a standard for
+      the Web.
+    </p><p>
+      A <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation is a specification that, after extensive
+      consensus-building, is endorsed by
+      <abbr title="World Wide Web Consortium">W3C</abbr> and its Members, and
+      has commitments from Working Group members to
+      <a href="https://www.w3.org/policies/patent-policy/#sec-Requirements">royalty-free licensing</a>
+      for implementations.
+      
+    </p><p>
+    
+        This document was produced by a group
+        operating under the
+        <a href="https://www.w3.org/policies/patent-policy/"><abbr title="World Wide Web Consortium">W3C</abbr> Patent
+          Policy</a>.
+      
+    
+                <abbr title="World Wide Web Consortium">W3C</abbr> maintains a
+                <a rel="disclosure" href="https://www.w3.org/groups/wg/vc/ipr">public list of any patent disclosures</a>
+          made in connection with the deliverables of
+          the group; that page also includes
+          instructions for disclosing a patent. An individual who has actual
+          knowledge of a patent which the individual believes contains
+          <a href="https://www.w3.org/policies/patent-policy/#def-essential">Essential Claim(s)</a>
+          must disclose the information in accordance with
+          <a href="https://www.w3.org/policies/patent-policy/#sec-Disclosure">section 6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
+        
+  </p><p>
+                      This document is governed by the
+                      <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20231103/">03 November 2023 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.
+                    </p></section><nav id="toc"><h2 class="introductory" id="table-of-contents">Table of Contents</h2><ol class="toc"><li class="tocline"><a class="tocxref" href="#abstract">Abstract</a></li><li class="tocline"><a class="tocxref" href="#sotd">Status of This Document</a></li><li class="tocline"><a class="tocxref" href="#section-introduction"><bdi class="secno">1. </bdi>Introduction</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#conformance"><bdi class="secno">1.1 </bdi>Conformance</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#conformance-classes"><bdi class="secno">1.1.1 </bdi>Conformance Classes</a></li><li class="tocline"><a class="tocxref" href="#securing-verifiable-credentials"><bdi class="secno">1.1.2 </bdi>Securing Verifiable Credentials</a><ol class="toc"></ol></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#terminology"><bdi class="secno">2. </bdi>Terminology</a></li><li class="tocline"><a class="tocxref" href="#securing-the-vc-data-model"><bdi class="secno">3. </bdi>Securing the VC Data Model</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#with-jose"><bdi class="secno">3.1 </bdi>With JOSE</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#securing-with-jose"><bdi class="secno">3.1.1 </bdi>Securing JSON-LD Verifiable Credentials
+          with JOSE</a></li><li class="tocline"><a class="tocxref" href="#securing-vps-with-jose"><bdi class="secno">3.1.2 </bdi>Securing JSON-LD
+          Verifiable Presentations with JOSE</a></li><li class="tocline"><a class="tocxref" href="#jose-header-parameters-jwt-claims"><bdi class="secno">3.1.3 </bdi>JOSE Header Parameters and
+           JWT Claims</a></li></ol></li><li class="tocline"><a class="tocxref" href="#with-sd-jwt"><bdi class="secno">3.2 </bdi>With SD-JWT</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#securing-with-sd-jwt"><bdi class="secno">3.2.1 </bdi>Securing JSON-LD Verifiable Credentials with SD-JWT</a></li><li class="tocline"><a class="tocxref" href="#securing-vps-sd-jwt"><bdi class="secno">3.2.2 </bdi>Securing JSON-LD Verifiable Presentations with SD-JWT</a></li></ol></li><li class="tocline"><a class="tocxref" href="#securing-with-cose"><bdi class="secno">3.3 </bdi>With COSE</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#securing-vcs-with-cose"><bdi class="secno">3.3.1 </bdi>Securing JSON-LD
+          Verifiable Credentials with COSE</a></li><li class="tocline"><a class="tocxref" href="#securing-vps-with-cose"><bdi class="secno">3.3.2 </bdi>Securing JSON-LD Verifiable Presentations with COSE</a></li><li class="tocline"><a class="tocxref" href="#cose-header-param-cwt-claims"><bdi class="secno">3.3.3 </bdi>COSE Header Parameters and CWT Claims</a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#key-discovery"><bdi class="secno">4. </bdi>Key Discovery</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#using-header-params-claims-key-discovery"><bdi class="secno">4.1 </bdi>Using Header Parameters and Claims for Key Discovery</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#kid"><bdi class="secno">4.1.1 </bdi>kid</a></li><li class="tocline"><a class="tocxref" href="#iss"><bdi class="secno">4.1.2 </bdi>iss</a></li><li class="tocline"><a class="tocxref" href="#cnf"><bdi class="secno">4.1.3 </bdi>cnf</a></li></ol></li><li class="tocline"><a class="tocxref" href="#well-known-uris"><bdi class="secno">4.2 </bdi>Well-Known URIs</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#jwt-issuer"><bdi class="secno">4.2.1 </bdi>JWT Issuer</a></li></ol></li><li class="tocline"><a class="tocxref" href="#using-controlled-identifier-documents"><bdi class="secno">4.3 </bdi>Using Controlled Identifier Documents</a></li></ol></li><li class="tocline"><a class="tocxref" href="#algorithms"><bdi class="secno">5. </bdi>Algorithms</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#alg-jose"><bdi class="secno">5.1 </bdi>Verifying a Credential or Presentation Secured with JOSE</a></li><li class="tocline"><a class="tocxref" href="#alg-sd-jwt"><bdi class="secno">5.2 </bdi>Verifying a Credential or Presentation Secured with SD-JWT</a></li><li class="tocline"><a class="tocxref" href="#alg-cose"><bdi class="secno">5.3 </bdi>Verifying a Credential or Presentation Secured with
+         COSE</a></li><li class="tocline"><a class="tocxref" href="#validation-algorithm"><bdi class="secno">5.4 </bdi>Validation</a></li></ol></li><li class="tocline"><a class="tocxref" href="#iana-considerations"><bdi class="secno">6. </bdi>IANA Considerations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#media-types"><bdi class="secno">6.1 </bdi>Media Types</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#vc-json-jwt"><bdi class="secno">6.1.1 </bdi><code>application/vc+jwt</code></a></li><li class="tocline"><a class="tocxref" href="#vp-json-jwt"><bdi class="secno">6.1.2 </bdi><code>application/vp+jwt</code></a></li><li class="tocline"><a class="tocxref" href="#vc-json-sd-jwt"><bdi class="secno">6.1.3 </bdi><code>application/vc+sd-jwt</code></a></li><li class="tocline"><a class="tocxref" href="#vp-json-sd-jwt"><bdi class="secno">6.1.4 </bdi><code>application/vp+sd-jwt</code></a></li><li class="tocline"><a class="tocxref" href="#vc-json-cose"><bdi class="secno">6.1.5 </bdi><code>application/vc+cose</code></a></li><li class="tocline"><a class="tocxref" href="#vp-json-cose"><bdi class="secno">6.1.6 </bdi><code>application/vp+cose</code></a></li></ol></li></ol></li><li class="tocline"><a class="tocxref" href="#other-considerations"><bdi class="secno">7. </bdi>Other Considerations</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#privacy-considerations"><bdi class="secno">7.1 </bdi>Privacy Considerations</a></li><li class="tocline"><a class="tocxref" href="#security-considerations"><bdi class="secno">7.2 </bdi>Security Considerations</a></li><li class="tocline"><a class="tocxref" href="#accessibility"><bdi class="secno">7.3 </bdi>Accessibility</a></li></ol></li><li class="tocline"><a class="tocxref" href="#examples"><bdi class="secno">8. </bdi>Examples</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#controllers"><bdi class="secno">8.1 </bdi>Controllers</a></li><li class="tocline"><a class="tocxref" href="#credentials"><bdi class="secno">8.2 </bdi>Credentials</a></li><li class="tocline"><a class="tocxref" href="#presentations"><bdi class="secno">8.3 </bdi>Presentations</a></li><li class="tocline"><a class="tocxref" href="#date-uris"><bdi class="secno">8.4 </bdi>Data URIs</a></li><li class="tocline"><a class="tocxref" href="#cose-examples"><bdi class="secno">8.5 </bdi>COSE Examples</a></li></ol></li><li class="tocline"><a class="tocxref" href="#revision-history"><bdi class="secno">A. </bdi>Revision History</a></li><li class="tocline"><a class="tocxref" href="#acknowledgements"><bdi class="secno">B. </bdi>Acknowledgements</a></li><li class="tocline"><a class="tocxref" href="#references"><bdi class="secno">C. </bdi>References</a><ol class="toc"><li class="tocline"><a class="tocxref" href="#normative-references"><bdi class="secno">C.1 </bdi>Normative references</a></li><li class="tocline"><a class="tocxref" href="#informative-references"><bdi class="secno">C.2 </bdi>Informative references</a></li></ol></li></ol></nav>
+    <section id="introduction"><div class="header-wrapper"><h2 id="section-introduction"><bdi class="secno">1. </bdi>Introduction</h2><a class="self-link" href="#section-introduction" aria-label="Permalink for Section 1."></a></div>
+      
+      <p>
+        This specification defines how to secure media types expressing
+        Verifiable Credentials and Verifiable Presentations as described in
+        [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>] using approaches defined by the JOSE, OAuth, and
+        COSE working groups at the IETF. This includes JSON Web Signature (JWS)
+        [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7515" title="JSON Web Signature (JWS)">RFC7515</a></cite>], Selective Disclosure for JWTs [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>],
+        and CBOR Object Signing and Encryption (COSE) [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>].
+        It uses content types [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc6838" title="Media Type Specifications and Registration Procedures">RFC6838</a></cite>] to distinguish between the data types
+        of unsecured documents conforming to [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>] and the data
+        types of secured documents conforming to [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+      </p>
+      <p>
+        JSON Web Signature (JWS) [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7515" title="JSON Web Signature (JWS)">RFC7515</a></cite>] defines a standard means of
+        digitally signing documents, including JSON documents, using JSON-based
+        data structures. It provides a means to ensure the integrity,
+        authenticity, and non-repudiation of the information contained in the
+        document. Selective Disclosure for JWTs (SD-JWT) [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>] builds on
+        JWS by also providing a mechanism enabling selective disclosure of
+        document elements. These properties make JWS and SD-JWT especially
+        well-suited to securing documents conforming to [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+      </p>
+      <p>
+        CBOR Object Signing and Encryption (COSE) [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>] defines a standard
+        means of representing digitally signed data structures using
+        Concise Binary Object Representation (CBOR) [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8949" title="Concise Binary Object Representation (CBOR)">RFC8949</a></cite>]. Like JWS, COSE
+        provides a standardized way to secure the integrity, authenticity, and
+        confidentiality of information. It offers a flexible and extensible set
+        of cryptographic options, allowing for a wide range of algorithms
+        to be used for signing and encryption.
+      </p>
+      <p>
+        COSE supports two main operations: signing and encryption. For signing,
+        COSE allows the creation of digital signatures over CBOR data using
+        various algorithms such as RSA, ECDSA, and EdDSA. These signatures
+        provide assurance of data integrity and authenticity. COSE also supports
+        encryption, enabling the confidentiality of CBOR data by encrypting it
+        with symmetric or asymmetric encryption algorithms.
+      </p>
+      <section id="conformance"><div class="header-wrapper"><h3 id="x1-1-conformance"><bdi class="secno">1.1 </bdi>Conformance</h3><a class="self-link" href="#conformance" aria-label="Permalink for Section 1.1"></a></div><p>As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.</p><p>
+        The key words <em class="rfc2119">MAY</em>, <em class="rfc2119">MUST</em>, <em class="rfc2119">MUST NOT</em>, <em class="rfc2119">NOT RECOMMENDED</em>, <em class="rfc2119">RECOMMENDED</em>, <em class="rfc2119">SHOULD</em>, and <em class="rfc2119">SHOULD NOT</em> in this document
+        are to be interpreted as described in
+        <a href="https://www.rfc-editor.org/info/bcp14">BCP 14</a>
+        [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2119" title="Key words for use in RFCs to Indicate Requirement Levels">RFC2119</a></cite>] [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8174" title="Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words">RFC8174</a></cite>]
+        when, and only when, they appear in all capitals, as shown here.
+      </p>
+        <section id="conformance-classes-0"><div class="header-wrapper"><h4 id="conformance-classes"><bdi class="secno">1.1.1 </bdi>Conformance Classes</h4><a class="self-link" href="#conformance-classes" aria-label="Permalink for Section 1.1.1"></a></div>
+          
+          <p>
+            A <dfn data-plurals="conforming jws documents" id="dfn-conforming-jws-document" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming JWS document</dfn> is one that conforms to all of
+            the "<em class="rfc2119">MUST</em>" statements in Section <a href="#secure-with-jose" class="sec-ref"><bdi class="secno">3.1 </bdi>With JOSE</a>.
+          </p>
+          <p>
+            A <dfn id="dfn-conforming-jws-issuer-implementation" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming JWS issuer implementation</dfn> produces
+            <a data-link-type="dfn|abstract-op" href="#dfn-conforming-jws-document" class="internalDFN" id="ref-for-dfn-conforming-jws-document-1">conforming JWS documents</a> and <em class="rfc2119">MUST</em> secure them as described in
+            Section <a href="#secure-with-jose" class="sec-ref"><bdi class="secno">3.1 </bdi>With JOSE</a>.
+          </p><p>
+            A <dfn id="dfn-conforming-jws-verifier-implementation" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming JWS verifier implementation</dfn> verifies
+            <a data-link-type="dfn|abstract-op" href="#dfn-conforming-jws-document" class="internalDFN" id="ref-for-dfn-conforming-jws-document-2">conforming JWS documents</a> as described in Section
+            <a href="#secure-with-jose" class="sec-ref"><bdi class="secno">3.1 </bdi>With JOSE</a>.
+          </p>
+          <p>
+            A <dfn data-plurals="conforming sd-jwt documents" id="dfn-conforming-sd-jwt-document" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming SD-JWT document</dfn> is one that conforms to all
+            of the "<em class="rfc2119">MUST</em>" statements in Section <a href="#secure-with-sd-jwt" class="sec-ref"><bdi class="secno">3.2 </bdi>With SD-JWT</a>.
+          </p>
+          <p>
+            A <dfn id="dfn-conforming-sd-jwt-issuer-implementation" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming SD-JWT issuer implementation</dfn> produces
+            <a data-link-type="dfn|abstract-op" href="#dfn-conforming-sd-jwt-document" class="internalDFN" id="ref-for-dfn-conforming-sd-jwt-document-1">conforming SD-JWT documents</a> and <em class="rfc2119">MUST</em> secure them as described
+            in Section <a href="#secure-with-sd-jwt" class="sec-ref"><bdi class="secno">3.2 </bdi>With SD-JWT</a>.
+          </p><p>
+            A <dfn id="dfn-conforming-sd-jwt-verifier-implementation" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming SD-JWT verifier implementation</dfn> verifies
+            <a data-link-type="dfn|abstract-op" href="#dfn-conforming-sd-jwt-document" class="internalDFN" id="ref-for-dfn-conforming-sd-jwt-document-2">conforming SD-JWT documents</a> as described in Section
+            <a href="#secure-with-sd-jwt" class="sec-ref"><bdi class="secno">3.2 </bdi>With SD-JWT</a>.
+          </p>
+          <p>
+            A <dfn data-plurals="conforming cose documents" id="dfn-conforming-cose-document" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming COSE document</dfn> is one that conforms to all
+            of the "<em class="rfc2119">MUST</em>" statements in Section <a href="#secure-with-cose" class="sec-ref"><bdi class="secno">3.3 </bdi>With COSE</a>.
+          </p>
+          <p>
+            A <dfn id="dfn-conforming-cose-issuer-implementation" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming COSE issuer implementation</dfn> produces
+            <a data-link-type="dfn|abstract-op" href="#dfn-conforming-cose-document" class="internalDFN" id="ref-for-dfn-conforming-cose-document-1">conforming COSE documents</a> and <em class="rfc2119">MUST</em> secure them as described in
+            Section <a href="#secure-with-cose" class="sec-ref"><bdi class="secno">3.3 </bdi>With COSE</a>.
+          </p>
+          <p>
+            A <dfn id="dfn-conforming-cose-verifier-implementation" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">conforming COSE verifier implementation</dfn> verifies
+            <a data-link-type="dfn|abstract-op" href="#dfn-conforming-cose-document" class="internalDFN" id="ref-for-dfn-conforming-cose-document-2">conforming COSE documents</a> as described in Section
+            <a href="#secure-with-cose" class="sec-ref"><bdi class="secno">3.3 </bdi>With COSE</a>.
+          </p>
+        </section>
+        <section id="securing-verifiable-credentials-0"><div class="header-wrapper"><h4 id="securing-verifiable-credentials"><bdi class="secno">1.1.2 </bdi>Securing Verifiable Credentials</h4><a class="self-link" href="#securing-verifiable-credentials" aria-label="Permalink for Section 1.1.2"></a></div>
+          
+          <p>
+            The <a href="https://www.w3.org/TR/vc-data-model-2.0/#securing-mechanism-specifications">Verifiable Credentials Data Model v2.0</a>
+            describes the approach taken by this specification to secure JSON
+            and CBOR claims by <i>applying an <code>enveloping proof</code></i>.
+          </p>
+          <p>
+            This specification defines how to secure different data structures
+            using various <code>enveloping proof</code> mechanisms:
+          </p>
+          <dl>
+            <dt>JSON Web Token (JWT):</dt>
+            <dd>A JWT secures a JWT Claims Set, in its entirety. A JWT Claims Set
+              is a JSON object containing one or more claims about an entity
+              (typically the subject of the JWT). If any part of the
+              JWT Claims Set is to be revealed, all claims in that set must be
+              revealed; there is no option to reveal (or conceal) <i>some</i> of
+              the claims while concealing (or revealing) the others.
+            </dd>
+            <dt>Selective Disclosure JSON Web Token (SD-JWT):</dt>
+            <dd>
+              An SD-JWT secures a JWT Claims Set, similar to a JWT securing
+              a JWT Claims Set, but with the added capabilities of selectively
+              revealing or withholding parts of the JWT Claims Set.
+              A JWT Claims Set is one or more claims about an entity
+              (typically the subject of the SD-JWT).
+            </dd>
+            <dt>CBOR Object Signing and Encryption (COSE):</dt>
+            <dd>
+              COSE secures CBOR (Concise Binary Object Representation) data structures.
+              CBOR is a binary data format that is more compact than JSON and is
+              designed for constrained environments.
+            </dd>
+          </dl>
+          <p>In the context of Verifiable Credentials:</p>
+          <ul>
+            <li>
+              When using JWTs,
+              the Verifiable Credential or Presentation is encoded as a JWT Claims Set.
+            </li>
+            <li>
+              When using SD-JWTs,
+              the Verifiable Credential or Presentation is encoded as a JWT Claims Set with Selective Disclosure features.
+            </li>
+            <li>
+              When using COSE,
+              the Verifiable Credential or Presentation is encoded as a CBOR data structure.
+            </li>
+          </ul>
+          <p>
+            In all cases, the underlying data model of the Verifiable Credential
+            or Presentation remains consistent with the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>],
+            but the encoding and security mechanisms differ.
+          </p>
+          <p>
+            The normative statements in <a href="https://www.w3.org/TR/vc-data-model-2.0/#securing-mechanisms">
+            Securing Mechanisms</a> apply to securing
+            <code>application/vc+jwt</code> and
+            <code>application/vp+jwt</code>,
+            <code>application/vc+sd-jwt</code> and
+            <code>application/vp+sd-jwt</code>,
+            <code>application/vc+cose</code> and
+            <code>application/vp+cose</code>.
+          </p>
+          <section id="jwt-format-and-requirements"><div class="header-wrapper"><h5 id="x1-1-2-1-jwt-format-and-requirements"><bdi class="secno">1.1.2.1 </bdi>JWT Format and Requirements</h5><a class="self-link" href="#jwt-format-and-requirements" aria-label="Permalink for Section 1.1.2.1"></a></div>
+            
+            <p>
+              JSON Web Token implementers are advised to review
+              <a href="https://www.rfc-editor.org/rfc/rfc7519#section-8">Implementation Requirements</a>.
+            </p>
+            <p>
+              Issuers, Holders, and Verifiers of JWTs <em class="rfc2119">MUST</em> understand the effect
+              of the JSON Web Token header parameter setting of
+              <code>"alg": "none"</code> when using JSON Web Tokens to secure
+              [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>]. When content types from the
+              [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>] are secured using JSON Web Tokens, the
+              header parameter setting of <code>"alg": "none"</code>
+              is used to communicate that a Verifiable Credential or
+              Verifiable Presentation encoded as a JWT Claims Set has no
+              integrity protection.
+            </p>
+            <p>
+              Issuers, Holders, and Verifiers <em class="rfc2119">MUST</em> ignore all JWT Claims Sets
+              that have no integrity protection.
+            </p>
+            <p>
+              The JWT Claim Names <code>vc</code> and <code>vp</code>
+              <em class="rfc2119">MUST NOT</em> be present in any JWT Claims Set that comprises a
+              <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-1">verifiable credential</a> or a <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentation</a>.
+            </p>
+          </section>
+          <section id="sd-jwt-format-and-requirements"><div class="header-wrapper"><h5 id="x1-1-2-2-sd-jwt-format-and-requirements"><bdi class="secno">1.1.2.2 </bdi>SD-JWT Format and Requirements</h5><a class="self-link" href="#sd-jwt-format-and-requirements" aria-label="Permalink for Section 1.1.2.2"></a></div>
+            
+            <p>
+              This specification uses Selective Disclosure for JWTs (SD-JWT) as
+              defined in the IETF draft [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>]. Implementers <em class="rfc2119">SHOULD</em> refer to
+              this draft for the full details of the SD-JWT format and
+              processing requirements.
+            </p>
+            <ul>
+              <li>An SD-JWT consists of three main parts: the
+                SD-JWT itself, optional disclosures, and an optional KB-JWT (Key
+                Binding JWT). These parts are separated by tilde (~) characters.
+              </li>
+              <li>If the KB-JWT is not present, the SD-JWT must end with a
+                tilde (~) character. This is crucial for correct parsing and
+                processing of the SD-JWT.
+              </li>
+              <li>Selective disclosure is achieved through the use of
+                disclosure objects. These are base64url-encoded JSON arrays
+                containing the digest of the disclosed claim, the claim name,
+                and the claim value.
+              </li>
+              <li>Each disclosable claim is combined with a salt value
+                before hashing to prevent dictionary attacks.
+              </li>
+            </ul>
+          </section>
+        </section>
+      </section>
+    </section>
+    <section id="terminology-0"><div class="header-wrapper"><h2 id="terminology"><bdi class="secno">2. </bdi>Terminology</h2><a class="self-link" href="#terminology" aria-label="Permalink for Section 2."></a></div>
+      
+      <p>
+        This section defines the terms used in this specification. A link to
+        these terms is included whenever they appear in this specification.
+      </p>
+      <dl class="termlist">
+        <dt><dfn data-plurals="public keys" id="dfn-public-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">public key</dfn></dt>
+        <dd>
+          Cryptographic material that can be used to verify digital proofs
+          created with a corresponding <a href="#dfn-private-key" class="internalDFN" data-link-type="dfn" id="ref-for-dfn-private-key-1">private key</a>.
+        </dd>
+        <dt><dfn id="dfn-private-key" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">private key</dfn></dt>
+        <dd>
+          Cryptographic material that can be used to generate digital proofs.
+        </dd>
+        <dt><dfn data-lt="verifiable credentials|verifiable credential" id="dfn-verifiable-credentials" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">verifiable credential</dfn></dt>
+        <dd>
+          A standard data model and representation format for expressing
+          cryptographically-verifiable digital credentials, as defined by the <abbr title="World Wide Web Consortium">W3C</abbr>
+          Verifiable Credentials specification [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+        </dd>
+        <dt><dfn data-plurals="controlled identifier documents" id="dfn-controlled-identifier-document" tabindex="0" aria-haspopup="dialog" data-dfn-type="dfn">controlled identifier document</dfn></dt>
+        <dd>
+          A document that contains public cryptographic material as defined in
+          the <cite><a data-matched-text="[[[CID-1.0]]]" href="https://www.w3.org/TR/cid-1.0/">Controlled Identifiers v1.0</a></cite> specification.
+        </dd>
+      </dl>
+    </section>
+    <section id="securing-the-vc-data-model-0"><div class="header-wrapper"><h2 id="securing-the-vc-data-model"><bdi class="secno">3. </bdi>Securing the VC Data Model</h2><a class="self-link" href="#securing-the-vc-data-model" aria-label="Permalink for Section 3."></a></div>
+      
+      <p>
+        This section outlines how to secure documents conforming
+        to [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>] using JOSE, SD-JWT, and COSE.
+      </p>
+      <p>
+        Documents conforming to [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>],
+        and their associated media types, rely on
+        JSON-LD, which is an extensible format for describing
+        linked data; see
+        <a href="https://www.w3.org/TR/json-ld11/#relationship-to-rdf">JSON-LD Relationship to RDF</a>.
+      </p>
+      <p>
+        A benefit to this approach is that payloads can be made to conform
+        directly to [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>] without any mappings or
+        transformation, while at the same time supporting registered
+        header parameters and claims that are understood in the context of JOSE,
+        SD-JWT, and COSE.
+      </p>
+      <p>
+        It is <em class="rfc2119">RECOMMENDED</em> that media types be used to distinguish
+        <a href="https://www.w3.org/TR/vc-data-model-2.0/#credentials">verifiable credentials</a>
+        and <a href="https://www.w3.org/TR/vc-data-model-2.0/#presentations">verifiable presentations</a>
+        from other kinds of secured JSON or CBOR.
+      </p>
+      <p>
+        The most specific media type (or subtype) available <em class="rfc2119">SHOULD</em> be used,
+        instead of more generic media types (or supertypes). For example, rather
+        than the general <code>application/sd-jwt</code>,
+        <code>application/vc+sd-jwt</code> <em class="rfc2119">SHOULD</em> be used, unless there is a
+        more specific media type that would even better identify the secured
+        envelope format.
+      </p>
+      <p>
+        If implementations do not know which media type to use, media types
+        defined in this specification <em class="rfc2119">MUST</em> be used.
+      </p>
+      <section id="secure-with-jose"><div class="header-wrapper"><h3 id="with-jose"><bdi class="secno">3.1 </bdi>With JOSE</h3><a class="self-link" href="#with-jose" aria-label="Permalink for Section 3.1"></a></div>
+        
+        <section id="securing-json-ld-verifiable-credentials-with-jose"><div class="header-wrapper"><h4 id="securing-with-jose"><bdi class="secno">3.1.1 </bdi>Securing JSON-LD Verifiable Credentials
+          with JOSE</h4><a class="self-link" href="#securing-with-jose" aria-label="Permalink for Section 3.1.1"></a></div>
+          
+          <p>
+            This section details how to use JOSE to secure
+            <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-2">verifiable credentials</a> conforming to [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+          </p>
+          <p>
+            A <a data-link-type="dfn|abstract-op" href="#dfn-conforming-jws-issuer-implementation" class="internalDFN" id="ref-for-dfn-conforming-jws-issuer-implementation-1">conforming JWS issuer implementation</a> <em class="rfc2119">MUST</em> use [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7515" title="JSON Web Signature (JWS)">RFC7515</a></cite>] to
+            secure this media type. The unsecured <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-3">verifiable credential</a> is
+            the unencoded JWS payload.
+          </p>
+          <p>
+            The <code>typ</code> header parameter <em class="rfc2119">SHOULD</em> be <code>vc+jwt</code>.
+            When present, the <code>cty</code> header parameter <em class="rfc2119">SHOULD</em> be
+            <code>vc</code>. 
+            The <code>cty</code> header parameter value can be used to differentiate
+            between secured content of different types when using <code>vc+jwt</code>.
+            The <code>content type</code> header parameter is optional, and can be used
+            to express a more specific media type than <code>application/vc</code> when one is available.
+            See <a href="https://www.rfc-editor.org/rfc/rfc7515#section-4.1">Registered Header Parameter Names</a>
+            for additional details regarding usage of <code>typ</code> and <code>cty</code>.
+          </p>
+          <p>
+            A <a data-link-type="dfn|abstract-op" href="#dfn-conforming-jws-verifier-implementation" class="internalDFN" id="ref-for-dfn-conforming-jws-verifier-implementation-1">conforming JWS verifier implementation</a> <em class="rfc2119">MUST</em> use [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7515" title="JSON Web Signature (JWS)">RFC7515</a></cite>] to
+            verify <a data-link-type="dfn|abstract-op" href="#dfn-conforming-jws-document" class="internalDFN" id="ref-for-dfn-conforming-jws-document-3">conforming JWS documents</a> that use this media type.
+          </p>
+          <p>
+            To encrypt a secured <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-4">verifiable credential</a> when transmitting
+            over an insecure channel, implementers <em class="rfc2119">MAY</em> use
+            JSON Web Encryption (JWE) [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>] by nesting the secured
+            <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-5">verifiable credential</a> as the plaintext payload of a JWE, per the
+            description of Nested JWTs in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>].
+          </p>
+          <div class="example" id="example-a-simple-example-of-a-verifiable-credential-secured-with-jose">
+        <div class="marker">
+    <a class="self-link" href="#example-a-simple-example-of-a-verifiable-credential-secured-with-jose">Example<bdi> 1</bdi></a><span class="example-title">: A simple example of a verifiable credential secured with JOSE</span>
+  </div> 
+      <div class="vc-tabbed"><input type="radio" id="vc-tab1unsigned" name="vc-tabs1" checked=""><input type="radio" id="vc-tab1jose" name="vc-tabs1"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab1unsigned"><abbr title="Unsecured credential">Credential</abbr></label></li><li class="vc-tab"><label for="vc-tab1jose"><abbr title="Secured with JOSE">jose</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 605px;"><pre class="nohighlight vc" data-vc-tabs="jose">{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "http://university.example/credentials/3732",
+  "type": ["VerifiableCredential", "ExampleDegreeCredential", "ExamplePersonCredential"],
+  "issuer": "https://university.example/issuers/14",
+  "validFrom": "2010-01-01T19:23:24Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "ExampleBachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    },
+    "alumniOf": {
+      "name": "Example University"
+    }
+  },
+  "credentialSchema": [{
+    "id": "https://example.org/examples/degree.json",
+    "type": "JsonSchema"
+  },
+  {
+    "id": "https://example.org/examples/alumni.json",
+    "type": "JsonSchema"
+  }]
+}</pre></div><div class="vc-tab-content" style="min-height: 605px;">
+<div class="vc-jose-cose-jwt-tabbed">
+    <div class="vc-jose-cose-jwt-tab-content">
+<strong>Protected Headers</strong>
+<pre>{
+  "kid": "ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",
+  "alg": "ES256"
+}
+</pre>
+<strong>application/vc</strong>
+<pre>{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "http://university.example/credentials/3732",
+  "type": [
+    "VerifiableCredential",
+    "ExampleDegreeCredential",
+    "ExamplePersonCredential"
+  ],
+  "issuer": "https://university.example/issuers/14",
+  "validFrom": "2010-01-01T19:23:24Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "ExampleBachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    },
+    "alumniOf": {
+      "name": "Example University"
+    }
+  },
+  "credentialSchema": [
+    {
+      "id": "https://example.org/examples/degree.json",
+      "type": "JsonSchema"
+    },
+    {
+      "id": "https://example.org/examples/alumni.json",
+      "type": "JsonSchema"
+    }
+  ]
+}
+</pre>
+<strong>application/vc+jwt</strong>
+<div class="jose-text">
+<div class="jwt-compact">
+<span class="jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
+.<span class="jwt-payload">eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwOi8vdW5pdmVyc2l0eS5leGFtcGxlL2NyZWRlbnRpYWxzLzM3MzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRXhhbXBsZURlZ3JlZUNyZWRlbnRpYWwiLCJFeGFtcGxlUGVyc29uQ3JlZGVudGlhbCJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzE0IiwidmFsaWRGcm9tIjoiMjAxMC0wMS0wMVQxOToyMzoyNFoiLCJjcmVkZW50aWFsU3ViamVjdCI6eyJpZCI6ImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSIsImRlZ3JlZSI6eyJ0eXBlIjoiRXhhbXBsZUJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifSwiYWx1bW5pT2YiOnsibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSJ9fSwiY3JlZGVudGlhbFNjaGVtYSI6W3siaWQiOiJodHRwczovL2V4YW1wbGUub3JnL2V4YW1wbGVzL2RlZ3JlZS5qc29uIiwidHlwZSI6Ikpzb25TY2hlbWEifSx7ImlkIjoiaHR0cHM6Ly9leGFtcGxlLm9yZy9leGFtcGxlcy9hbHVtbmkuanNvbiIsInR5cGUiOiJKc29uU2NoZW1hIn1dfQ</span>
+.<span class="jwt-signature">w7T-Tan_Ck4TwJ7TtUnMSQXSV64-cSGZPV_c-_xivMiMYCfW_07dAiWLt0kOxYVUML9KGj591wGbwSdL0h0IMQ</span>
+</div>
+</div>
+    </div>
+</div></div></div></div>
+          <p>
+            See <a href="https://www.w3.org/TR/vc-data-model-2.0/#example-using-the-credentialschema-property-to-perform-json-schema-validation">Verifiable Credentials Data Model v2.0</a>
+            for more details regarding this example.
+          </p>
+        </section>
+        <section id="securing-json-ld-verifiable-presentations-with-jose"><div class="header-wrapper"><h4 id="securing-vps-with-jose"><bdi class="secno">3.1.2 </bdi>Securing JSON-LD
+          Verifiable Presentations with JOSE</h4><a class="self-link" href="#securing-vps-with-jose" aria-label="Permalink for Section 3.1.2"></a></div>
+          
+          <p>
+            This section details how to use JOSE to secure
+            <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentations</a> conforming to [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+          </p>
+          <p>
+            A <a data-link-type="dfn|abstract-op" href="#dfn-conforming-jws-issuer-implementation" class="internalDFN" id="ref-for-dfn-conforming-jws-issuer-implementation-2">conforming JWS issuer implementation</a> <em class="rfc2119">MUST</em> use [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7515" title="JSON Web Signature (JWS)">RFC7515</a></cite>] to
+            secure this media type. The unsecured <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentation</a> is
+            the unencoded JWS payload.
+          </p>
+          <p>
+            The <code>typ</code> header parameter <em class="rfc2119">SHOULD</em> be <code>vp+jwt</code>.
+            When present, the <code>cty</code> header parameter <em class="rfc2119">SHOULD</em> be
+            <code>vp</code>.
+            The <code>cty</code> header parameter value can be used to differentiate
+            between secured content of different types when using <code>vp+jwt</code>.
+            The <code>content type</code> header parameter is optional, and can be used
+            to express a more specific media type than <code>application/vc</code> when one is available.
+            See <a href="https://www.rfc-editor.org/rfc/rfc7515#section-4.1">Registered Header Parameter Names</a>
+            for additional details regarding usage of <code>typ</code> and <code>cty</code>.
+          </p>
+          <p>
+            A <a data-link-type="dfn|abstract-op" href="#dfn-conforming-jws-verifier-implementation" class="internalDFN" id="ref-for-dfn-conforming-jws-verifier-implementation-2">conforming JWS verifier implementation</a> <em class="rfc2119">MUST</em> use [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7515" title="JSON Web Signature (JWS)">RFC7515</a></cite>] to
+            verify <a data-link-type="dfn|abstract-op" href="#dfn-conforming-jws-document" class="internalDFN" id="ref-for-dfn-conforming-jws-document-4">conforming JWS documents</a> that use this media type.
+          </p>
+          <p>
+            Verifiable Credentials secured in
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations">verifiable presentations</a>
+            <em class="rfc2119">MUST</em> use the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#defn-EnvelopedVerifiableCredential">Enveloped Verifiable Credential</a>
+            type defined by the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+          </p>
+          <p>
+            Verifiable Presentations in
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations">verifiable presentations</a>
+            <em class="rfc2119">MUST</em> use the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#defn-EnvelopedVerifiablePresentation">Enveloped Verifiable Presentation</a>
+            type defined by the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+          </p>
+          <p>
+            Credentials in <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentations</a> <em class="rfc2119">MUST</em> be secured.
+            In this case, these <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-credential">credentials</a> are secured using JWS.
+          </p><p>
+          </p><p>
+            To encrypt a secured <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentation</a> when transmitting
+            over an insecure channel, implementers <em class="rfc2119">MAY</em> use
+            JSON Web Encryption (JWE) [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>] by nesting the secured
+            <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentation</a> as the plaintext payload of a JWE,
+            per the description of Nested JWTs in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>].
+          </p>
+          <div class="example" id="example-a-simple-example-of-a-verifiable-presentation-secured-with-jose-with-the-envelopedverifiablecredential-type">
+        <div class="marker">
+    <a class="self-link" href="#example-a-simple-example-of-a-verifiable-presentation-secured-with-jose-with-the-envelopedverifiablecredential-type">Example<bdi> 2</bdi></a><span class="example-title">: A simple example of a verifiable presentation secured with JOSE with the EnvelopedVerifiableCredential type</span>
+  </div> 
+      <div class="vc-tabbed"><input type="radio" id="vc-tab2unsigned" name="vc-tabs2" checked=""><input type="radio" id="vc-tab2jose" name="vc-tabs2"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab2unsigned"><abbr title="Unsecured presentation">Presentation</abbr></label></li><li class="vc-tab"><label for="vc-tab2jose"><abbr title="Secured with JOSE">jose</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 259px;"><pre class="nohighlight vc" data-vc-tabs="jose">{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "VerifiablePresentation",
+  "verifiableCredential": [{
+    "@context": ["https://www.w3.org/ns/credentials/v2"],
+    "type": ["EnvelopedVerifiableCredential"],
+    "id": "data:application/vc+jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMzODQifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwOi8vdW5pdmVyc2l0eS5leGFtcGxlL2NyZWRlbnRpYWxzLzE4NzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRXhhbXBsZUFsdW1uaUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiaWQiOiJodHRwczovL2V4YW1wbGUub3JnL2V4YW1wbGVzL2RlZ3JlZS5qc29uIiwidHlwZSI6Ikpzb25TY2hlbWEifSwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZToxMjMiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19.d2k4O3FytQJf83kLh-HsXuPvh6yeOlhJELVo5TF71gu7elslQyOf2ZItAXrtbXF4Kz9WivNdztOayz4VUQ0Mwa8yCDZkP9B2pH-9S_tcAFxeoeJ6Z4XnFuL_DOfkR1fP"
+  }]
+}</pre></div><div class="vc-tab-content" style="min-height: 259px;">
+<div class="vc-jose-cose-jwt-tabbed">
+    <div class="vc-jose-cose-jwt-tab-content">
+<strong>Protected Headers</strong>
+<pre>{
+  "kid": "ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",
+  "alg": "ES256"
+}
+</pre>
+<strong>application/vp</strong>
+<pre>{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "VerifiablePresentation",
+  "verifiableCredential": [
+    {
+      "@context": "https://www.w3.org/ns/credentials/v2",
+      "id": "data:application/vc+jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMzODQifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwOi8vdW5pdmVyc2l0eS5leGFtcGxlL2NyZWRlbnRpYWxzLzE4NzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRXhhbXBsZUFsdW1uaUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiaWQiOiJodHRwczovL2V4YW1wbGUub3JnL2V4YW1wbGVzL2RlZ3JlZS5qc29uIiwidHlwZSI6Ikpzb25TY2hlbWEifSwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZToxMjMiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19.d2k4O3FytQJf83kLh-HsXuPvh6yeOlhJELVo5TF71gu7elslQyOf2ZItAXrtbXF4Kz9WivNdztOayz4VUQ0Mwa8yCDZkP9B2pH-9S_tcAFxeoeJ6Z4XnFuL_DOfkR1fP;data:application/vc+jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMzODQifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwOi8vdW5pdmVyc2l0eS5leGFtcGxlL2NyZWRlbnRpYWxzLzE4NzIiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRXhhbXBsZUFsdW1uaUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiaWQiOiJodHRwczovL2V4YW1wbGUub3JnL2V4YW1wbGVzL2RlZ3JlZS5qc29uIiwidHlwZSI6Ikpzb25TY2hlbWEifSwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZToxMjMiLCJkZWdyZWUiOnsidHlwZSI6IkJhY2hlbG9yRGVncmVlIiwibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMifX19.d2k4O3FytQJf83kLh-HsXuPvh6yeOlhJELVo5TF71gu7elslQyOf2ZItAXrtbXF4Kz9WivNdztOayz4VUQ0Mwa8yCDZkP9B2pH-9S_tcAFxeoeJ6Z4XnFuL_DOfkR1fP",
+      "type": "EnvelopedVerifiableCredential"
+    }
+  ]
+}
+</pre>
+<strong>application/vp+jwt</strong>
+<div class="jose-text">
+<div class="jwt-compact">
+<span class="jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
+.<span class="jwt-payload">eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidHlwZSI6IlZlcmlmaWFibGVQcmVzZW50YXRpb24iLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6W3siQGNvbnRleHQiOiJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJpZCI6ImRhdGE6YXBwbGljYXRpb24vdmMrand0LGV5SnJhV1FpT2lKRmVFaHJRazFYT1dadFltdDJWakkyTm0xU2NIVlFNbk5WV1Y5T1gwVlhTVTR4YkdGd1ZYcFBPSEp2SWl3aVlXeG5Jam9pUlZNek9EUWlmUS5leUpBWTI5dWRHVjRkQ0k2V3lKb2RIUndjem92TDNkM2R5NTNNeTV2Y21jdmJuTXZZM0psWkdWdWRHbGhiSE12ZGpJaUxDSm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdlpYaGhiWEJzWlhNdmRqSWlYU3dpYVdRaU9pSm9kSFJ3T2k4dmRXNXBkbVZ5YzJsMGVTNWxlR0Z0Y0d4bEwyTnlaV1JsYm5ScFlXeHpMekU0TnpJaUxDSjBlWEJsSWpwYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdpUlhoaGJYQnNaVUZzZFcxdWFVTnlaV1JsYm5ScFlXd2lYU3dpYVhOemRXVnlJam9pYUhSMGNITTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2YVhOemRXVnljeTgxTmpVd05Ea2lMQ0oyWVd4cFpFWnliMjBpT2lJeU1ERXdMVEF4TFRBeFZERTVPakl6T2pJMFdpSXNJbU55WldSbGJuUnBZV3hUWTJobGJXRWlPbnNpYVdRaU9pSm9kSFJ3Y3pvdkwyVjRZVzF3YkdVdWIzSm5MMlY0WVcxd2JHVnpMMlJsWjNKbFpTNXFjMjl1SWl3aWRIbHdaU0k2SWtwemIyNVRZMmhsYldFaWZTd2lZM0psWkdWdWRHbGhiRk4xWW1wbFkzUWlPbnNpYVdRaU9pSmthV1E2WlhoaGJYQnNaVG94TWpNaUxDSmtaV2R5WldVaU9uc2lkSGx3WlNJNklrSmhZMmhsYkc5eVJHVm5jbVZsSWl3aWJtRnRaU0k2SWtKaFkyaGxiRzl5SUc5bUlGTmphV1Z1WTJVZ1lXNWtJRUZ5ZEhNaWZYMTkuZDJrNE8zRnl0UUpmODNrTGgtSHNYdVB2aDZ5ZU9saEpFTFZvNVRGNzFndTdlbHNsUXlPZjJaSXRBWHJ0YlhGNEt6OVdpdk5kenRPYXl6NFZVUTBNd2E4eUNEWmtQOUIycEgtOVNfdGNBRnhlb2VKNlo0WG5GdUxfRE9ma1IxZlA7ZGF0YTphcHBsaWNhdGlvbi92Yytqd3QsZXlKcmFXUWlPaUpGZUVoclFrMVhPV1p0WW10MlZqSTJObTFTY0hWUU1uTlZXVjlPWDBWWFNVNHhiR0Z3VlhwUE9ISnZJaXdpWVd4bklqb2lSVk16T0RRaWZRLmV5SkFZMjl1ZEdWNGRDSTZXeUpvZEhSd2N6b3ZMM2QzZHk1M015NXZjbWN2Ym5NdlkzSmxaR1Z1ZEdsaGJITXZkaklpTENKb2RIUndjem92TDNkM2R5NTNNeTV2Y21jdmJuTXZZM0psWkdWdWRHbGhiSE12WlhoaGJYQnNaWE12ZGpJaVhTd2lhV1FpT2lKb2RIUndPaTh2ZFc1cGRtVnljMmwwZVM1bGVHRnRjR3hsTDJOeVpXUmxiblJwWVd4ekx6RTROeklpTENKMGVYQmxJanBiSWxabGNtbG1hV0ZpYkdWRGNtVmtaVzUwYVdGc0lpd2lSWGhoYlhCc1pVRnNkVzF1YVVOeVpXUmxiblJwWVd3aVhTd2lhWE56ZFdWeUlqb2lhSFIwY0hNNkx5OTFibWwyWlhKemFYUjVMbVY0WVcxd2JHVXZhWE56ZFdWeWN5ODFOalV3TkRraUxDSjJZV3hwWkVaeWIyMGlPaUl5TURFd0xUQXhMVEF4VkRFNU9qSXpPakkwV2lJc0ltTnlaV1JsYm5ScFlXeFRZMmhsYldFaU9uc2lhV1FpT2lKb2RIUndjem92TDJWNFlXMXdiR1V1YjNKbkwyVjRZVzF3YkdWekwyUmxaM0psWlM1cWMyOXVJaXdpZEhsd1pTSTZJa3B6YjI1VFkyaGxiV0VpZlN3aVkzSmxaR1Z1ZEdsaGJGTjFZbXBsWTNRaU9uc2lhV1FpT2lKa2FXUTZaWGhoYlhCc1pUb3hNak1pTENKa1pXZHlaV1VpT25zaWRIbHdaU0k2SWtKaFkyaGxiRzl5UkdWbmNtVmxJaXdpYm1GdFpTSTZJa0poWTJobGJHOXlJRzltSUZOamFXVnVZMlVnWVc1a0lFRnlkSE1pZlgxOS5kMms0TzNGeXRRSmY4M2tMaC1Ic1h1UHZoNnllT2xoSkVMVm81VEY3MWd1N2Vsc2xReU9mMlpJdEFYcnRiWEY0S3o5V2l2TmR6dE9heXo0VlVRME13YTh5Q0Raa1A5QjJwSC05U190Y0FGeGVvZUo2WjRYbkZ1TF9ET2ZrUjFmUCIsInR5cGUiOiJFbnZlbG9wZWRWZXJpZmlhYmxlQ3JlZGVudGlhbCJ9XX0</span>
+.<span class="jwt-signature">L0y-DE_Y9xfLsdvcCP4ZvB9I8hOaKkoR1T5C9eE2urMTpzadnC_5va7CsZM4MpQDzpc6aw6IZFROkRuIW9076w</span>
+</div>
+</div>
+    </div>
+</div></div></div></div>
+          <p>
+            See <a href="https://www.w3.org/TR/vc-data-model-2.0/#enveloped-verifiable-credentials">Verifiable Credentials Data Model v2.0</a> for more
+            details regarding this example.
+          </p>
+          <div class="example" id="example-a-simple-example-of-a-verifiable-presentation-secured-with-jose-with-the-envelopedverifiablepresentation-type">
+        <div class="marker">
+    <a class="self-link" href="#example-a-simple-example-of-a-verifiable-presentation-secured-with-jose-with-the-envelopedverifiablepresentation-type">Example<bdi> 3</bdi></a><span class="example-title">: A simple example of a verifiable presentation secured with JOSE with the EnvelopedVerifiablePresentation type</span>
+  </div> 
+      <div class="vc-tabbed"><input type="radio" id="vc-tab3unsigned" name="vc-tabs3" checked=""><input type="radio" id="vc-tab3jose" name="vc-tabs3"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab3unsigned"><abbr title="Unsecured presentation">Presentation</abbr></label></li><li class="vc-tab"><label for="vc-tab3jose"><abbr title="Secured with JOSE">jose</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 173px;"><pre class="nohighlight vc" data-vc-tabs="jose">{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "EnvelopedVerifiablePresentation",
+  "id": "data:application/vp+jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidHlwZSI6IlZlcmlmaWFibGVQcmVzZW50YXRpb24iLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6W3siQGNvbnRleHQiOiJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJpZCI6ImRhdGE6YXBwbGljYXRpb24vdmMrand0LGV5SnJhV1FpT2lKRmVFaHJRazFYT1dadFltdDJWakkyTm0xU2NIVlFNbk5WV1Y5T1gwVlhTVTR4YkdGd1ZYcFBPSEp2SWl3aVlXeG5Jam9pUlZNek9EUWlmUS5leUpBWTI5dWRHVjRkQ0k2V3lKb2RIUndjem92TDNkM2R5NTNNeTV2Y21jdmJuTXZZM0psWkdWdWRHbGhiSE12ZGpJaUxDSm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdlpYaGhiWEJzWlhNdmRqSWlYU3dpYVdRaU9pSm9kSFJ3T2k4dmRXNXBkbVZ5YzJsMGVTNWxlR0Z0Y0d4bEwyTnlaV1JsYm5ScFlXeHpMekU0TnpJaUxDSjBlWEJsSWpwYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdpUlhoaGJYQnNaVUZzZFcxdWFVTnlaV1JsYm5ScFlXd2lYU3dpYVhOemRXVnlJam9pYUhSMGNITTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2YVhOemRXVnljeTgxTmpVd05Ea2lMQ0oyWVd4cFpFWnliMjBpT2lJeU1ERXdMVEF4TFRBeFZERTVPakl6T2pJMFdpSXNJbU55WldSbGJuUnBZV3hUWTJobGJXRWlPbnNpYVdRaU9pSm9kSFJ3Y3pvdkwyVjRZVzF3YkdVdWIzSm5MMlY0WVcxd2JHVnpMMlJsWjNKbFpTNXFjMjl1SWl3aWRIbHdaU0k2SWtwemIyNVRZMmhsYldFaWZTd2lZM0psWkdWdWRHbGhiRk4xWW1wbFkzUWlPbnNpYVdRaU9pSmthV1E2WlhoaGJYQnNaVG94TWpNaUxDSmtaV2R5WldVaU9uc2lkSGx3WlNJNklrSmhZMmhsYkc5eVJHVm5jbVZsSWl3aWJtRnRaU0k2SWtKaFkyaGxiRzl5SUc5bUlGTmphV1Z1WTJVZ1lXNWtJRUZ5ZEhNaWZYMTkuZDJrNE8zRnl0UUpmODNrTGgtSHNYdVB2aDZ5ZU9saEpFTFZvNVRGNzFndTdlbHNsUXlPZjJaSXRBWHJ0YlhGNEt6OVdpdk5kenRPYXl6NFZVUTBNd2E4eUNEWmtQOUIycEgtOVNfdGNBRnhlb2VKNlo0WG5GdUxfRE9ma1IxZlA7ZGF0YTphcHBsaWNhdGlvbi92Yytqd3QsZXlKcmFXUWlPaUpGZUVoclFrMVhPV1p0WW10MlZqSTJObTFTY0hWUU1uTlZXVjlPWDBWWFNVNHhiR0Z3VlhwUE9ISnZJaXdpWVd4bklqb2lSVk16T0RRaWZRLmV5SkFZMjl1ZEdWNGRDSTZXeUpvZEhSd2N6b3ZMM2QzZHk1M015NXZjbWN2Ym5NdlkzSmxaR1Z1ZEdsaGJITXZkaklpTENKb2RIUndjem92TDNkM2R5NTNNeTV2Y21jdmJuTXZZM0psWkdWdWRHbGhiSE12WlhoaGJYQnNaWE12ZGpJaVhTd2lhV1FpT2lKb2RIUndPaTh2ZFc1cGRtVnljMmwwZVM1bGVHRnRjR3hsTDJOeVpXUmxiblJwWVd4ekx6RTROeklpTENKMGVYQmxJanBiSWxabGNtbG1hV0ZpYkdWRGNtVmtaVzUwYVdGc0lpd2lSWGhoYlhCc1pVRnNkVzF1YVVOeVpXUmxiblJwWVd3aVhTd2lhWE56ZFdWeUlqb2lhSFIwY0hNNkx5OTFibWwyWlhKemFYUjVMbVY0WVcxd2JHVXZhWE56ZFdWeWN5ODFOalV3TkRraUxDSjJZV3hwWkVaeWIyMGlPaUl5TURFd0xUQXhMVEF4VkRFNU9qSXpPakkwV2lJc0ltTnlaV1JsYm5ScFlXeFRZMmhsYldFaU9uc2lhV1FpT2lKb2RIUndjem92TDJWNFlXMXdiR1V1YjNKbkwyVjRZVzF3YkdWekwyUmxaM0psWlM1cWMyOXVJaXdpZEhsd1pTSTZJa3B6YjI1VFkyaGxiV0VpZlN3aVkzSmxaR1Z1ZEdsaGJGTjFZbXBsWTNRaU9uc2lhV1FpT2lKa2FXUTZaWGhoYlhCc1pUb3hNak1pTENKa1pXZHlaV1VpT25zaWRIbHdaU0k2SWtKaFkyaGxiRzl5UkdWbmNtVmxJaXdpYm1GdFpTSTZJa0poWTJobGJHOXlJRzltSUZOamFXVnVZMlVnWVc1a0lFRnlkSE1pZlgxOS5kMms0TzNGeXRRSmY4M2tMaC1Ic1h1UHZoNnllT2xoSkVMVm81VEY3MWd1N2Vsc2xReU9mMlpJdEFYcnRiWEY0S3o5V2l2TmR6dE9heXo0VlVRME13YTh5Q0Raa1A5QjJwSC05U190Y0FGeGVvZUo2WjRYbkZ1TF9ET2ZrUjFmUCIsInR5cGUiOiJFbnZlbG9wZWRWZXJpZmlhYmxlQ3JlZGVudGlhbCJ9XX0.DiZfXw5jTXeDBobq5ZdcL3S3o8mioZJlqo3iHDtLcEww5L_n2ZJfAJU-a-SmqvMYM--7w4CmeOfq890UGsg_aQ"
+}</pre></div><div class="vc-tab-content" style="min-height: 173px;">
+<div class="vc-jose-cose-jwt-tabbed">
+    <div class="vc-jose-cose-jwt-tab-content">
+<strong>Protected Headers</strong>
+<pre>{
+  "kid": "ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",
+  "alg": "ES256"
+}
+</pre>
+<strong>application/vp</strong>
+<pre>{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "EnvelopedVerifiablePresentation",
+  "id": "data:application/vp+jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidHlwZSI6IlZlcmlmaWFibGVQcmVzZW50YXRpb24iLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6W3siQGNvbnRleHQiOiJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJpZCI6ImRhdGE6YXBwbGljYXRpb24vdmMrand0LGV5SnJhV1FpT2lKRmVFaHJRazFYT1dadFltdDJWakkyTm0xU2NIVlFNbk5WV1Y5T1gwVlhTVTR4YkdGd1ZYcFBPSEp2SWl3aVlXeG5Jam9pUlZNek9EUWlmUS5leUpBWTI5dWRHVjRkQ0k2V3lKb2RIUndjem92TDNkM2R5NTNNeTV2Y21jdmJuTXZZM0psWkdWdWRHbGhiSE12ZGpJaUxDSm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdlpYaGhiWEJzWlhNdmRqSWlYU3dpYVdRaU9pSm9kSFJ3T2k4dmRXNXBkbVZ5YzJsMGVTNWxlR0Z0Y0d4bEwyTnlaV1JsYm5ScFlXeHpMekU0TnpJaUxDSjBlWEJsSWpwYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdpUlhoaGJYQnNaVUZzZFcxdWFVTnlaV1JsYm5ScFlXd2lYU3dpYVhOemRXVnlJam9pYUhSMGNITTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2YVhOemRXVnljeTgxTmpVd05Ea2lMQ0oyWVd4cFpFWnliMjBpT2lJeU1ERXdMVEF4TFRBeFZERTVPakl6T2pJMFdpSXNJbU55WldSbGJuUnBZV3hUWTJobGJXRWlPbnNpYVdRaU9pSm9kSFJ3Y3pvdkwyVjRZVzF3YkdVdWIzSm5MMlY0WVcxd2JHVnpMMlJsWjNKbFpTNXFjMjl1SWl3aWRIbHdaU0k2SWtwemIyNVRZMmhsYldFaWZTd2lZM0psWkdWdWRHbGhiRk4xWW1wbFkzUWlPbnNpYVdRaU9pSmthV1E2WlhoaGJYQnNaVG94TWpNaUxDSmtaV2R5WldVaU9uc2lkSGx3WlNJNklrSmhZMmhsYkc5eVJHVm5jbVZsSWl3aWJtRnRaU0k2SWtKaFkyaGxiRzl5SUc5bUlGTmphV1Z1WTJVZ1lXNWtJRUZ5ZEhNaWZYMTkuZDJrNE8zRnl0UUpmODNrTGgtSHNYdVB2aDZ5ZU9saEpFTFZvNVRGNzFndTdlbHNsUXlPZjJaSXRBWHJ0YlhGNEt6OVdpdk5kenRPYXl6NFZVUTBNd2E4eUNEWmtQOUIycEgtOVNfdGNBRnhlb2VKNlo0WG5GdUxfRE9ma1IxZlA7ZGF0YTphcHBsaWNhdGlvbi92Yytqd3QsZXlKcmFXUWlPaUpGZUVoclFrMVhPV1p0WW10MlZqSTJObTFTY0hWUU1uTlZXVjlPWDBWWFNVNHhiR0Z3VlhwUE9ISnZJaXdpWVd4bklqb2lSVk16T0RRaWZRLmV5SkFZMjl1ZEdWNGRDSTZXeUpvZEhSd2N6b3ZMM2QzZHk1M015NXZjbWN2Ym5NdlkzSmxaR1Z1ZEdsaGJITXZkaklpTENKb2RIUndjem92TDNkM2R5NTNNeTV2Y21jdmJuTXZZM0psWkdWdWRHbGhiSE12WlhoaGJYQnNaWE12ZGpJaVhTd2lhV1FpT2lKb2RIUndPaTh2ZFc1cGRtVnljMmwwZVM1bGVHRnRjR3hsTDJOeVpXUmxiblJwWVd4ekx6RTROeklpTENKMGVYQmxJanBiSWxabGNtbG1hV0ZpYkdWRGNtVmtaVzUwYVdGc0lpd2lSWGhoYlhCc1pVRnNkVzF1YVVOeVpXUmxiblJwWVd3aVhTd2lhWE56ZFdWeUlqb2lhSFIwY0hNNkx5OTFibWwyWlhKemFYUjVMbVY0WVcxd2JHVXZhWE56ZFdWeWN5ODFOalV3TkRraUxDSjJZV3hwWkVaeWIyMGlPaUl5TURFd0xUQXhMVEF4VkRFNU9qSXpPakkwV2lJc0ltTnlaV1JsYm5ScFlXeFRZMmhsYldFaU9uc2lhV1FpT2lKb2RIUndjem92TDJWNFlXMXdiR1V1YjNKbkwyVjRZVzF3YkdWekwyUmxaM0psWlM1cWMyOXVJaXdpZEhsd1pTSTZJa3B6YjI1VFkyaGxiV0VpZlN3aVkzSmxaR1Z1ZEdsaGJGTjFZbXBsWTNRaU9uc2lhV1FpT2lKa2FXUTZaWGhoYlhCc1pUb3hNak1pTENKa1pXZHlaV1VpT25zaWRIbHdaU0k2SWtKaFkyaGxiRzl5UkdWbmNtVmxJaXdpYm1GdFpTSTZJa0poWTJobGJHOXlJRzltSUZOamFXVnVZMlVnWVc1a0lFRnlkSE1pZlgxOS5kMms0TzNGeXRRSmY4M2tMaC1Ic1h1UHZoNnllT2xoSkVMVm81VEY3MWd1N2Vsc2xReU9mMlpJdEFYcnRiWEY0S3o5V2l2TmR6dE9heXo0VlVRME13YTh5Q0Raa1A5QjJwSC05U190Y0FGeGVvZUo2WjRYbkZ1TF9ET2ZrUjFmUCIsInR5cGUiOiJFbnZlbG9wZWRWZXJpZmlhYmxlQ3JlZGVudGlhbCJ9XX0.DiZfXw5jTXeDBobq5ZdcL3S3o8mioZJlqo3iHDtLcEww5L_n2ZJfAJU-a-SmqvMYM--7w4CmeOfq890UGsg_aQ"
+}
+</pre>
+<strong>application/vp+jwt</strong>
+<div class="jose-text">
+<div class="jwt-compact">
+<span class="jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
+.<span class="jwt-payload">eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidHlwZSI6IkVudmVsb3BlZFZlcmlmaWFibGVQcmVzZW50YXRpb24iLCJpZCI6ImRhdGE6YXBwbGljYXRpb24vdnArand0LGV5SnJhV1FpT2lKRmVFaHJRazFYT1dadFltdDJWakkyTm0xU2NIVlFNbk5WV1Y5T1gwVlhTVTR4YkdGd1ZYcFBPSEp2SWl3aVlXeG5Jam9pUlZNeU5UWWlmUS5leUpBWTI5dWRHVjRkQ0k2V3lKb2RIUndjem92TDNkM2R5NTNNeTV2Y21jdmJuTXZZM0psWkdWdWRHbGhiSE12ZGpJaUxDSm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdlpYaGhiWEJzWlhNdmRqSWlYU3dpZEhsd1pTSTZJbFpsY21sbWFXRmliR1ZRY21WelpXNTBZWFJwYjI0aUxDSjJaWEpwWm1saFlteGxRM0psWkdWdWRHbGhiQ0k2VzNzaVFHTnZiblJsZUhRaU9pSm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdmRqSWlMQ0pwWkNJNkltUmhkR0U2WVhCd2JHbGpZWFJwYjI0dmRtTXJhbmQwTEdWNVNuSmhWMUZwVDJsS1JtVkZhSEpSYXpGWVQxZGFkRmx0ZERKV2Fra3lUbTB4VTJOSVZsRk5iazVXVjFZNVQxZ3dWbGhUVlRSNFlrZEdkMVpZY0ZCUFNFcDJTV2wzYVZsWGVHNUphbTlwVWxaTmVrOUVVV2xtVVM1bGVVcEJXVEk1ZFdSSFZqUmtRMGsyVjNsS2IyUklVbmRqZW05MlRETmtNMlI1TlROTmVUVjJZMjFqZG1KdVRYWlpNMHBzV2tkV2RXUkhiR2hpU0UxMlpHcEphVXhEU205a1NGSjNZM3B2ZGt3elpETmtlVFV6VFhrMWRtTnRZM1ppYmsxMldUTktiRnBIVm5Wa1IyeG9Za2hOZGxwWWFHaGlXRUp6V2xoTmRtUnFTV2xZVTNkcFlWZFJhVTlwU205a1NGSjNUMms0ZG1SWE5YQmtiVlo1WXpKc01HVlROV3hsUjBaMFkwZDRiRXd5VG5sYVYxSnNZbTVTY0ZsWGVIcE1la1UwVG5wSmFVeERTakJsV0VKc1NXcHdZa2xzV214amJXeHRZVmRHYVdKSFZrUmpiVlpyV2xjMU1HRlhSbk5KYVhkcFVsaG9hR0pZUW5OYVZVWnpaRmN4ZFdGVlRubGFWMUpzWW01U2NGbFhkMmxZVTNkcFlWaE9lbVJYVm5sSmFtOXBZVWhTTUdOSVRUWk1lVGt4WW0xc01scFlTbnBoV0ZJMVRHMVdORmxYTVhkaVIxVjJZVmhPZW1SWFZubGplVGd4VG1wVmQwNUVhMmxNUTBveVdWZDRjRnBGV25saU1qQnBUMmxKZVUxRVJYZE1WRUY0VEZSQmVGWkVSVFZQYWtsNlQycEpNRmRwU1hOSmJVNTVXbGRTYkdKdVVuQlpWM2hVV1RKb2JHSlhSV2xQYm5OcFlWZFJhVTlwU205a1NGSjNZM3B2ZGt3eVZqUlpWekYzWWtkVmRXSXpTbTVNTWxZMFdWY3hkMkpIVm5wTU1sSnNXak5LYkZwVE5YRmpNamwxU1dsM2FXUkliSGRhVTBrMlNXdHdlbUl5TlZSWk1taHNZbGRGYVdaVGQybFpNMHBzV2tkV2RXUkhiR2hpUms0eFdXMXdiRmt6VVdsUGJuTnBZVmRSYVU5cFNtdGhWMUUyV2xob2FHSllRbk5hVkc5NFRXcE5hVXhEU210YVYyUjVXbGRWYVU5dWMybGtTR3gzV2xOSk5rbHJTbWhaTW1oc1lrYzVlVkpIVm01amJWWnNTV2wzYVdKdFJuUmFVMGsyU1d0S2FGa3lhR3hpUnpsNVNVYzViVWxHVG1waFYxWjFXVEpWWjFsWE5XdEpSVVo1WkVoTmFXWllNVGt1WkRKck5FOHpSbmwwVVVwbU9ETnJUR2d0U0hOWWRWQjJhRFo1WlU5c2FFcEZURlp2TlZSR056Rm5kVGRsYkhOc1VYbFBaakphU1hSQldISjBZbGhHTkV0Nk9WZHBkazVrZW5SUFlYbDZORlpWVVRCTmQyRTRlVU5FV210UU9VSXljRWd0T1ZOZmRHTkJSbmhsYjJWS05sbzBXRzVHZFV4ZlJFOW1hMUl4WmxBN1pHRjBZVHBoY0hCc2FXTmhkR2x2Ymk5Mll5dHFkM1FzWlhsS2NtRlhVV2xQYVVwR1pVVm9jbEZyTVZoUFYxcDBXVzEwTWxacVNUSk9iVEZUWTBoV1VVMXVUbFpYVmpsUFdEQldXRk5WTkhoaVIwWjNWbGh3VUU5SVNuWkphWGRwV1ZkNGJrbHFiMmxTVmsxNlQwUlJhV1pSTG1WNVNrRlpNamwxWkVkV05HUkRTVFpYZVVwdlpFaFNkMk42YjNaTU0yUXpaSGsxTTAxNU5YWmpiV04yWW01TmRsa3pTbXhhUjFaMVpFZHNhR0pJVFhaa2FrbHBURU5LYjJSSVVuZGplbTkyVEROa00yUjVOVE5OZVRWMlkyMWpkbUp1VFhaWk0wcHNXa2RXZFdSSGJHaGlTRTEyV2xob2FHSllRbk5hV0UxMlpHcEphVmhUZDJsaFYxRnBUMmxLYjJSSVVuZFBhVGgyWkZjMWNHUnRWbmxqTW13d1pWTTFiR1ZIUm5SalIzaHNUREpPZVZwWFVteGlibEp3V1ZkNGVreDZSVFJPZWtscFRFTktNR1ZZUW14SmFuQmlTV3hhYkdOdGJHMWhWMFpwWWtkV1JHTnRWbXRhVnpVd1lWZEdjMGxwZDJsU1dHaG9ZbGhDYzFwVlJuTmtWekYxWVZWT2VWcFhVbXhpYmxKd1dWZDNhVmhUZDJsaFdFNTZaRmRXZVVscWIybGhTRkl3WTBoTk5reDVPVEZpYld3eVdsaEtlbUZZVWpWTWJWWTBXVmN4ZDJKSFZYWmhXRTU2WkZkV2VXTjVPREZPYWxWM1RrUnJhVXhEU2pKWlYzaHdXa1ZhZVdJeU1HbFBhVWw1VFVSRmQweFVRWGhNVkVGNFZrUkZOVTlxU1hwUGFra3dWMmxKYzBsdFRubGFWMUpzWW01U2NGbFhlRlJaTW1oc1lsZEZhVTl1YzJsaFYxRnBUMmxLYjJSSVVuZGplbTkyVERKV05GbFhNWGRpUjFWMVlqTktia3d5VmpSWlZ6RjNZa2RXZWt3eVVteGFNMHBzV2xNMWNXTXlPWFZKYVhkcFpFaHNkMXBUU1RaSmEzQjZZakkxVkZreWFHeGlWMFZwWmxOM2FWa3pTbXhhUjFaMVpFZHNhR0pHVGpGWmJYQnNXVE5SYVU5dWMybGhWMUZwVDJsS2EyRlhVVFphV0dob1lsaENjMXBVYjNoTmFrMXBURU5LYTFwWFpIbGFWMVZwVDI1emFXUkliSGRhVTBrMlNXdEthRmt5YUd4aVJ6bDVVa2RXYm1OdFZteEphWGRwWW0xR2RGcFRTVFpKYTBwb1dUSm9iR0pIT1hsSlJ6bHRTVVpPYW1GWFZuVlpNbFZuV1ZjMWEwbEZSbmxrU0UxcFpsZ3hPUzVrTW1zMFR6TkdlWFJSU21ZNE0ydE1hQzFJYzFoMVVIWm9ObmxsVDJ4b1NrVk1WbTgxVkVZM01XZDFOMlZzYzJ4UmVVOW1NbHBKZEVGWWNuUmlXRVkwUzNvNVYybDJUbVI2ZEU5aGVYbzBWbFZSTUUxM1lUaDVRMFJhYTFBNVFqSndTQzA1VTE5MFkwRkdlR1Z2WlVvMldqUllia1oxVEY5RVQyWnJVakZtVUNJc0luUjVjR1VpT2lKRmJuWmxiRzl3WldSV1pYSnBabWxoWW14bFEzSmxaR1Z1ZEdsaGJDSjlYWDAuRGlaZlh3NWpUWGVEQm9icTVaZGNMM1MzbzhtaW9aSmxxbzNpSER0TGNFd3c1TF9uMlpKZkFKVS1hLVNtcXZNWU0tLTd3NENtZU9mcTg5MFVHc2dfYVEiLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6W119</span>
+.<span class="jwt-signature">EogM7TRguKB_cvYID8cuakO1nSnIf94Qon5nkaD8FiCHvz3GoemnUrg72GPJ7u81ptt1aR6izBKukEN-lvh2EQ</span>
+</div>
+</div>
+    </div>
+</div></div></div></div>
+          <p>
+            See <a href="https://www.w3.org/TR/vc-data-model-2.0/#enveloped-verifiable-presentations">Verifiable Credentials Data Model v2.0</a>
+            for more details regarding this example.
+          </p>
+          <p>
+            Implementations <em class="rfc2119">MUST</em> support the JWS compact serialization.
+            Use of the JWS JSON serialization is <em class="rfc2119">NOT RECOMMENDED</em>.
+          </p>
+        </section>
+        <section class="appendix informative" id="jose-header-parameters-and-jwt-claims"><div class="header-wrapper"><h4 id="jose-header-parameters-jwt-claims"><bdi class="secno">3.1.3 </bdi>JOSE Header Parameters and
+           JWT Claims</h4><a class="self-link" href="#jose-header-parameters-jwt-claims" aria-label="Permalink for Appendix 3.1.3"></a></div><p><em>This section is non-normative.</em></p>
+          
+          <p>
+            When present in the <a href="https://www.rfc-editor.org/rfc/rfc7515#section-4">JOSE Header</a>
+            or the
+            <a href="https://www.rfc-editor.org/rfc/rfc7519#section-4">JWT Claims Set</a>, members
+            registered in the IANA
+            <a href="https://www.iana.org/assignments/jwt/jwt.xhtml">JSON Web Token Claims</a>
+            registry or the IANA
+            <a href="https://www.iana.org/assignments/jose/jose.xhtml">JSON Web Signature and Encryption Header Parameters</a>
+            registry are to be interpreted as defined by the specifications
+            referenced in the registries.
+          </p>
+          <p>
+            The normative statements in
+            <a href="https://www.rfc-editor.org/rfc/rfc7515#section-4.1">Registered Header Parameter Names</a>,
+            <a href="https://www.rfc-editor.org/rfc/rfc7519#section-5">JOSE Header</a>, and
+            <a href="https://www.rfc-editor.org/rfc/rfc7519#section-5.3">Replicating Claims as Header Parameters</a>
+            apply to securing <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-credential">credentials</a> and <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-presentation">presentations</a>.
+          </p>
+          <p>
+            The unencoded JOSE Header is JSON (<code>application/json</code>), not JSON-LD
+            (<code>application/ld+json</code>).
+          </p>
+          <p>
+            It is <em class="rfc2119">RECOMMENDED</em> to use the IANA
+            <a href="https://www.iana.org/assignments/jwt/jwt.xhtml">JSON Web Token Claims</a>
+            registry and the IANA
+            <a href="https://www.iana.org/assignments/jose/jose.xhtml">JSON Web Signature and Encryption Header Parameters</a>
+            registry to identify any claims and header parameters that might be
+            confused with members defined by [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+            These include but are not limited to: <code>iss</code>,
+            <code>kid</code>, <code>alg</code>, <code>iat</code>,
+            <code>exp</code>, and <code>cnf</code>.
+          </p>
+          <p>
+            When the <code>iat</code> (Issued At) and/or
+            <code>exp</code> (Expiration Time) JWT claims are present, they
+            represent the issuance and expiration time of the signature,
+            respectively.
+            Note that these are different from the <code>validFrom</code> and
+            <code>validUntil</code> properties defined in
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#validity-period">Validity Period</a>,
+            which represent the validity of the data that is being secured.
+            Use of the <code>nbf</code> (Not Before) claim is <em class="rfc2119">NOT RECOMMENDED</em>,
+            as it makes little sense to attempt to assign a future date to
+            a signature.
+          </p>
+          <p>
+            The claims and security provided by this specification are
+            independent of the data secured and semantics provided by the
+            [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+            This means that while the security features
+            of this specification ensure data integrity and authenticity,
+            they do not dictate the interpretation of claim data.
+          </p>
+          <p>
+            Implementers <em class="rfc2119">SHOULD</em> avoid setting JWT claims to values that conflict
+            with the values of <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-6">verifiable credential</a> properties when a
+            claim and property pair refer to the same conceptual entity,
+            especially with pairs such as <code>iss</code> and <code>issuer</code>, <code>jti</code> and <code>id</code>,
+            and <code>sub</code> and <code>credentialSubject.id</code>.
+            For example, JWK claim <code>iss</code> <em class="rfc2119">SHOULD NOT</em> be set to a value which
+            conflicts with the value of <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-7">verifiable credential</a> property
+            <code>issuer</code>.
+          </p>
+          <p>
+            The JWT Claim Names <code>vc</code> and <code>vp</code> <em class="rfc2119">MUST NOT</em> be present.
+          </p>
+          <p>
+            Additional members may be present as header parameters and claims.
+            If they are not understood, they <em class="rfc2119">MUST</em> be ignored.
+          </p>
+        </section>
+      </section>
+      <section id="secure-with-sd-jwt"><div class="header-wrapper"><h3 id="with-sd-jwt"><bdi class="secno">3.2 </bdi>With SD-JWT</h3><a class="self-link" href="#with-sd-jwt" aria-label="Permalink for Section 3.2"></a></div>
+        
+        
+        <section id="securing-json-ld-verifiable-credentials-with-sd-jwt"><div class="header-wrapper"><h4 id="securing-with-sd-jwt"><bdi class="secno">3.2.1 </bdi>Securing JSON-LD Verifiable Credentials with SD-JWT</h4><a class="self-link" href="#securing-with-sd-jwt" aria-label="Permalink for Section 3.2.1"></a></div>
+          
+          <p>
+            This section details how to use JOSE to secure
+            <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-8">verifiable credentials</a> conforming to [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+          </p>
+          <p>
+            A <a data-link-type="dfn|abstract-op" href="#dfn-conforming-sd-jwt-issuer-implementation" class="internalDFN" id="ref-for-dfn-conforming-sd-jwt-issuer-implementation-1">conforming SD-JWT issuer implementation</a> <em class="rfc2119">MUST</em> use [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>]
+            to secure this media type.
+            The unsecured <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-9">verifiable credential</a> is the input JWT Claims Set.
+            The Issuer then converts the input JWT Claims Set (i.e., the
+            unsecured <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-10">verifiable credential</a>) into an [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>] payload
+            according to
+            <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt#section-6.1">SD-JWT issuance instructions</a>.
+          </p>
+          <p>
+            The <code>typ</code> header parameter <em class="rfc2119">SHOULD</em> be <code>vc+sd-jwt</code>.
+            When present, the <code>cty</code> header parameter <em class="rfc2119">SHOULD</em> be <code>vc</code>.
+            The <code>cty</code> header parameter value can be used to differentiate 
+            between secured content of different types when using <code>vc+sd-jwt</code>.
+            The <code>content type</code> header parameter is optional, and can be used
+            to express a more specific media type than <code>application/vc</code> when one is available.
+            See <a href="https://www.rfc-editor.org/rfc/rfc7515#section-4.1">Registered Header Parameter Names</a>
+            for additional details regarding usage of <code>typ</code> and <code>cty</code>.
+          </p>
+          <p>
+            A <a data-link-type="dfn|abstract-op" href="#dfn-conforming-sd-jwt-verifier-implementation" class="internalDFN" id="ref-for-dfn-conforming-sd-jwt-verifier-implementation-1">conforming SD-JWT verifier implementation</a> <em class="rfc2119">MUST</em> use [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>]
+            to verify <a data-link-type="dfn|abstract-op" href="#dfn-conforming-jws-document" class="internalDFN" id="ref-for-dfn-conforming-jws-document-5">conforming JWS documents</a> that use this media type.
+          </p>
+          <p>
+            When securing <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-11">verifiable credentials</a> with [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>],
+            implementers <em class="rfc2119">SHOULD</em> ensure that properties necessary for the
+            validation and verification of a credential are NOT selectively
+            disclosable (i.e., such properties <em class="rfc2119">SHOULD</em> be disclosed).
+            These properties can include but are not limited to
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#contexts"><code>@context</code></a>,
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#types"><code>type</code></a>,
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#status"><code>credentialStatus</code></a>,
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#data-schemas"><code>credentialSchema</code></a>,
+            and <a href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources"><code>relatedResource</code></a>.
+          </p>
+          <p>
+            To encrypt a secured <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-12">verifiable credential</a> when transmitting
+            over an insecure channel, implementers <em class="rfc2119">MAY</em> use
+            JSON Web Encryption (JWE) [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>] by nesting the secured
+            <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-13">verifiable credential</a> as the plaintext payload of a JWE,
+            per the instructions in Section 11.2 of [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>].
+          </p>
+          <div class="example" id="example-a-simple-example-of-a-verifiable-credential-secured-with-sd-jwt">
+        <div class="marker">
+    <a class="self-link" href="#example-a-simple-example-of-a-verifiable-credential-secured-with-sd-jwt">Example<bdi> 4</bdi></a><span class="example-title">: A simple example of a verifiable credential secured with SD-JWT</span>
+  </div> 
+      <div class="vc-tabbed"><input type="radio" id="vc-tab4unsigned" name="vc-tabs4" checked=""><input type="radio" id="vc-tab4sd-jwt" name="vc-tabs4"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab4unsigned"><abbr title="Unsecured credential">Credential</abbr></label></li><li class="vc-tab"><label for="vc-tab4sd-jwt"><abbr title="Secured with SD-JWT">sd-jwt</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 605px;"><pre class="nohighlight vc" data-vc-tabs="sd-jwt">{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "http://university.example/credentials/3732",
+  "type": ["VerifiableCredential", "ExampleDegreeCredential", "ExamplePersonCredential"],
+  "issuer": "https://university.example/issuers/14",
+  "validFrom": "2010-01-01T19:23:24Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "ExampleBachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    },
+    "alumniOf": {
+      "name": "Example University"
+    }
+  },
+  "credentialSchema": [{
+    "id": "https://example.org/examples/degree.json",
+    "type": "JsonSchema"
+  },
+  {
+    "id": "https://example.org/examples/alumni.json",
+    "type": "JsonSchema"
+  }]
+}</pre></div><div class="vc-tab-content" style="min-height: 605px;"><div>
+
+<div class="sd-jwt-tabbed">
+    <input type="radio" id="sd-jwt-4-e54y3ej-encoded" name="sd-jwt-4-e54y3ej-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="sd-jwt-4-e54y3ej-decoded" name="sd-jwt-4-e54y3ej-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-4-e54y3ej-disclosures" name="sd-jwt-4-e54y3ej-tabs" tabindex="0">
+    <ul class="sd-jwt-tabs">
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-4-e54y3ej-encoded">Encoded</label>
+      </li>
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-4-e54y3ej-decoded">Decoded</label>
+      </li>
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-4-e54y3ej-disclosures">Issuer Disclosures</label>
+      </li>
+    </ul>
+    <div class="sd-jwt-tab-content" id="sd-jwt-4-e54y3ej-content-encoded">
+      
+<div class="sd-jwt-compact">
+<span class="sd-jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
+.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1NjU5NzksImV4cCI6MTc0Njc3NTU3OSwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy8xNCIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiZGVncmVlIjp7Im5hbWUiOiJCYWNoZWxvciBvZiBTY2llbmNlIGFuZCBBcnRzIiwiX3NkIjpbIkpzWUlhQXBMejhaVDdwOFhFeXVJeG5sOXNYMHRCUktILWZKSnBYRWhtNEkiXX0sImFsdW1uaU9mIjp7Im5hbWUiOiJFeGFtcGxlIFVuaXZlcnNpdHkifSwiX3NkIjpbImFwMTM5MUJ3ZERnM2lLelJoQlFkUkFvS3ZHbWc0MkpndW00bThZQTRsLTAiXX0sImNyZWRlbnRpYWxTY2hlbWEiOlt7Il9zZCI6WyJJd2hPdGs1V2QzQ2M5cUVNbXBaOERPeEd6WlAzc0Q5b2ltQWpfUlc3eUNzIiwiS3N3R1pVRzRQOFllbTM4eV9ROUpwcUhrN0dUWmkzeDU2S3o1cV9CVnpLdyJdfSx7Il9zZCI6WyJQNWJnLVFqakhQcHo0N3lWd1VGNmhHSkJRQ0pBT291WmFuX1l5SnZTY0NRIiwic3R6bVEyQTJmaG9NVWdxakFXTlNBRk9ZbzYySFNvLXIwTktmNG1oVkxZQSJdfV0sIl9zZCI6WyJGUmNRRjlGaTBlSnMzaVdCdXlDb3dlUEpCdWxiYjhqNk50elpjSElROHpnIiwibEJJY3ZmTHRuSGdKcG83dlFfUVpTTDhGN1lkVWF1eUdRb1lYMHR1bkk0VSJdfQ</span>
+.<span class="sd-jwt-signature">BrAFD0LOzMo6Yq4_G99PT9MiscdbdxPBgSg72cGx5I4po-JAPfBg7Q5KNS-kb2D6YoWF_9nq7gKMHconTrPQPA</span>
+~<span class="sd-jwt-disclosure">WyJvRERrZnpFZWdFZzI0WktkeUdBSmJ3IiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMzczMiJd</span>~<span class="sd-jwt-disclosure">WyIwazkxbXpIV2tSNkM1TW0wNS1Id3pBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVEZWdyZWVDcmVkZW50aWFsIiwgIkV4YW1wbGVQZXJzb25DcmVkZW50aWFsIl1d</span>~<span class="sd-jwt-disclosure">WyJmbmNCcGdDMXBlQ2JjTDRDcVRWNzdnIiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd</span>~<span class="sd-jwt-disclosure">WyIxVlFBRklXQUNlb0RBblNNc1czU2x3IiwgInR5cGUiLCAiRXhhbXBsZUJhY2hlbG9yRGVncmVlIl0</span>~<span class="sd-jwt-disclosure">WyJ2T0R1VVQ5dm9jVU95Uk1XVkR2ME53IiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ</span>~<span class="sd-jwt-disclosure">WyJqUG5zbHBxaG1RV0tIbl9tMWNXb2xRIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span>~<span class="sd-jwt-disclosure">WyJtWE9pQkdsYlVyWVdkUzYtRXBVMzVRIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvYWx1bW5pLmpzb24iXQ</span>~<span class="sd-jwt-disclosure">WyJINjR4U0hRdFRNZXZZUENLOGJCajlnIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span>~
+</div>
+    </div>
+    <div class="sd-jwt-tab-content" id="sd-jwt-4-e54y3ej-content-decoded">
+      <pre class="header-value">{<br>&nbsp;&nbsp;"kid":&nbsp;"ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",<br>&nbsp;&nbsp;"alg":&nbsp;"ES256"<br>}</pre>
+      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745565979,<br>&nbsp;&nbsp;"exp":&nbsp;1746775579,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"issuer":&nbsp;"https://university.example/issuers/14",<br>&nbsp;&nbsp;"validFrom":&nbsp;"2010-01-01T19:23:24Z",<br>&nbsp;&nbsp;"credentialSubject":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"degree":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name":&nbsp;"Bachelor&nbsp;of&nbsp;Science&nbsp;and&nbsp;Arts",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"JsYIaApLz8ZT7p8XEyuIxnl9sX0tBRKH-fJJpXEhm4I"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;"alumniOf":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"name":&nbsp;"Example&nbsp;University"<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"ap1391BwdDg3iKzRhBQdRAoKvGmg42Jgum4m8YA4l-0"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"credentialSchema":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"IwhOtk5Wd3Cc9qEMmpZ8DOxGzZP3sD9oimAj_RW7yCs",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"KswGZUG4P8Yem38y_Q9JpqHk7GTZi3x56Kz5q_BVzKw"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"P5bg-QjjHPpz47yVwUF6hGJBQCJAOouZan_YyJvScCQ",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"stzmQ2A2fhoMUgqjAWNSAFOYo62HSo-r0NKf4mhVLYA"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"FRcQF9Fi0eJs3iWBuyCowePJBulbb8j6NtzZcHIQ8zg",<br>&nbsp;&nbsp;&nbsp;&nbsp;"lBIcvfLtnHgJpo7vQ_QZSL8F7YdUauyGQoYX0tunI4U"<br>&nbsp;&nbsp;]<br>}</pre>
+    </div>
+    <div class="sd-jwt-tab-content" id="sd-jwt-4-e54y3ej-content-disclosures">
+      <div class="disclosures">
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-lBIcvfLtnHgJpo7vQ_QZSL8F7YdUauyGQoYX0tunI4U">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">lBIcvfLtnHgJpo7vQ_QZSL8F7YdUauyGQoYX0tunI4U</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJvRERrZnpFZWdFZzI0WktkeUdBSmJ3IiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMzczMiJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"oDDkfzEegEg24ZKdyGAJbw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"http://university.example/credentials/3732"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-FRcQF9Fi0eJs3iWBuyCowePJBulbb8j6NtzZcHIQ8zg">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">FRcQF9Fi0eJs3iWBuyCowePJBulbb8j6NtzZcHIQ8zg</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyIwazkxbXpIV2tSNkM1TW0wNS1Id3pBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVEZWdyZWVDcmVkZW50aWFsIiwgIkV4YW1wbGVQZXJzb25DcmVkZW50aWFsIl1d</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"0k91mzHWkR6C5Mm05-HwzA",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"VerifiableCredential",<br>&nbsp;&nbsp;&nbsp;&nbsp;"ExampleDegreeCredential",<br>&nbsp;&nbsp;&nbsp;&nbsp;"ExamplePersonCredential"<br>&nbsp;&nbsp;]<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-ap1391BwdDg3iKzRhBQdRAoKvGmg42Jgum4m8YA4l-0">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">ap1391BwdDg3iKzRhBQdRAoKvGmg42Jgum4m8YA4l-0</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJmbmNCcGdDMXBlQ2JjTDRDcVRWNzdnIiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"fncBpgC1peCbcL4CqTV77g",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"did:example:ebfeb1f712ebc6f1c276e12ec21"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-JsYIaApLz8ZT7p8XEyuIxnl9sX0tBRKH-fJJpXEhm4I">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">JsYIaApLz8ZT7p8XEyuIxnl9sX0tBRKH-fJJpXEhm4I</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyIxVlFBRklXQUNlb0RBblNNc1czU2x3IiwgInR5cGUiLCAiRXhhbXBsZUJhY2hlbG9yRGVncmVlIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"1VQAFIWACeoDAnSMsW3Slw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"ExampleBachelorDegree"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-KswGZUG4P8Yem38y_Q9JpqHk7GTZi3x56Kz5q_BVzKw">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">KswGZUG4P8Yem38y_Q9JpqHk7GTZi3x56Kz5q_BVzKw</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ2T0R1VVQ5dm9jVU95Uk1XVkR2ME53IiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"vODuUT9vocUOyRMWVDv0Nw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://example.org/examples/degree.json"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-IwhOtk5Wd3Cc9qEMmpZ8DOxGzZP3sD9oimAj_RW7yCs">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">IwhOtk5Wd3Cc9qEMmpZ8DOxGzZP3sD9oimAj_RW7yCs</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJqUG5zbHBxaG1RV0tIbl9tMWNXb2xRIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"jPnslpqhmQWKHn_m1cWolQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"JsonSchema"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-stzmQ2A2fhoMUgqjAWNSAFOYo62HSo-r0NKf4mhVLYA">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">stzmQ2A2fhoMUgqjAWNSAFOYo62HSo-r0NKf4mhVLYA</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJtWE9pQkdsYlVyWVdkUzYtRXBVMzVRIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvYWx1bW5pLmpzb24iXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"mXOiBGlbUrYWdS6-EpU35Q",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://example.org/examples/alumni.json"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-P5bg-QjjHPpz47yVwUF6hGJBQCJAOouZan_YyJvScCQ">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">P5bg-QjjHPpz47yVwUF6hGJBQCJAOouZan_YyJvScCQ</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJINjR4U0hRdFRNZXZZUENLOGJCajlnIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"H64xSHQtTMevYPCK8bBj9g",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"JsonSchema"<br>]</span></p>
+</div>
+</div>
+    </div>
+</div>
+
+</div></div></div></div>
+          <p>
+            See <a href="https://www.w3.org/TR/vc-data-model-2.0/#example-using-the-credentialschema-property-to-perform-json-schema-validation">Verifiable Credentials Data Model v2.0</a>
+            for more details regarding this example.
+          </p>
+        </section>
+        <section id="securing-json-ld-verifiable-presentations-with-sd-jwt"><div class="header-wrapper"><h4 id="securing-vps-sd-jwt"><bdi class="secno">3.2.2 </bdi>Securing JSON-LD Verifiable Presentations with SD-JWT</h4><a class="self-link" href="#securing-vps-sd-jwt" aria-label="Permalink for Section 3.2.2"></a></div>
+          
+          <p>
+            This section details how to use [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>] to secure
+            <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentations</a> conforming to [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+          </p>
+          <p>
+            A <a data-link-type="dfn|abstract-op" href="#dfn-conforming-sd-jwt-issuer-implementation" class="internalDFN" id="ref-for-dfn-conforming-sd-jwt-issuer-implementation-2">conforming SD-JWT issuer implementation</a> <em class="rfc2119">MUST</em> use [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>] to secure this media type.
+            The unsecured <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentation</a> is the unencoded [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>] payload.
+          </p>
+          <p>
+            The <code>typ</code> header parameter <em class="rfc2119">SHOULD</em> be <code>vp+sd-jwt</code>.
+            When present, the <code>cty</code> header parameter <em class="rfc2119">SHOULD</em> be <code>vp</code>.
+            The <code>cty</code> header parameter value can be used to differentiate
+            between secured content of different types when using <code>vp+sd-jwt</code>.
+            The <code>content type</code> header parameter is optional, and can be used
+            to express a more specific media type than <code>application/vc</code> when one is available.
+            See <a href="https://www.rfc-editor.org/rfc/rfc7515#section-4.1">Registered Header Parameter Names</a>
+            for additional details regarding usage of <code>typ</code> and <code>cty</code>.
+          </p>
+          <p>
+            A <a data-link-type="dfn|abstract-op" href="#dfn-conforming-sd-jwt-verifier-implementation" class="internalDFN" id="ref-for-dfn-conforming-sd-jwt-verifier-implementation-2">conforming SD-JWT verifier implementation</a> <em class="rfc2119">MUST</em> use [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>]
+            to verify <a data-link-type="dfn|abstract-op" href="#dfn-conforming-jws-document" class="internalDFN" id="ref-for-dfn-conforming-jws-document-6">conforming JWS documents</a> that use this media type.
+          </p>
+          <p>
+            Verifiable Credentials secured in
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations">verifiable presentations</a>
+            <em class="rfc2119">MUST</em> use the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#defn-EnvelopedVerifiableCredential">Enveloped Verifiable Credential</a>
+            type defined by the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+          </p>
+          <p>
+            Verifiable Presentations in
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations">verifiable presentations</a>
+            <em class="rfc2119">MUST</em> use the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#defn-EnvelopedVerifiablePresentation">Enveloped Verifiable Presentation</a>
+            type defined by the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+          </p>
+          <p>
+            Credentials in <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentations</a> <em class="rfc2119">MUST</em> be secured.
+            These <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-credential">credentials</a> are secured using SD-JWT in this case.
+          </p><p>
+          </p><p>
+            When securing <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentations</a> with [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>]
+            implementers <em class="rfc2119">SHOULD</em> ensure that properties necessary for the
+            validation and verification of a credential are NOT selectively
+            disclosable (i.e., such properties <em class="rfc2119">SHOULD</em> be disclosed).
+            These properties can include but are not limited to
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#contexts"><code>@context</code></a>,
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#types"><code>type</code></a>,
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#status"><code>credentialStatus</code></a>,
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#data-schemas"><code>credentialSchema</code></a>,
+            and <a href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources"><code>relatedResource</code></a>.
+          </p>
+          <p>
+            To encrypt a secured <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentation</a> when transmitting
+            over an insecure channel, implementers <em class="rfc2119">MAY</em> use
+            JSON Web Encryption (JWE) [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7516" title="JSON Web Encryption (JWE)">RFC7516</a></cite>] by nesting the secured
+            <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentation</a> as the plaintext payload of a JWE,
+            per the instructions in Section 11.2 of [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>].
+          </p>
+          <div class="example" id="example-a-simple-example-of-a-verifiable-presentation-secured-with-sd-jwt-using-the-envelopedverifiablecredential-type">
+        <div class="marker">
+    <a class="self-link" href="#example-a-simple-example-of-a-verifiable-presentation-secured-with-sd-jwt-using-the-envelopedverifiablecredential-type">Example<bdi> 5</bdi></a><span class="example-title">: A simple example of a verifiable presentation secured with SD-JWT using the EnvelopedVerifiableCredential type</span>
+  </div> 
+      <div class="vc-tabbed"><input type="radio" id="vc-tab5unsigned" name="vc-tabs5" checked=""><input type="radio" id="vc-tab5sd-jwt" name="vc-tabs5"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab5unsigned"><abbr title="Unsecured presentation">Presentation</abbr></label></li><li class="vc-tab"><label for="vc-tab5sd-jwt"><abbr title="Secured with SD-JWT">sd-jwt</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 259px;"><pre class="nohighlight vc" data-vc-tabs="sd-jwt">{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "VerifiablePresentation",
+  "verifiableCredential": [{
+    "@context": "https://www.w3.org/ns/credentials/v2",
+    "type": "EnvelopedVerifiableCredential",
+    "id": "data:application/vc+sd-jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJfc2RfYWxnIjoic2hhLTI1NiIsIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiNjVFLVZZbmE3UE5mSGVsUDN6THFwcE5ERXhSLWhjWkhSTnlxN2U0ZVdabyIsIjhJbEwtUGx4Ukt3S0hLaTMtTXhXMjM4d0FkTmQ0NHdabC1iY3NBc2JIQjAiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJuYW1lIjoiQmFjaGVsb3Igb2YgU2NpZW5jZSBhbmQgQXJ0cyIsIl9zZCI6WyJMVXhqcWtsWS1hdDVSVmFoSXpxM3NJZ015dkdwVDlwdlUwdTRyU2ktMXl3Il19LCJfc2QiOlsiVmxZLW50ZklPOUI5RGRsUWp5U2REMldoVWI0bjc3Zl9HWDZ2U1dLQWpCNCJdfSwiX3NkIjpbIi1iREZ4Um94UUVlcEdjZFl6a250aTVGWXBsUTU5N0djaEdUTGVtLVJSY1UiLCJfREFVZ0xrTF9zVkVtLTBvcE8zaWhpeVFhS0ZzT08xUl9ONk1CUmprOWhFIl19.Kc083RKbBxc3Vr5qR3iEEPp3dKxTa6sPaWNsqtkIw8TvMRf9EZL2ajtgkWSBYzyzOzawOrCXryyp4rMTyI9vfA ~WyJiQ1RTaU9HNUo1VXhPY1QwUlNfd01nIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJTclNWMS01SjR6cWhOU3N3STIwaHdRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJKX294dDhtUGUtaDl4MkQzc29uT1N3IiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJDMlpWektmZ185RUh1ajB2S1ExdWJnIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJ6Szd5QlFPbFhfX2Q0X0VoYUc0Y0pRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyJ6b1pzRzMzeXBMeVRGMm9aS3ZmMVFnIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~"
+  }]
+}</pre></div><div class="vc-tab-content" style="min-height: 259px;"><div>
+
+<div class="sd-jwt-tabbed">
+    <input type="radio" id="sd-jwt-5-uxcfkkd-encoded" name="sd-jwt-5-uxcfkkd-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="sd-jwt-5-uxcfkkd-decoded" name="sd-jwt-5-uxcfkkd-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-5-uxcfkkd-disclosures" name="sd-jwt-5-uxcfkkd-tabs" tabindex="0">
+    <ul class="sd-jwt-tabs">
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-5-uxcfkkd-encoded">Encoded</label>
+      </li>
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-5-uxcfkkd-decoded">Decoded</label>
+      </li>
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-5-uxcfkkd-disclosures">Issuer Disclosures</label>
+      </li>
+    </ul>
+    <div class="sd-jwt-tab-content" id="sd-jwt-5-uxcfkkd-content-encoded">
+      
+<div class="sd-jwt-compact">
+<span class="sd-jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
+.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1NjU5NzksImV4cCI6MTc0Njc3NTU3OSwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjoiaHR0cHM6Ly93d3cudzMub3JnL25zL2NyZWRlbnRpYWxzL3YyIiwiX3NkIjpbIlJxNmlWM0RYSUl3R1JoMjBWbDBjX2IxbkUtR1J4aUlOWkxONHF2NzVodkkiLCJ3MzhfeVlfdUxRemY3WDNfMFM3c2VmZ1I5TjlnTnMzakQ3VTNrRXVTWC1vIl19XSwiX3NkIjpbInRBeC01N2wwNlUzZzhTdmNRWXRfMndyem4xOUJsMkk0Nm56NThib0NwT2MiXX0</span>
+.<span class="sd-jwt-signature">yqd93PdaHzsTVz-mQT17vnyay9AJoCMWMH4BsMwtLC1byvkrA2w_3CXz2bc0MJMEAgp63NHK07w495sZzAYtTg</span>
+~<span class="sd-jwt-disclosure">WyJRU0U0eVZzYk1kU3E1dE8yR0NiR3J3IiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span>~<span class="sd-jwt-disclosure">WyJ1bko3emplY3ByVG8wZHkyWTBGZkFRIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span>~<span class="sd-jwt-disclosure">WyJIaVJySEowSmNzWjlsQ2xGZk9LSUp3IiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleUpyYVdRaU9pSkZlRWhyUWsxWE9XWnRZbXQyVmpJMk5tMVNjSFZRTW5OVldWOU9YMFZYU1U0eGJHRndWWHBQT0hKdklpd2lZV3huSWpvaVJWTXlOVFlpZlEuZXlKZmMyUmZZV3huSWpvaWMyaGhMVEkxTmlJc0lrQmpiMjUwWlhoMElqcGJJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OTJNaUlzSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk5dWN5OWpjbVZrWlc1MGFXRnNjeTlsZUdGdGNHeGxjeTkyTWlKZExDSnBjM04xWlhJaU9pSm9kSFJ3Y3pvdkwzVnVhWFpsY25OcGRIa3VaWGhoYlhCc1pTOXBjM04xWlhKekx6VTJOVEEwT1NJc0luWmhiR2xrUm5KdmJTSTZJakl3TVRBdE1ERXRNREZVTVRrNk1qTTZNalJhSWl3aVkzSmxaR1Z1ZEdsaGJGTmphR1Z0WVNJNmV5SmZjMlFpT2xzaU5qVkZMVlpaYm1FM1VFNW1TR1ZzVURONlRIRndjRTVFUlhoU0xXaGpXa2hTVG5seE4yVTBaVmRhYnlJc0lqaEpiRXd0VUd4NFVrdDNTMGhMYVRNdFRYaFhNak00ZDBGa1RtUTBOSGRhYkMxaVkzTkJjMkpJUWpBaVhYMHNJbU55WldSbGJuUnBZV3hUZFdKcVpXTjBJanA3SW1SbFozSmxaU0k2ZXlKdVlXMWxJam9pUW1GamFHVnNiM0lnYjJZZ1UyTnBaVzVqWlNCaGJtUWdRWEowY3lJc0lsOXpaQ0k2V3lKTVZYaHFjV3RzV1MxaGREVlNWbUZvU1hweE0zTkpaMDE1ZGtkd1ZEbHdkbFV3ZFRSeVUya3RNWGwzSWwxOUxDSmZjMlFpT2xzaVZteFpMVzUwWmtsUE9VSTVSR1JzVVdwNVUyUkVNbGRvVldJMGJqYzNabDlIV0RaMlUxZExRV3BDTkNKZGZTd2lYM05rSWpwYklpMWlSRVo0VW05NFVVVmxjRWRqWkZsNmEyNTBhVFZHV1hCc1VUVTVOMGRqYUVkVVRHVnRMVkpTWTFVaUxDSmZSRUZWWjB4clRGOXpWa1Z0TFRCdmNFOHphV2hwZVZGaFMwWnpUMDh4VWw5T05rMUNVbXByT1doRklsMTkuS2MwODNSS2JCeGMzVnI1cVIzaUVFUHAzZEt4VGE2c1BhV05zcXRrSXc4VHZNUmY5RVpMMmFqdGdrV1NCWXp5ek96YXdPckNYcnl5cDRyTVR5STl2ZkEgfld5SmlRMVJUYVU5SE5VbzFWWGhQWTFRd1VsTmZkMDFuSWl3Z0ltbGtJaXdnSW1oMGRIQTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2WTNKbFpHVnVkR2xoYkhNdk1UZzNNaUpkfld5SlRjbE5XTVMwMVNqUjZjV2hPVTNOM1NUSXdhSGRSSWl3Z0luUjVjR1VpTENCYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdnSWtWNFlXMXdiR1ZCYkhWdGJtbERjbVZrWlc1MGFXRnNJbDFkfld5SktYMjk0ZERodFVHVXRhRGw0TWtRemMyOXVUMU4zSWl3Z0ltbGtJaXdnSW1oMGRIQnpPaTh2WlhoaGJYQnNaUzV2Y21jdlpYaGhiWEJzWlhNdlpHVm5jbVZsTG1wemIyNGlYUX5XeUpETWxwV2VrdG1aMTg1UlVoMWFqQjJTMUV4ZFdKbklpd2dJblI1Y0dVaUxDQWlTbk52YmxOamFHVnRZU0pkfld5SjZTemQ1UWxGUGJGaGZYMlEwWDBWb1lVYzBZMHBSSWl3Z0ltbGtJaXdnSW1ScFpEcGxlR0Z0Y0d4bE9qRXlNeUpkfld5SjZiMXB6UnpNemVYQk1lVlJHTW05YVMzWm1NVkZuSWl3Z0luUjVjR1VpTENBaVFtRmphR1ZzYjNKRVpXZHlaV1VpWFF-Il0</span>~
+</div>
+    </div>
+    <div class="sd-jwt-tab-content" id="sd-jwt-5-uxcfkkd-content-decoded">
+      <pre class="header-value">{<br>&nbsp;&nbsp;"kid":&nbsp;"ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",<br>&nbsp;&nbsp;"alg":&nbsp;"ES256"<br>}</pre>
+      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745565979,<br>&nbsp;&nbsp;"exp":&nbsp;1746775579,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"verifiableCredential":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"@context":&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Rq6iV3DXIIwGRh20Vl0c_b1nE-GRxiINZLN4qv75hvI",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"w38_yY_uLQzf7X3_0S7sefgR9N9gNs3jD7U3kEuSX-o"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"tAx-57l06U3g8SvcQYt_2wrzn19Bl2I46nz58boCpOc"<br>&nbsp;&nbsp;]<br>}</pre>
+    </div>
+    <div class="sd-jwt-tab-content" id="sd-jwt-5-uxcfkkd-content-disclosures">
+      <div class="disclosures">
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-tAx-57l06U3g8SvcQYt_2wrzn19Bl2I46nz58boCpOc">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">tAx-57l06U3g8SvcQYt_2wrzn19Bl2I46nz58boCpOc</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJRU0U0eVZzYk1kU3E1dE8yR0NiR3J3IiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"QSE4yVsbMdSq5tO2GCbGrw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"VerifiablePresentation"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-Rq6iV3DXIIwGRh20Vl0c_b1nE-GRxiINZLN4qv75hvI">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">Rq6iV3DXIIwGRh20Vl0c_b1nE-GRxiINZLN4qv75hvI</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ1bko3emplY3ByVG8wZHkyWTBGZkFRIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"unJ7zjecprTo0dy2Y0FfAQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiableCredential"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-w38_yY_uLQzf7X3_0S7sefgR9N9gNs3jD7U3kEuSX-o">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">w38_yY_uLQzf7X3_0S7sefgR9N9gNs3jD7U3kEuSX-o</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJIaVJySEowSmNzWjlsQ2xGZk9LSUp3IiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleUpyYVdRaU9pSkZlRWhyUWsxWE9XWnRZbXQyVmpJMk5tMVNjSFZRTW5OVldWOU9YMFZYU1U0eGJHRndWWHBQT0hKdklpd2lZV3huSWpvaVJWTXlOVFlpZlEuZXlKZmMyUmZZV3huSWpvaWMyaGhMVEkxTmlJc0lrQmpiMjUwWlhoMElqcGJJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OTJNaUlzSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk5dWN5OWpjbVZrWlc1MGFXRnNjeTlsZUdGdGNHeGxjeTkyTWlKZExDSnBjM04xWlhJaU9pSm9kSFJ3Y3pvdkwzVnVhWFpsY25OcGRIa3VaWGhoYlhCc1pTOXBjM04xWlhKekx6VTJOVEEwT1NJc0luWmhiR2xrUm5KdmJTSTZJakl3TVRBdE1ERXRNREZVTVRrNk1qTTZNalJhSWl3aVkzSmxaR1Z1ZEdsaGJGTmphR1Z0WVNJNmV5SmZjMlFpT2xzaU5qVkZMVlpaYm1FM1VFNW1TR1ZzVURONlRIRndjRTVFUlhoU0xXaGpXa2hTVG5seE4yVTBaVmRhYnlJc0lqaEpiRXd0VUd4NFVrdDNTMGhMYVRNdFRYaFhNak00ZDBGa1RtUTBOSGRhYkMxaVkzTkJjMkpJUWpBaVhYMHNJbU55WldSbGJuUnBZV3hUZFdKcVpXTjBJanA3SW1SbFozSmxaU0k2ZXlKdVlXMWxJam9pUW1GamFHVnNiM0lnYjJZZ1UyTnBaVzVqWlNCaGJtUWdRWEowY3lJc0lsOXpaQ0k2V3lKTVZYaHFjV3RzV1MxaGREVlNWbUZvU1hweE0zTkpaMDE1ZGtkd1ZEbHdkbFV3ZFRSeVUya3RNWGwzSWwxOUxDSmZjMlFpT2xzaVZteFpMVzUwWmtsUE9VSTVSR1JzVVdwNVUyUkVNbGRvVldJMGJqYzNabDlIV0RaMlUxZExRV3BDTkNKZGZTd2lYM05rSWpwYklpMWlSRVo0VW05NFVVVmxjRWRqWkZsNmEyNTBhVFZHV1hCc1VUVTVOMGRqYUVkVVRHVnRMVkpTWTFVaUxDSmZSRUZWWjB4clRGOXpWa1Z0TFRCdmNFOHphV2hwZVZGaFMwWnpUMDh4VWw5T05rMUNVbXByT1doRklsMTkuS2MwODNSS2JCeGMzVnI1cVIzaUVFUHAzZEt4VGE2c1BhV05zcXRrSXc4VHZNUmY5RVpMMmFqdGdrV1NCWXp5ek96YXdPckNYcnl5cDRyTVR5STl2ZkEgfld5SmlRMVJUYVU5SE5VbzFWWGhQWTFRd1VsTmZkMDFuSWl3Z0ltbGtJaXdnSW1oMGRIQTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2WTNKbFpHVnVkR2xoYkhNdk1UZzNNaUpkfld5SlRjbE5XTVMwMVNqUjZjV2hPVTNOM1NUSXdhSGRSSWl3Z0luUjVjR1VpTENCYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdnSWtWNFlXMXdiR1ZCYkhWdGJtbERjbVZrWlc1MGFXRnNJbDFkfld5SktYMjk0ZERodFVHVXRhRGw0TWtRemMyOXVUMU4zSWl3Z0ltbGtJaXdnSW1oMGRIQnpPaTh2WlhoaGJYQnNaUzV2Y21jdlpYaGhiWEJzWlhNdlpHVm5jbVZsTG1wemIyNGlYUX5XeUpETWxwV2VrdG1aMTg1UlVoMWFqQjJTMUV4ZFdKbklpd2dJblI1Y0dVaUxDQWlTbk52YmxOamFHVnRZU0pkfld5SjZTemQ1UWxGUGJGaGZYMlEwWDBWb1lVYzBZMHBSSWl3Z0ltbGtJaXdnSW1ScFpEcGxlR0Z0Y0d4bE9qRXlNeUpkfld5SjZiMXB6UnpNemVYQk1lVlJHTW05YVMzWm1NVkZuSWl3Z0luUjVjR1VpTENBaVFtRmphR1ZzYjNKRVpXZHlaV1VpWFF-Il0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"HiRrHJ0JcsZ9lClFfOKIJw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vc+sd-jwt,&nbsp;eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJfc2RfYWxnIjoic2hhLTI1NiIsIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiNjVFLVZZbmE3UE5mSGVsUDN6THFwcE5ERXhSLWhjWkhSTnlxN2U0ZVdabyIsIjhJbEwtUGx4Ukt3S0hLaTMtTXhXMjM4d0FkTmQ0NHdabC1iY3NBc2JIQjAiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJuYW1lIjoiQmFjaGVsb3Igb2YgU2NpZW5jZSBhbmQgQXJ0cyIsIl9zZCI6WyJMVXhqcWtsWS1hdDVSVmFoSXpxM3NJZ015dkdwVDlwdlUwdTRyU2ktMXl3Il19LCJfc2QiOlsiVmxZLW50ZklPOUI5RGRsUWp5U2REMldoVWI0bjc3Zl9HWDZ2U1dLQWpCNCJdfSwiX3NkIjpbIi1iREZ4Um94UUVlcEdjZFl6a250aTVGWXBsUTU5N0djaEdUTGVtLVJSY1UiLCJfREFVZ0xrTF9zVkVtLTBvcE8zaWhpeVFhS0ZzT08xUl9ONk1CUmprOWhFIl19.Kc083RKbBxc3Vr5qR3iEEPp3dKxTa6sPaWNsqtkIw8TvMRf9EZL2ajtgkWSBYzyzOzawOrCXryyp4rMTyI9vfA&nbsp;~WyJiQ1RTaU9HNUo1VXhPY1QwUlNfd01nIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJTclNWMS01SjR6cWhOU3N3STIwaHdRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJKX294dDhtUGUtaDl4MkQzc29uT1N3IiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJDMlpWektmZ185RUh1ajB2S1ExdWJnIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJ6Szd5QlFPbFhfX2Q0X0VoYUc0Y0pRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyJ6b1pzRzMzeXBMeVRGMm9aS3ZmMVFnIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~"<br>]</span></p>
+</div>
+</div>
+    </div>
+</div>
+
+</div></div></div></div>
+          <p>
+            See <a href="https://www.w3.org/TR/vc-data-model-2.0/#enveloped-verifiable-credentials">Verifiable Credentials Data Model v2.0</a>
+            for more details regarding this example.
+          </p>
+          <div class="example" id="example-a-simple-example-of-a-verifiable-presentation-secured-with-sd-jwt-using-the-envelopedverifiablepresentation-type">
+        <div class="marker">
+    <a class="self-link" href="#example-a-simple-example-of-a-verifiable-presentation-secured-with-sd-jwt-using-the-envelopedverifiablepresentation-type">Example<bdi> 6</bdi></a><span class="example-title">: A simple example of a verifiable presentation secured with SD-JWT using the EnvelopedVerifiablePresentation type</span>
+  </div> 
+      <div class="vc-tabbed"><input type="radio" id="vc-tab6unsigned" name="vc-tabs6" checked=""><input type="radio" id="vc-tab6sd-jwt" name="vc-tabs6"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab6unsigned"><abbr title="Unsecured presentation">Presentation</abbr></label></li><li class="vc-tab"><label for="vc-tab6sd-jwt"><abbr title="Secured with SD-JWT">sd-jwt</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 173px;"><pre class="nohighlight vc" data-vc-tabs="sd-jwt">{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "EnvelopedVerifiablePresentation",
+  "id": "data:application/vp+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlVRTV9fblE0UzZCTzhuUTRuT05YeHB4aHRob3lOeGI1M0xZZ1l6LTJBQnMiLCJ0eXAiOiJ2cCtsZCtqc29uK3NkLWp3dCIsImN0eSI6InZwK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiYWx1bW5pT2YiOnsibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSIsIl9zZCI6WyJoek9LRzU2cDI5c1ByTGFDNUE4RndFdUczVU05dUlZU1p1cU9YczJlVGJBIl19LCJfc2QiOlsiWVdXVmVDRndxQmk4WDBqSF9jV0NWWU16STNhOHBjTEVYRWZicFNSQVlndyJdfSwiX3NkIjpbIjJJZjhhaUs4REZwVWJ4dEc1cGMwel9SaFJzbm1ybGFRMEhzcTk4WFNyYWsiLCJUeDZ4ZWZMVUdUZUpfYWtVUFdGeHNvbUhobGtWVnpfNzVoaVZ6eWpyYmVzIl19XSwiX3NkIjpbIjd2anl0VVN3ZEJ0MXQ5RktlOVFfS3JIRXhFWGxrTEFaTzBKM0Jpd200dlkiXSwiX3NkX2FsZyI6InNoYS0yNTYiLCJpYXQiOjE3MDY1NjI4NDksImV4cCI6MTczODE4NTI0OSwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwiYWxnIjoiRVMzODQiLCJ4IjoidWtEd1U2ZzlQUVRFUWhYaEgyckRZNndMQlg3UHFlUjZBcGlhVHBEUXowcl8tdDl6UXNxem54Z0hEcE5oekZlQyIsInkiOiJMQnhVYnBVdFNGMVVKVTVpYnJIdkpINjBUSG5YMk1xa0xHZGltU1l0UGR4RlkxOEdhcldiS3FZV0djUkZHVE9BIn19fQ.kYD63YtBNYnLUTw6Szf1vs_Ug3UBXhPwCyqpNmPnPDa3rXZQhQLdB1BgaoO8zgQ-c3B41fxaXMnLHYV9-B20uboSpJP0B-2Vre917eQt1cSDswDGA_Ytvn4BSqYVBB2J~WyJFMkFsRzhsY2p0QVFrcllIbjlIbnVRIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd~WyI5NldYMDRneno4cVZzOVZLU2wwYTVnIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJaekU2VFVaamtHMW1DWXBKMEhnc0l3IiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyItQ3NsS25GZGFYb2JiQWsyU0JBVGR3IiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd~WyJuRm1OWl9IczB3WWNoOFdkeTdnQUNRIiwgImlkIiwgImRpZDpleGFtcGxlOmMyNzZlMTJlYzIxZWJmZWIxZjcxMmViYzZmMSJd~"
+}</pre></div><div class="vc-tab-content" style="min-height: 173px;"><div>
+
+<div class="sd-jwt-tabbed">
+    <input type="radio" id="sd-jwt-6-kh1fl6x-encoded" name="sd-jwt-6-kh1fl6x-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="sd-jwt-6-kh1fl6x-decoded" name="sd-jwt-6-kh1fl6x-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-6-kh1fl6x-disclosures" name="sd-jwt-6-kh1fl6x-tabs" tabindex="0">
+    <ul class="sd-jwt-tabs">
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-6-kh1fl6x-encoded">Encoded</label>
+      </li>
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-6-kh1fl6x-decoded">Decoded</label>
+      </li>
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-6-kh1fl6x-disclosures">Issuer Disclosures</label>
+      </li>
+    </ul>
+    <div class="sd-jwt-tab-content" id="sd-jwt-6-kh1fl6x-content-encoded">
+      
+<div class="sd-jwt-compact">
+<span class="sd-jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
+.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1NjU5NzksImV4cCI6MTc0Njc3NTU3OSwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiX3NkIjpbIlpTOTNQQ0xvWkpmQm1YanM4cjVLeXlULU14MVpKb2YwYnViZW9GZmFFalkiLCJ2c3VPYy13Y3JpZWhSVnNXVk55NWhrbHBweTQ2SmdDc05LUzNyN3A5eWhRIl19</span>
+.<span class="sd-jwt-signature">RYVsmuhUJJYVTLrVZUUBjU2gfBk_rG1k-w7yVWWKXcvi4Px4OxqMepgWuAiGu9H0upLFqP1gHCn-2BBgyGlwxw</span>
+~<span class="sd-jwt-disclosure">WyJGUXI4Qm9IT00xbF84QVV3YkkyYlBRIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span>~<span class="sd-jwt-disclosure">WyJTa0ViejVQRjNxTDU1Vy1sZWhISFhRIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdnArc2Qtand0LCBleUpoYkdjaU9pSkZVek00TkNJc0ltdHBaQ0k2SWxWUlRWOWZibEUwVXpaQ1R6aHVVVFJ1VDA1WWVIQjRhSFJvYjNsT2VHSTFNMHhaWjFsNkxUSkJRbk1pTENKMGVYQWlPaUoyY0N0c1pDdHFjMjl1SzNOa0xXcDNkQ0lzSW1OMGVTSTZJblp3SzJ4a0sycHpiMjRpZlEuZXlKQVkyOXVkR1Y0ZENJNld5Sm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdmRqSWlMQ0pvZEhSd2N6b3ZMM2QzZHk1M015NXZjbWN2Ym5NdlkzSmxaR1Z1ZEdsaGJITXZaWGhoYlhCc1pYTXZkaklpWFN3aWRtVnlhV1pwWVdKc1pVTnlaV1JsYm5ScFlXd2lPbHQ3SWtCamIyNTBaWGgwSWpwYkltaDBkSEJ6T2k4dmQzZDNMbmN6TG05eVp5OXVjeTlqY21Wa1pXNTBhV0ZzY3k5Mk1pSXNJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OWxlR0Z0Y0d4bGN5OTJNaUpkTENKcGMzTjFaWElpT2lKb2RIUndjem92TDNWdWFYWmxjbk5wZEhrdVpYaGhiWEJzWlM5cGMzTjFaWEp6THpVMk5UQTBPU0lzSW5aaGJHbGtSbkp2YlNJNklqSXdNVEF0TURFdE1ERlVNVGs2TWpNNk1qUmFJaXdpWTNKbFpHVnVkR2xoYkZOMVltcGxZM1FpT25zaVlXeDFiVzVwVDJZaU9uc2libUZ0WlNJNklrVjRZVzF3YkdVZ1ZXNXBkbVZ5YzJsMGVTSXNJbDl6WkNJNld5Sm9lazlMUnpVMmNESTVjMUJ5VEdGRE5VRTRSbmRGZFVjelZVMDVkVWxaVTFwMWNVOVljekpsVkdKQklsMTlMQ0pmYzJRaU9sc2lXVmRYVm1WRFJuZHhRbWs0V0RCcVNGOWpWME5XV1UxNlNUTmhPSEJqVEVWWVJXWmljRk5TUVZsbmR5SmRmU3dpWDNOa0lqcGJJakpKWmpoaGFVczRSRVp3VldKNGRFYzFjR013ZWw5U2FGSnpibTF5YkdGUk1FaHpjVGs0V0ZOeVlXc2lMQ0pVZURaNFpXWk1WVWRVWlVwZllXdFZVRmRHZUhOdmJVaG9iR3RXVm5wZk56Vm9hVlo2ZVdweVltVnpJbDE5WFN3aVgzTmtJanBiSWpkMmFubDBWVk4zWkVKME1YUTVSa3RsT1ZGZlMzSklSWGhGV0d4clRFRmFUekJLTTBKcGQyMDBkbGtpWFN3aVgzTmtYMkZzWnlJNkluTm9ZUzB5TlRZaUxDSnBZWFFpT2pFM01EWTFOakk0TkRrc0ltVjRjQ0k2TVRjek9ERTROVEkwT1N3aVkyNW1JanA3SW1wM2F5STZleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TXpnMElpd2lZV3huSWpvaVJWTXpPRFFpTENKNElqb2lkV3RFZDFVMlp6bFFVVlJGVVdoWWFFZ3lja1JaTm5kTVFsZzNVSEZsVWpaQmNHbGhWSEJFVVhvd2NsOHRkRGw2VVhOeGVtNTRaMGhFY0U1b2VrWmxReUlzSW5raU9pSk1RbmhWWW5CVmRGTkdNVlZLVlRWcFluSklka3BJTmpCVVNHNVlNazF4YTB4SFpHbHRVMWwwVUdSNFJsa3hPRWRoY2xkaVMzRlpWMGRqVWtaSFZFOUJJbjE5ZlEua1lENjNZdEJOWW5MVVR3NlN6ZjF2c19VZzNVQlhoUHdDeXFwTm1QblBEYTNyWFpRaFFMZEIxQmdhb084emdRLWMzQjQxZnhhWE1uTEhZVjktQjIwdWJvU3BKUDBCLTJWcmU5MTdlUXQxY1NEc3dER0FfWXR2bjRCU3FZVkJCMkp-V3lKRk1rRnNSemhzWTJwMFFWRnJjbGxJYmpsSWJuVlJJaXdnSW5SNWNHVWlMQ0FpVm1WeWFXWnBZV0pzWlZCeVpYTmxiblJoZEdsdmJpSmR-V3lJNU5sZFlNRFJuZW5vNGNWWnpPVlpMVTJ3d1lUVm5JaXdnSW1sa0lpd2dJbWgwZEhBNkx5OTFibWwyWlhKemFYUjVMbVY0WVcxd2JHVXZZM0psWkdWdWRHbGhiSE12TVRnM01pSmR-V3lKYWVrVTJWRlZhYW10SE1XMURXWEJLTUVobmMwbDNJaXdnSW5SNWNHVWlMQ0JiSWxabGNtbG1hV0ZpYkdWRGNtVmtaVzUwYVdGc0lpd2dJa1Y0WVcxd2JHVkJiSFZ0Ym1sRGNtVmtaVzUwYVdGc0lsMWR-V3lJdFEzTnNTMjVHWkdGWWIySmlRV3N5VTBKQlZHUjNJaXdnSW1sa0lpd2dJbVJwWkRwbGVHRnRjR3hsT21WaVptVmlNV1kzTVRKbFltTTJaakZqTWpjMlpURXlaV015TVNKZH5XeUp1Um0xT1dsOUljekIzV1dOb09GZGtlVGRuUVVOUklpd2dJbWxrSWl3Z0ltUnBaRHBsZUdGdGNHeGxPbU15TnpabE1USmxZekl4WldKbVpXSXhaamN4TW1WaVl6Wm1NU0pkfiJd</span>~
+</div>
+    </div>
+    <div class="sd-jwt-tab-content" id="sd-jwt-6-kh1fl6x-content-decoded">
+      <pre class="header-value">{<br>&nbsp;&nbsp;"kid":&nbsp;"ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",<br>&nbsp;&nbsp;"alg":&nbsp;"ES256"<br>}</pre>
+      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745565979,<br>&nbsp;&nbsp;"exp":&nbsp;1746775579,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"ZS93PCLoZJfBmXjs8r5KyyT-Mx1ZJof0bubeoFfaEjY",<br>&nbsp;&nbsp;&nbsp;&nbsp;"vsuOc-wcriehRVsWVNy5hklppy46JgCsNKS3r7p9yhQ"<br>&nbsp;&nbsp;]<br>}</pre>
+    </div>
+    <div class="sd-jwt-tab-content" id="sd-jwt-6-kh1fl6x-content-disclosures">
+      <div class="disclosures">
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-vsuOc-wcriehRVsWVNy5hklppy46JgCsNKS3r7p9yhQ">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">vsuOc-wcriehRVsWVNy5hklppy46JgCsNKS3r7p9yhQ</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJGUXI4Qm9IT00xbF84QVV3YkkyYlBRIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"FQr8BoHOM1l_8AUwbI2bPQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiablePresentation"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-ZS93PCLoZJfBmXjs8r5KyyT-Mx1ZJof0bubeoFfaEjY">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">ZS93PCLoZJfBmXjs8r5KyyT-Mx1ZJof0bubeoFfaEjY</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJTa0ViejVQRjNxTDU1Vy1sZWhISFhRIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdnArc2Qtand0LCBleUpoYkdjaU9pSkZVek00TkNJc0ltdHBaQ0k2SWxWUlRWOWZibEUwVXpaQ1R6aHVVVFJ1VDA1WWVIQjRhSFJvYjNsT2VHSTFNMHhaWjFsNkxUSkJRbk1pTENKMGVYQWlPaUoyY0N0c1pDdHFjMjl1SzNOa0xXcDNkQ0lzSW1OMGVTSTZJblp3SzJ4a0sycHpiMjRpZlEuZXlKQVkyOXVkR1Y0ZENJNld5Sm9kSFJ3Y3pvdkwzZDNkeTUzTXk1dmNtY3Zibk12WTNKbFpHVnVkR2xoYkhNdmRqSWlMQ0pvZEhSd2N6b3ZMM2QzZHk1M015NXZjbWN2Ym5NdlkzSmxaR1Z1ZEdsaGJITXZaWGhoYlhCc1pYTXZkaklpWFN3aWRtVnlhV1pwWVdKc1pVTnlaV1JsYm5ScFlXd2lPbHQ3SWtCamIyNTBaWGgwSWpwYkltaDBkSEJ6T2k4dmQzZDNMbmN6TG05eVp5OXVjeTlqY21Wa1pXNTBhV0ZzY3k5Mk1pSXNJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OWxlR0Z0Y0d4bGN5OTJNaUpkTENKcGMzTjFaWElpT2lKb2RIUndjem92TDNWdWFYWmxjbk5wZEhrdVpYaGhiWEJzWlM5cGMzTjFaWEp6THpVMk5UQTBPU0lzSW5aaGJHbGtSbkp2YlNJNklqSXdNVEF0TURFdE1ERlVNVGs2TWpNNk1qUmFJaXdpWTNKbFpHVnVkR2xoYkZOMVltcGxZM1FpT25zaVlXeDFiVzVwVDJZaU9uc2libUZ0WlNJNklrVjRZVzF3YkdVZ1ZXNXBkbVZ5YzJsMGVTSXNJbDl6WkNJNld5Sm9lazlMUnpVMmNESTVjMUJ5VEdGRE5VRTRSbmRGZFVjelZVMDVkVWxaVTFwMWNVOVljekpsVkdKQklsMTlMQ0pmYzJRaU9sc2lXVmRYVm1WRFJuZHhRbWs0V0RCcVNGOWpWME5XV1UxNlNUTmhPSEJqVEVWWVJXWmljRk5TUVZsbmR5SmRmU3dpWDNOa0lqcGJJakpKWmpoaGFVczRSRVp3VldKNGRFYzFjR013ZWw5U2FGSnpibTF5YkdGUk1FaHpjVGs0V0ZOeVlXc2lMQ0pVZURaNFpXWk1WVWRVWlVwZllXdFZVRmRHZUhOdmJVaG9iR3RXVm5wZk56Vm9hVlo2ZVdweVltVnpJbDE5WFN3aVgzTmtJanBiSWpkMmFubDBWVk4zWkVKME1YUTVSa3RsT1ZGZlMzSklSWGhGV0d4clRFRmFUekJLTTBKcGQyMDBkbGtpWFN3aVgzTmtYMkZzWnlJNkluTm9ZUzB5TlRZaUxDSnBZWFFpT2pFM01EWTFOakk0TkRrc0ltVjRjQ0k2TVRjek9ERTROVEkwT1N3aVkyNW1JanA3SW1wM2F5STZleUpyZEhraU9pSkZReUlzSW1OeWRpSTZJbEF0TXpnMElpd2lZV3huSWpvaVJWTXpPRFFpTENKNElqb2lkV3RFZDFVMlp6bFFVVlJGVVdoWWFFZ3lja1JaTm5kTVFsZzNVSEZsVWpaQmNHbGhWSEJFVVhvd2NsOHRkRGw2VVhOeGVtNTRaMGhFY0U1b2VrWmxReUlzSW5raU9pSk1RbmhWWW5CVmRGTkdNVlZLVlRWcFluSklka3BJTmpCVVNHNVlNazF4YTB4SFpHbHRVMWwwVUdSNFJsa3hPRWRoY2xkaVMzRlpWMGRqVWtaSFZFOUJJbjE5ZlEua1lENjNZdEJOWW5MVVR3NlN6ZjF2c19VZzNVQlhoUHdDeXFwTm1QblBEYTNyWFpRaFFMZEIxQmdhb084emdRLWMzQjQxZnhhWE1uTEhZVjktQjIwdWJvU3BKUDBCLTJWcmU5MTdlUXQxY1NEc3dER0FfWXR2bjRCU3FZVkJCMkp-V3lKRk1rRnNSemhzWTJwMFFWRnJjbGxJYmpsSWJuVlJJaXdnSW5SNWNHVWlMQ0FpVm1WeWFXWnBZV0pzWlZCeVpYTmxiblJoZEdsdmJpSmR-V3lJNU5sZFlNRFJuZW5vNGNWWnpPVlpMVTJ3d1lUVm5JaXdnSW1sa0lpd2dJbWgwZEhBNkx5OTFibWwyWlhKemFYUjVMbVY0WVcxd2JHVXZZM0psWkdWdWRHbGhiSE12TVRnM01pSmR-V3lKYWVrVTJWRlZhYW10SE1XMURXWEJLTUVobmMwbDNJaXdnSW5SNWNHVWlMQ0JiSWxabGNtbG1hV0ZpYkdWRGNtVmtaVzUwYVdGc0lpd2dJa1Y0WVcxd2JHVkJiSFZ0Ym1sRGNtVmtaVzUwYVdGc0lsMWR-V3lJdFEzTnNTMjVHWkdGWWIySmlRV3N5VTBKQlZHUjNJaXdnSW1sa0lpd2dJbVJwWkRwbGVHRnRjR3hsT21WaVptVmlNV1kzTVRKbFltTTJaakZqTWpjMlpURXlaV015TVNKZH5XeUp1Um0xT1dsOUljekIzV1dOb09GZGtlVGRuUVVOUklpd2dJbWxrSWl3Z0ltUnBaRHBsZUdGdGNHeGxPbU15TnpabE1USmxZekl4WldKbVpXSXhaamN4TW1WaVl6Wm1NU0pkfiJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"SkEbz5PF3qL55W-lehHHXQ",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vp+sd-jwt,&nbsp;eyJhbGciOiJFUzM4NCIsImtpZCI6IlVRTV9fblE0UzZCTzhuUTRuT05YeHB4aHRob3lOeGI1M0xZZ1l6LTJBQnMiLCJ0eXAiOiJ2cCtsZCtqc29uK3NkLWp3dCIsImN0eSI6InZwK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiYWx1bW5pT2YiOnsibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSIsIl9zZCI6WyJoek9LRzU2cDI5c1ByTGFDNUE4RndFdUczVU05dUlZU1p1cU9YczJlVGJBIl19LCJfc2QiOlsiWVdXVmVDRndxQmk4WDBqSF9jV0NWWU16STNhOHBjTEVYRWZicFNSQVlndyJdfSwiX3NkIjpbIjJJZjhhaUs4REZwVWJ4dEc1cGMwel9SaFJzbm1ybGFRMEhzcTk4WFNyYWsiLCJUeDZ4ZWZMVUdUZUpfYWtVUFdGeHNvbUhobGtWVnpfNzVoaVZ6eWpyYmVzIl19XSwiX3NkIjpbIjd2anl0VVN3ZEJ0MXQ5RktlOVFfS3JIRXhFWGxrTEFaTzBKM0Jpd200dlkiXSwiX3NkX2FsZyI6InNoYS0yNTYiLCJpYXQiOjE3MDY1NjI4NDksImV4cCI6MTczODE4NTI0OSwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwiYWxnIjoiRVMzODQiLCJ4IjoidWtEd1U2ZzlQUVRFUWhYaEgyckRZNndMQlg3UHFlUjZBcGlhVHBEUXowcl8tdDl6UXNxem54Z0hEcE5oekZlQyIsInkiOiJMQnhVYnBVdFNGMVVKVTVpYnJIdkpINjBUSG5YMk1xa0xHZGltU1l0UGR4RlkxOEdhcldiS3FZV0djUkZHVE9BIn19fQ.kYD63YtBNYnLUTw6Szf1vs_Ug3UBXhPwCyqpNmPnPDa3rXZQhQLdB1BgaoO8zgQ-c3B41fxaXMnLHYV9-B20uboSpJP0B-2Vre917eQt1cSDswDGA_Ytvn4BSqYVBB2J~WyJFMkFsRzhsY2p0QVFrcllIbjlIbnVRIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd~WyI5NldYMDRneno4cVZzOVZLU2wwYTVnIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJaekU2VFVaamtHMW1DWXBKMEhnc0l3IiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyItQ3NsS25GZGFYb2JiQWsyU0JBVGR3IiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd~WyJuRm1OWl9IczB3WWNoOFdkeTdnQUNRIiwgImlkIiwgImRpZDpleGFtcGxlOmMyNzZlMTJlYzIxZWJmZWIxZjcxMmViYzZmMSJd~"<br>]</span></p>
+</div>
+</div>
+    </div>
+</div>
+
+</div></div></div></div>
+          <p>
+            See <a href="https://www.w3.org/TR/vc-data-model-2.0/#enveloped-verifiable-presentations">Verifiable Credentials Data Model v2.0</a>
+            for more details regarding this example.
+          </p>
+          <p>
+            Implementations <em class="rfc2119">MUST</em> support the compact serialization
+            (<code>application/sd-jwt</code>) and <em class="rfc2119">MAY</em> support the JSON
+            serialization (<code>application/sd-jwt+json</code>).
+            If the JSON serialization is used, it is <em class="rfc2119">RECOMMENDED</em> that a profile
+            be defined to ensure any additional JSON members are understood consistently.
+          </p>
+        </section>
+      </section>
+      <section id="secure-with-cose"><div class="header-wrapper"><h3 id="securing-with-cose"><bdi class="secno">3.3 </bdi>With COSE</h3><a class="self-link" href="#securing-with-cose" aria-label="Permalink for Section 3.3"></a></div>
+        
+        <p>
+          COSE [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>] is a common approach to encoding and securing
+          information using CBOR [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8949" title="Concise Binary Object Representation (CBOR)">RFC8949</a></cite>].
+          Verifiable credentials <em class="rfc2119">MAY</em> be secured using COSE [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>] and
+          <em class="rfc2119">SHOULD</em> be identified through use of content types as outlined in this section.
+        </p>
+        <section id="securing-json-ld-verifiable-credentials-with-cose"><div class="header-wrapper"><h4 id="securing-vcs-with-cose"><bdi class="secno">3.3.1 </bdi>Securing JSON-LD
+          Verifiable Credentials with COSE</h4><a class="self-link" href="#securing-vcs-with-cose" aria-label="Permalink for Section 3.3.1"></a></div>
+          
+          <p>
+            This section details how to use COSE to secure
+            <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-14">verifiable credentials</a> conforming to [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+          </p>
+          <p>
+            A <a data-link-type="dfn|abstract-op" href="#dfn-conforming-cose-issuer-implementation" class="internalDFN" id="ref-for-dfn-conforming-cose-issuer-implementation-1">conforming COSE issuer implementation</a> <em class="rfc2119">MUST</em> use COSE_Sign1 as
+            specified in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>] to secure this media type.
+            The unsecured <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-15">verifiable credential</a> is the unencoded COSE_Sign1 payload.
+          </p>
+          <p>
+            The <code>typ (16)</code> header parameter, as described in
+            <a href="https://www.rfc-editor.org/rfc/rfc9596#section-2">COSE "typ" (type) Header Parameter</a>,
+            <em class="rfc2119">SHOULD</em> be <code>application/vc+cose</code>.
+            The <code>content type (3)</code> header parameter <em class="rfc2119">SHOULD</em> be <code>application/vc</code>.
+            The <code>content type (3)</code> header parameter is optional, and can be used
+            to express a more specific media type than <code>application/vc</code> when one is available.
+            See <a href="https://www.rfc-editor.org/rfc/rfc9052#section-3.1">Common COSE Header Parameters</a>
+            for additional details.
+          </p>
+          <p>
+            A <a data-link-type="dfn|abstract-op" href="#dfn-conforming-cose-verifier-implementation" class="internalDFN" id="ref-for-dfn-conforming-cose-verifier-implementation-1">conforming COSE verifier implementation</a> <em class="rfc2119">MUST</em> use COSE_Sign1 as
+            specified in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>] to verify <a data-link-type="dfn|abstract-op" href="#dfn-conforming-cose-document" class="internalDFN" id="ref-for-dfn-conforming-cose-document-3">conforming COSE documents</a>
+            that use this media type.
+          </p>
+          <p>
+            When including <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-16">verifiable credentials</a> secured with COSE in
+            <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentations</a> as
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#defn-EnvelopedVerifiableCredential">Enveloped Verifiable Credentials</a>,
+            the credentials <em class="rfc2119">MUST</em> be encoded using base64 as specified in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc2397" title="The &quot;data&quot; URL scheme">RFC2397</a></cite>].
+          </p>
+          <p>
+            To encrypt a secured <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-17">verifiable credential</a> when transmitting
+            over an insecure channel, implementers <em class="rfc2119">MAY</em> use COSE encryption,
+            as defined in Section 5 of [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>], by nesting the secured
+            <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-18">verifiable credential</a> as the plaintext payload of an encrypted
+            COSE object.
+          </p>
+          <div class="example" id="example-a-simple-example-of-a-verifiable-credential-secured-with-cose">
+        <div class="marker">
+    <a class="self-link" href="#example-a-simple-example-of-a-verifiable-credential-secured-with-cose">Example<bdi> 7</bdi></a><span class="example-title">: A simple example of a verifiable credential secured with COSE</span>
+  </div> 
+      <div class="vc-tabbed"><input type="radio" id="vc-tab7unsigned" name="vc-tabs7" checked=""><input type="radio" id="vc-tab7cose" name="vc-tabs7"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab7unsigned"><abbr title="Unsecured credential">Credential</abbr></label></li><li class="vc-tab"><label for="vc-tab7cose"><abbr title="Secured with COSE">cose</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 605px;"><pre class="nohighlight vc" data-vc-tabs="cose">{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "http://university.example/credentials/3732",
+  "type": ["VerifiableCredential", "ExampleDegreeCredential", "ExamplePersonCredential"],
+  "issuer": "https://university.example/issuers/14",
+  "validFrom": "2010-01-01T19:23:24Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "ExampleBachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    },
+    "alumniOf": {
+      "name": "Example University"
+    }
+  },
+  "credentialSchema": [{
+    "id": "https://example.org/examples/degree.json",
+    "type": "JsonSchema"
+  },
+  {
+    "id": "https://example.org/examples/alumni.json",
+    "type": "JsonSchema"
+  }]
+}</pre></div><div class="vc-tab-content" style="min-height: 605px;">
+<div class="vc-jose-cose-cose-tabbed">
+    <div class="vc-jose-cose-cose-tab-content">
+<strong>application/vc</strong>
+<pre>{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "http://university.example/credentials/3732",
+  "type": [
+    "VerifiableCredential",
+    "ExampleDegreeCredential",
+    "ExamplePersonCredential"
+  ],
+  "issuer": "https://university.example/issuers/14",
+  "validFrom": "2010-01-01T19:23:24Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "ExampleBachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    },
+    "alumniOf": {
+      "name": "Example University"
+    }
+  },
+  "credentialSchema": [
+    {
+      "id": "https://example.org/examples/degree.json",
+      "type": "JsonSchema"
+    },
+    {
+      "id": "https://example.org/examples/alumni.json",
+      "type": "JsonSchema"
+    }
+  ]
+}
+</pre>
+<strong>application/vc+cose</strong>
+<div class="cose-text">
+d28444a1013822a059029e7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c226964223a22687474703a2f2f756e69766572736974792e6578616d706c652f63726564656e7469616c732f33373332222c2274797065223a5b2256657269666961626c6543726564656e7469616c222c224578616d706c6544656772656543726564656e7469616c222c224578616d706c65506572736f6e43726564656e7469616c225d2c22697373756572223a2268747470733a2f2f756e69766572736974792e6578616d706c652f697373756572732f3134222c2276616c696446726f6d223a22323031302d30312d30315431393a32333a32345a222c2263726564656e7469616c5375626a656374223a7b226964223a226469643a6578616d706c653a656266656231663731326562633666316332373665313265633231222c22646567726565223a7b2274797065223a224578616d706c6542616368656c6f72446567726565222c226e616d65223a2242616368656c6f72206f6620536369656e636520616e642041727473227d2c22616c756d6e694f66223a7b226e616d65223a224578616d706c6520556e6976657273697479227d7d2c2263726564656e7469616c536368656d61223a5b7b226964223a2268747470733a2f2f6578616d706c652e6f72672f6578616d706c65732f6465677265652e6a736f6e222c2274797065223a224a736f6e536368656d61227d2c7b226964223a2268747470733a2f2f6578616d706c652e6f72672f6578616d706c65732f616c756d6e692e6a736f6e222c2274797065223a224a736f6e536368656d61227d5d7d58405e8def02de73d12afc98b8ceecb087b66fa039b7e37b300a367112c488d4963e698caf4ae833a32c00febc9bab8cbdeb3bb9cc99102961bff388f9fc9c263943
+</div>
+    </div>
+</div></div></div></div>
+          <p>
+            See <a href="https://www.w3.org/TR/vc-data-model-2.0/#example-using-the-credentialschema-property-to-perform-json-schema-validation">Verifiable Credentials Data Model v2.0</a>
+            for more details regarding this example.
+          </p>
+        </section>
+        <section id="securing-json-ld-verifiable-presentations-with-cose"><div class="header-wrapper"><h4 id="securing-vps-with-cose"><bdi class="secno">3.3.2 </bdi>Securing JSON-LD Verifiable Presentations with COSE</h4><a class="self-link" href="#securing-vps-with-cose" aria-label="Permalink for Section 3.3.2"></a></div>
+          
+          <p>
+            This section details how to use COSE to secure
+            <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentations</a> conforming to [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+          </p>
+          <p>
+            A <a data-link-type="dfn|abstract-op" href="#dfn-conforming-cose-issuer-implementation" class="internalDFN" id="ref-for-dfn-conforming-cose-issuer-implementation-2">conforming COSE issuer implementation</a> <em class="rfc2119">MUST</em> use COSE_Sign1 as
+            specified in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>] to secure this media type.
+            The unsecured <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentation</a> is the unencoded COSE_Sign1 payload.
+          </p>
+          <p>
+            The <code>typ (16)</code> header parameter, as described in
+            <a href="https://www.rfc-editor.org/rfc/rfc9596#section-2">COSE "typ" (type) Header Parameter</a>,
+            <em class="rfc2119">SHOULD</em> be <code>application/vp+cose</code>.
+            The <code>content type (3)</code> header parameter <em class="rfc2119">SHOULD</em> be <code>application/vp</code>.
+            The <code>content type (3)</code> header parameter is optional, and can be used
+            to express a more specific media type than <code>application/vp</code> when one is available.
+            See <a href="https://www.rfc-editor.org/rfc/rfc9052#section-3.1">Common COSE Header Parameters</a>
+            for additional details.
+          </p>
+          <p>
+            A <a data-link-type="dfn|abstract-op" href="#dfn-conforming-cose-verifier-implementation" class="internalDFN" id="ref-for-dfn-conforming-cose-verifier-implementation-2">conforming COSE verifier implementation</a> <em class="rfc2119">MUST</em> use COSE_Sign1 as
+            specified in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>] to verify <a data-link-type="dfn|abstract-op" href="#dfn-conforming-cose-document" class="internalDFN" id="ref-for-dfn-conforming-cose-document-4">conforming COSE documents</a>
+            that use this media type.
+          </p>
+          <p>
+            Verifiable Credentials secured in
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations">verifiable presentations</a>
+            <em class="rfc2119">MUST</em> use the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#defn-EnvelopedVerifiableCredential">Enveloped Verifiable Credential</a>
+            type defined by the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+          </p>
+          <p>
+            Verifiable Presentations in
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations">verifiable presentations</a>
+            <em class="rfc2119">MUST</em> use the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#defn-EnvelopedVerifiablePresentation">Enveloped Verifiable Presentation</a>
+            type defined by the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+          </p>
+          <p>
+            Credentials in <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentations</a> <em class="rfc2119">MUST</em> be secured.
+            These <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-credential">credentials</a> are secured using COSE in this case.
+          </p><p>
+          </p><p>
+            To encrypt a secured <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentation</a> when transmitting
+            over an insecure channel, implementers <em class="rfc2119">MAY</em> use COSE encryption,
+            as defined in Section 5 of [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>], by nesting the secured
+            <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentation</a> as the plaintext payload of an encrypted
+            COSE object.
+          </p>
+          <div class="example" id="example-a-simple-example-of-a-verifiable-presentation-secured-withcose-using-the-envelopedverifiablecredential-type">
+        <div class="marker">
+    <a class="self-link" href="#example-a-simple-example-of-a-verifiable-presentation-secured-withcose-using-the-envelopedverifiablecredential-type">Example<bdi> 8</bdi></a><span class="example-title">: A simple example of a verifiable presentation secured withCOSE using the EnvelopedVerifiableCredential type</span>
+  </div> 
+      <div class="vc-tabbed"><input type="radio" id="vc-tab8unsigned" name="vc-tabs8" checked=""><input type="radio" id="vc-tab8cose" name="vc-tabs8"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab8unsigned"><abbr title="Unsecured presentation">Presentation</abbr></label></li><li class="vc-tab"><label for="vc-tab8cose"><abbr title="Secured with COSE">cose</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 259px;"><pre class="nohighlight vc" data-vc-tabs="cose">{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "VerifiablePresentation",
+  "verifiableCredential": [{
+    "@context": "https://www.w3.org/ns/credentials/v2",
+    "type": "EnvelopedVerifiableCredential",
+    "id": "data:application/vc+sd-jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJfc2RfYWxnIjoic2hhLTI1NiIsIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiNWJBeDMteHBmQWxVS0ZJOXNuM2hWQ21wR2trcUlzWmMzLUxiMzNmWmpiayIsIlpjQXZIMDhsdEJySUpmSWh0OF9tS1BfYzNscG5YMWNHclltVG8wZ1lCeTgiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJuYW1lIjoiQmFjaGVsb3Igb2YgU2NpZW5jZSBhbmQgQXJ0cyIsIl9zZCI6WyJST1Q3MUl0dTNMNlVXWFVqby1oWVdJQjY3bHVPTkVEUlNCaGxEVENxVU9RIl19LCJfc2QiOlsiTUVuZXNnMlhPUk5jY3NCTWVaXzE2MDJneTQwUi00WUJ2VlIweFE4b0Y4YyJdfSwiX3NkIjpbIkVlc2Jiay1mcGZwd2ZMOXdOczFxcjZ0aU43ZnEtSXQzWVM2V3ZCbl9iWG8iLCJab1I1ZGRhckdtZk15NEhuV0xVak5URnFURjNYRjZpdFBnZnlGQkhVX3FVIl19.gw3paxbkLjpi8CTsyRpXKbC7tpVa0q2sWKSD-_dcbuZ1LpZV3oQ8Ifzcm2bE8RY3fmJgbuyA9gbPL3sQBaTzkg ~WyJSeUQxVlB4VHBvbmtPeXZpczkta293IiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJfVjd1eTd3ay1RM3VZd2ZpZ0NvWUVBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJhazdqMTlnYVMtRDJLX2hzY3RVZGNRIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJUTjBXaXVZRkhXWkV2ZDZIQUJHQS1nIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJVMnBzMkxYVERVbVh3MDcxRVBmRUpnIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyJsQ042eTNEaTNDUk9VX3JuXzRENWRnIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~"
+  }]
+}</pre></div><div class="vc-tab-content" style="min-height: 259px;">
+<div class="vc-jose-cose-cose-tabbed">
+    <div class="vc-jose-cose-cose-tab-content">
+<strong>application/vp</strong>
+<pre>{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "VerifiablePresentation",
+  "verifiableCredential": [
+    {
+      "@context": "https://www.w3.org/ns/credentials/v2",
+      "id": "data:application/vc+sd-jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJfc2RfYWxnIjoic2hhLTI1NiIsIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiNWJBeDMteHBmQWxVS0ZJOXNuM2hWQ21wR2trcUlzWmMzLUxiMzNmWmpiayIsIlpjQXZIMDhsdEJySUpmSWh0OF9tS1BfYzNscG5YMWNHclltVG8wZ1lCeTgiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJuYW1lIjoiQmFjaGVsb3Igb2YgU2NpZW5jZSBhbmQgQXJ0cyIsIl9zZCI6WyJST1Q3MUl0dTNMNlVXWFVqby1oWVdJQjY3bHVPTkVEUlNCaGxEVENxVU9RIl19LCJfc2QiOlsiTUVuZXNnMlhPUk5jY3NCTWVaXzE2MDJneTQwUi00WUJ2VlIweFE4b0Y4YyJdfSwiX3NkIjpbIkVlc2Jiay1mcGZwd2ZMOXdOczFxcjZ0aU43ZnEtSXQzWVM2V3ZCbl9iWG8iLCJab1I1ZGRhckdtZk15NEhuV0xVak5URnFURjNYRjZpdFBnZnlGQkhVX3FVIl19.gw3paxbkLjpi8CTsyRpXKbC7tpVa0q2sWKSD-_dcbuZ1LpZV3oQ8Ifzcm2bE8RY3fmJgbuyA9gbPL3sQBaTzkg ~WyJSeUQxVlB4VHBvbmtPeXZpczkta293IiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJfVjd1eTd3ay1RM3VZd2ZpZ0NvWUVBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJhazdqMTlnYVMtRDJLX2hzY3RVZGNRIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJUTjBXaXVZRkhXWkV2ZDZIQUJHQS1nIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJVMnBzMkxYVERVbVh3MDcxRVBmRUpnIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyJsQ042eTNEaTNDUk9VX3JuXzRENWRnIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~;data:application/vc+sd-jwt,eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ.eyJfc2RfYWxnIjoic2hhLTI1NiIsIkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiNWJBeDMteHBmQWxVS0ZJOXNuM2hWQ21wR2trcUlzWmMzLUxiMzNmWmpiayIsIlpjQXZIMDhsdEJySUpmSWh0OF9tS1BfYzNscG5YMWNHclltVG8wZ1lCeTgiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImRlZ3JlZSI6eyJuYW1lIjoiQmFjaGVsb3Igb2YgU2NpZW5jZSBhbmQgQXJ0cyIsIl9zZCI6WyJST1Q3MUl0dTNMNlVXWFVqby1oWVdJQjY3bHVPTkVEUlNCaGxEVENxVU9RIl19LCJfc2QiOlsiTUVuZXNnMlhPUk5jY3NCTWVaXzE2MDJneTQwUi00WUJ2VlIweFE4b0Y4YyJdfSwiX3NkIjpbIkVlc2Jiay1mcGZwd2ZMOXdOczFxcjZ0aU43ZnEtSXQzWVM2V3ZCbl9iWG8iLCJab1I1ZGRhckdtZk15NEhuV0xVak5URnFURjNYRjZpdFBnZnlGQkhVX3FVIl19.gw3paxbkLjpi8CTsyRpXKbC7tpVa0q2sWKSD-_dcbuZ1LpZV3oQ8Ifzcm2bE8RY3fmJgbuyA9gbPL3sQBaTzkg ~WyJSeUQxVlB4VHBvbmtPeXZpczkta293IiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJfVjd1eTd3ay1RM3VZd2ZpZ0NvWUVBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJhazdqMTlnYVMtRDJLX2hzY3RVZGNRIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJUTjBXaXVZRkhXWkV2ZDZIQUJHQS1nIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJVMnBzMkxYVERVbVh3MDcxRVBmRUpnIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyJsQ042eTNEaTNDUk9VX3JuXzRENWRnIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~",
+      "type": "EnvelopedVerifiableCredential"
+    }
+  ]
+}
+</pre>
+<strong>application/vp+cose</strong>
+<div class="cose-text">
+d28444a1013822a0590d1c7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c2274797065223a2256657269666961626c6550726573656e746174696f6e222c2276657269666961626c6543726564656e7469616c223a5b7b2240636f6e74657874223a2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c226964223a22646174613a6170706c69636174696f6e2f76632b73642d6a77742c65794a72615751694f694a4665456872516b31584f575a74596d7432566a49324e6d3153634856514d6e4e565756394f583056585355347862474677565870504f484a76496977695957786e496a6f6952564d794e54596966512e65794a66633252665957786e496a6f69633268684c5449314e694973496b426a623235305a586830496a7062496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a57353061574673637939324d694973496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a573530615746736379396c654746746347786c637939324d694a644c434a7063334e315a5849694f694a6f64485277637a6f764c33567561585a6c636e4e7064486b755a586868625842735a53397063334e315a584a7a4c7a55324e5441304f534973496e5a6862476c6b526e4a7662534936496a49774d5441744d4445744d4446554d546b364d6a4d364d6a52614969776959334a6c5a47567564476c6862464e6a614756745953493665794a66633251694f6c73694e574a4265444d746548426d5157785653305a4a4f584e754d326857513231775232747263556c7a576d4d7a4c5578694d7a4e6d576d706961794973496c706a51585a494d44687364454a795355706d535768304f46397453314266597a4e73634735594d574e48636c6c74564738775a316c436554676958583073496d4e795a57526c626e52705957785464574a715a574e30496a7037496d526c5a334a6c5a53493665794a755957316c496a6f69516d466a61475673623349676232596755324e705a57356a5a534268626d516751584a3063794973496c397a5a43493657794a53543151334d556c3064544e4d4e6c5658574656716279316f5756644a516a593362485650546b5645556c4e436147784556454e7856553952496c31394c434a66633251694f6c7369545556755a584e6e4d6c6850556b356a59334e4354575661587a45324d444a6e655451775569303057554a32566c4977654645346230593459794a646653776958334e6b496a7062496b566c63324a696179316d63475a7764325a4d4f58644f637a4678636a5a30615534335a6e45745358517a57564d3256335a43626c3969574738694c434a61623149315a475268636b64745a6b31354e45687556307856616b3555526e4655526a4e59526a5a706446426e5a6e6c47516b685658334656496c31392e677733706178626b4c6a706938435473795270584b6243377470566130713273574b53442d5f646362755a314c705a56336f513849667a636d32624538525933666d4a6762757941396762504c3373514261547a6b67207e57794a5365555178566c423456484276626d745065585a70637a6b746132393349697767496d6c6b49697767496d6830644841364c793931626d6c325a584a7a615852354c6d5634595731776247557659334a6c5a47567564476c6862484d764d5467334d694a647e57794a66566a643165546433617931524d33565a64325a705a304e765755564249697767496e5235634755694c434262496c5a6c636d6c6d6157466962475644636d566b5a5735306157467349697767496b5634595731776247564262485674626d6c44636d566b5a57353061574673496c31647e57794a68617a64714d546c6e59564d7452444a4c5832687a593352565a474e5249697767496d6c6b49697767496d68306448427a4f6938765a586868625842735a533576636d63765a586868625842735a584d765a47566e636d566c4c6d707a6232346958517e57794a55546a42586158565a526b6858576b56325a445a4951554a485153316e49697767496e5235634755694c434169536e4e76626c4e6a6147567459534a647e57794a564d6e427a4d6b785956455256625668334d4463785256426d5255706e49697767496d6c6b49697767496d52705a44706c654746746347786c4f6a45794d794a647e57794a735130343265544e4561544e44556b395658334a75587a52454e57526e49697767496e5235634755694c434169516d466a6147567362334a455a5764795a57556958517e3b646174613a6170706c69636174696f6e2f76632b73642d6a77742c65794a72615751694f694a4665456872516b31584f575a74596d7432566a49324e6d3153634856514d6e4e565756394f583056585355347862474677565870504f484a76496977695957786e496a6f6952564d794e54596966512e65794a66633252665957786e496a6f69633268684c5449314e694973496b426a623235305a586830496a7062496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a57353061574673637939324d694973496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a573530615746736379396c654746746347786c637939324d694a644c434a7063334e315a5849694f694a6f64485277637a6f764c33567561585a6c636e4e7064486b755a586868625842735a53397063334e315a584a7a4c7a55324e5441304f534973496e5a6862476c6b526e4a7662534936496a49774d5441744d4445744d4446554d546b364d6a4d364d6a52614969776959334a6c5a47567564476c6862464e6a614756745953493665794a66633251694f6c73694e574a4265444d746548426d5157785653305a4a4f584e754d326857513231775232747263556c7a576d4d7a4c5578694d7a4e6d576d706961794973496c706a51585a494d44687364454a795355706d535768304f46397453314266597a4e73634735594d574e48636c6c74564738775a316c436554676958583073496d4e795a57526c626e52705957785464574a715a574e30496a7037496d526c5a334a6c5a53493665794a755957316c496a6f69516d466a61475673623349676232596755324e705a57356a5a534268626d516751584a3063794973496c397a5a43493657794a53543151334d556c3064544e4d4e6c5658574656716279316f5756644a516a593362485650546b5645556c4e436147784556454e7856553952496c31394c434a66633251694f6c7369545556755a584e6e4d6c6850556b356a59334e4354575661587a45324d444a6e655451775569303057554a32566c4977654645346230593459794a646653776958334e6b496a7062496b566c63324a696179316d63475a7764325a4d4f58644f637a4678636a5a30615534335a6e45745358517a57564d3256335a43626c3969574738694c434a61623149315a475268636b64745a6b31354e45687556307856616b3555526e4655526a4e59526a5a706446426e5a6e6c47516b685658334656496c31392e677733706178626b4c6a706938435473795270584b6243377470566130713273574b53442d5f646362755a314c705a56336f513849667a636d32624538525933666d4a6762757941396762504c3373514261547a6b67207e57794a5365555178566c423456484276626d745065585a70637a6b746132393349697767496d6c6b49697767496d6830644841364c793931626d6c325a584a7a615852354c6d5634595731776247557659334a6c5a47567564476c6862484d764d5467334d694a647e57794a66566a643165546433617931524d33565a64325a705a304e765755564249697767496e5235634755694c434262496c5a6c636d6c6d6157466962475644636d566b5a5735306157467349697767496b5634595731776247564262485674626d6c44636d566b5a57353061574673496c31647e57794a68617a64714d546c6e59564d7452444a4c5832687a593352565a474e5249697767496d6c6b49697767496d68306448427a4f6938765a586868625842735a533576636d63765a586868625842735a584d765a47566e636d566c4c6d707a6232346958517e57794a55546a42586158565a526b6858576b56325a445a4951554a485153316e49697767496e5235634755694c434169536e4e76626c4e6a6147567459534a647e57794a564d6e427a4d6b785956455256625668334d4463785256426d5255706e49697767496d6c6b49697767496d52705a44706c654746746347786c4f6a45794d794a647e57794a735130343265544e4561544e44556b395658334a75587a52454e57526e49697767496e5235634755694c434169516d466a6147567362334a455a5764795a57556958517e222c2274797065223a22456e76656c6f70656456657269666961626c6543726564656e7469616c227d5d7d5840023eb9d5683e3046fde1af6d383d5f323964114f86fb4dfe1fe65bd548c9b8425da15138df1241973f1dafc4301c8aa3a0311b3e370c5b7d18082b81fcc6f0bb
+</div>
+    </div>
+</div></div></div></div>
+          <p>
+            See <a href="https://www.w3.org/TR/vc-data-model-2.0/#enveloped-verifiable-credentials">Verifiable Credentials Data Model v2.0</a> for more
+            details regarding this example.
+          </p>
+          <div class="example" id="example-a-simple-example-of-a-verifiable-presentation-secured-with-cose-using-the-envelopedverifiablepresentation-type">
+        <div class="marker">
+    <a class="self-link" href="#example-a-simple-example-of-a-verifiable-presentation-secured-with-cose-using-the-envelopedverifiablepresentation-type">Example<bdi> 9</bdi></a><span class="example-title">: A simple example of a verifiable presentation secured with COSE using the EnvelopedVerifiablePresentation type</span>
+  </div> 
+      <div class="vc-tabbed"><input type="radio" id="vc-tab9unsigned" name="vc-tabs9" checked=""><input type="radio" id="vc-tab9cose" name="vc-tabs9"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab9unsigned"><abbr title="Unsecured presentation">Presentation</abbr></label></li><li class="vc-tab"><label for="vc-tab9cose"><abbr title="Secured with COSE">cose</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 173px;"><pre class="nohighlight vc" data-vc-tabs="cose">{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "EnvelopedVerifiablePresentation",
+  "id": "data:application/vp+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlVRTV9fblE0UzZCTzhuUTRuT05YeHB4aHRob3lOeGI1M0xZZ1l6LTJBQnMiLCJ0eXAiOiJ2cCtsZCtqc29uK3NkLWp3dCIsImN0eSI6InZwK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiYWx1bW5pT2YiOnsibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSIsIl9zZCI6WyJoek9LRzU2cDI5c1ByTGFDNUE4RndFdUczVU05dUlZU1p1cU9YczJlVGJBIl19LCJfc2QiOlsiWVdXVmVDRndxQmk4WDBqSF9jV0NWWU16STNhOHBjTEVYRWZicFNSQVlndyJdfSwiX3NkIjpbIjJJZjhhaUs4REZwVWJ4dEc1cGMwel9SaFJzbm1ybGFRMEhzcTk4WFNyYWsiLCJUeDZ4ZWZMVUdUZUpfYWtVUFdGeHNvbUhobGtWVnpfNzVoaVZ6eWpyYmVzIl19XSwiX3NkIjpbIjd2anl0VVN3ZEJ0MXQ5RktlOVFfS3JIRXhFWGxrTEFaTzBKM0Jpd200dlkiXSwiX3NkX2FsZyI6InNoYS0yNTYiLCJpYXQiOjE3MDY1NjI4NDksImV4cCI6MTczODE4NTI0OSwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwiYWxnIjoiRVMzODQiLCJ4IjoidWtEd1U2ZzlQUVRFUWhYaEgyckRZNndMQlg3UHFlUjZBcGlhVHBEUXowcl8tdDl6UXNxem54Z0hEcE5oekZlQyIsInkiOiJMQnhVYnBVdFNGMVVKVTVpYnJIdkpINjBUSG5YMk1xa0xHZGltU1l0UGR4RlkxOEdhcldiS3FZV0djUkZHVE9BIn19fQ.kYD63YtBNYnLUTw6Szf1vs_Ug3UBXhPwCyqpNmPnPDa3rXZQhQLdB1BgaoO8zgQ-c3B41fxaXMnLHYV9-B20uboSpJP0B-2Vre917eQt1cSDswDGA_Ytvn4BSqYVBB2J~WyJFMkFsRzhsY2p0QVFrcllIbjlIbnVRIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd~WyI5NldYMDRneno4cVZzOVZLU2wwYTVnIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJaekU2VFVaamtHMW1DWXBKMEhnc0l3IiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyItQ3NsS25GZGFYb2JiQWsyU0JBVGR3IiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd~WyJuRm1OWl9IczB3WWNoOFdkeTdnQUNRIiwgImlkIiwgImRpZDpleGFtcGxlOmMyNzZlMTJlYzIxZWJmZWIxZjcxMmViYzZmMSJd~"
+}</pre></div><div class="vc-tab-content" style="min-height: 173px;">
+<div class="vc-jose-cose-cose-tabbed">
+    <div class="vc-jose-cose-cose-tab-content">
+<strong>application/vp</strong>
+<pre>{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "EnvelopedVerifiablePresentation",
+  "id": "data:application/vp+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlVRTV9fblE0UzZCTzhuUTRuT05YeHB4aHRob3lOeGI1M0xZZ1l6LTJBQnMiLCJ0eXAiOiJ2cCtsZCtqc29uK3NkLWp3dCIsImN0eSI6InZwK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJpc3N1ZXIiOiJodHRwczovL3VuaXZlcnNpdHkuZXhhbXBsZS9pc3N1ZXJzLzU2NTA0OSIsInZhbGlkRnJvbSI6IjIwMTAtMDEtMDFUMTk6MjM6MjRaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiYWx1bW5pT2YiOnsibmFtZSI6IkV4YW1wbGUgVW5pdmVyc2l0eSIsIl9zZCI6WyJoek9LRzU2cDI5c1ByTGFDNUE4RndFdUczVU05dUlZU1p1cU9YczJlVGJBIl19LCJfc2QiOlsiWVdXVmVDRndxQmk4WDBqSF9jV0NWWU16STNhOHBjTEVYRWZicFNSQVlndyJdfSwiX3NkIjpbIjJJZjhhaUs4REZwVWJ4dEc1cGMwel9SaFJzbm1ybGFRMEhzcTk4WFNyYWsiLCJUeDZ4ZWZMVUdUZUpfYWtVUFdGeHNvbUhobGtWVnpfNzVoaVZ6eWpyYmVzIl19XSwiX3NkIjpbIjd2anl0VVN3ZEJ0MXQ5RktlOVFfS3JIRXhFWGxrTEFaTzBKM0Jpd200dlkiXSwiX3NkX2FsZyI6InNoYS0yNTYiLCJpYXQiOjE3MDY1NjI4NDksImV4cCI6MTczODE4NTI0OSwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMzg0IiwiYWxnIjoiRVMzODQiLCJ4IjoidWtEd1U2ZzlQUVRFUWhYaEgyckRZNndMQlg3UHFlUjZBcGlhVHBEUXowcl8tdDl6UXNxem54Z0hEcE5oekZlQyIsInkiOiJMQnhVYnBVdFNGMVVKVTVpYnJIdkpINjBUSG5YMk1xa0xHZGltU1l0UGR4RlkxOEdhcldiS3FZV0djUkZHVE9BIn19fQ.kYD63YtBNYnLUTw6Szf1vs_Ug3UBXhPwCyqpNmPnPDa3rXZQhQLdB1BgaoO8zgQ-c3B41fxaXMnLHYV9-B20uboSpJP0B-2Vre917eQt1cSDswDGA_Ytvn4BSqYVBB2J~WyJFMkFsRzhsY2p0QVFrcllIbjlIbnVRIiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd~WyI5NldYMDRneno4cVZzOVZLU2wwYTVnIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJaekU2VFVaamtHMW1DWXBKMEhnc0l3IiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyItQ3NsS25GZGFYb2JiQWsyU0JBVGR3IiwgImlkIiwgImRpZDpleGFtcGxlOmViZmViMWY3MTJlYmM2ZjFjMjc2ZTEyZWMyMSJd~WyJuRm1OWl9IczB3WWNoOFdkeTdnQUNRIiwgImlkIiwgImRpZDpleGFtcGxlOmMyNzZlMTJlYzIxZWJmZWIxZjcxMmViYzZmMSJd~"
+}
+</pre>
+<strong>application/vp+cose</strong>
+<div class="cose-text">
+d28444a1013822a05908837b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c2274797065223a22456e76656c6f70656456657269666961626c6550726573656e746174696f6e222c226964223a22646174613a6170706c69636174696f6e2f76702b73642d6a77742c65794a68624763694f694a46557a4d344e434973496d74705a434936496c565254563966626c4530557a5a43547a68755554527554303559654842346148526f62336c4f654749314d30785a5a316c364c544a42516e4d694c434a30655841694f694a32634374735a437471633239754b334e6b4c57703364434973496d4e3065534936496e5a774b32786b4b32707a6232346966512e65794a4159323975644756346443493657794a6f64485277637a6f764c336433647935334d793576636d6376626e4d7659334a6c5a47567564476c6862484d76646a49694c434a6f64485277637a6f764c336433647935334d793576636d6376626e4d7659334a6c5a47567564476c6862484d765a586868625842735a584d76646a496958537769646d567961575a7059574a735a554e795a57526c626e5270595777694f6c7437496b426a623235305a586830496a7062496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a57353061574673637939324d694973496d68306448427a4f693876643364334c6e637a4c6d39795a7939756379396a636d566b5a573530615746736379396c654746746347786c637939324d694a644c434a7063334e315a5849694f694a6f64485277637a6f764c33567561585a6c636e4e7064486b755a586868625842735a53397063334e315a584a7a4c7a55324e5441304f534973496e5a6862476c6b526e4a7662534936496a49774d5441744d4445744d4446554d546b364d6a4d364d6a52614969776959334a6c5a47567564476c6862464e31596d706c593351694f6e73695957783162573570543259694f6e7369626d46745a534936496b5634595731776247556756573570646d567963326c3065534973496c397a5a43493657794a6f656b394c527a55326344493563314279544746444e554534526e64466455637a5655303564556c5a5531703163553959637a4a6c56474a42496c31394c434a66633251694f6c736957566458566d5644526e6478516d6b34574442715346396a56304e575755313653544e684f48426a5445565952575a6963464e5351566c6e64794a646653776958334e6b496a7062496a4a4a5a6a68686155733452455a7756574a346445633163474d77656c395361464a7a626d3179624746524d45687a63546b3457464e79595773694c434a5565445a345a575a4d565564555a557066595774565546644765484e766255686f62477457566e70664e7a566f61565a3665577079596d567a496c31395853776958334e6b496a7062496a6432616e6c3056564e335a454a304d585135526b746c4f56466653334a49525868465747787254454661547a424b4d304a7064323030646c6b695853776958334e6b583246735a794936496e4e6f595330794e5459694c434a70595851694f6a45334d4459314e6a49344e446b73496d5634634349364d54637a4f4445344e5449304f5377695932356d496a7037496d70336179493665794a7264486b694f694a4651794973496d4e7964694936496c41744d7a6730496977695957786e496a6f6952564d7a4f4451694c434a34496a6f6964577445643155325a7a6c51555652465557685961456779636b525a4e6e644d516c67335548466c556a5a4263476c685648424555586f77636c387464446c3655584e78656d35345a3068456345356f656b5a6c51794973496e6b694f694a4d516e6856596e425664464e474d56564b56545670596e4a49646b70494e6a4255534735594d6b3178613078485a476c7455316c3055475234526c6b784f456468636c64695333465a5630646a556b5a4856453942496e313966512e6b594436335974424e596e4c55547736537a663176735f556733554258685077437971704e6d506e5044613372585a5168514c6442314267616f4f387a67512d6333423431667861584d6e4c485956392d42323075626f53704a5030422d325672653931376551743163534473774447415f5974766e3442537159564242324a7e57794a464d6b4673527a68735932703051564672636c6c49626a6c49626e565249697767496e5235634755694c434169566d567961575a7059574a735a5642795a584e6c626e526864476c7662694a647e577949354e6c64594d44526e656e6f3463565a7a4f565a4c553277775954566e49697767496d6c6b49697767496d6830644841364c793931626d6c325a584a7a615852354c6d5634595731776247557659334a6c5a47567564476c6862484d764d5467334d694a647e57794a61656b553256465661616d74484d5731445758424b4d45686e63306c3349697767496e5235634755694c434262496c5a6c636d6c6d6157466962475644636d566b5a5735306157467349697767496b5634595731776247564262485674626d6c44636d566b5a57353061574673496c31647e5779497451334e73533235475a47465962324a695157737955304a425647523349697767496d6c6b49697767496d52705a44706c654746746347786c4f6d56695a6d56694d5759334d544a6c596d4d325a6a466a4d6a63325a5445795a574d794d534a647e57794a75526d314f576c3949637a423357574e6f4f46646b6554646e51554e5249697767496d6c6b49697767496d52705a44706c654746746347786c4f6d4d794e7a5a6c4d544a6c597a49785a574a6d5a5749785a6a63784d6d5669597a5a6d4d534a647e222c2276657269666961626c6543726564656e7469616c223a5b5d7d5840d817f59e15a04f41995c28dbb1beb0ceae8f4e23daeb2135a6e492320e64d6af49fbe9ce1755e45a549f72fe5c149424de7a8fb8dc24b6279be1301c69a1302d
+</div>
+    </div>
+</div></div></div></div>
+          <p>
+            See <a href="https://www.w3.org/TR/vc-data-model-2.0/#enveloped-verifiable-presentations">Verifiable Credentials Data Model v2.0</a>
+            for more details regarding this example.
+          </p>
+        </section>
+        <section id="cose-header-parameters-and-cwt-claims"><div class="header-wrapper"><h4 id="cose-header-param-cwt-claims"><bdi class="secno">3.3.3 </bdi>COSE Header Parameters and CWT Claims</h4><a class="self-link" href="#cose-header-param-cwt-claims" aria-label="Permalink for Section 3.3.3"></a></div>
+          
+          <p>
+            When present in the <a href="https://www.rfc-editor.org/rfc/rfc9052#section-3.1">COSE Header</a>
+            or as <a href="https://www.rfc-editor.org/rfc/rfc8392#section-3">CWT Claims</a>,
+            members registered in the IANA
+            <a href="https://www.iana.org/assignments/cwt/cwt.xhtml">CBOR Web Token (CWT) Claims</a>
+            registry or the IANA
+            <a href="https://www.iana.org/assignments/cose/cose.xhtml">COSE Header Parameters</a>
+            registry are to be interpreted as defined by the specifications
+            referenced in those registries. CBOR Web Token (CWT) [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8392" title="CBOR Web Token (CWT)">RFC8392</a></cite>]
+            Claims <em class="rfc2119">MAY</em> be included in a COSE header parameter, as specified in
+            <a href="https://www.ietf.org/archive/id/draft-ietf-cose-cwt-claims-in-headers-10.html">I-D.ietf-cose-cwt-claims-in-headers</a>.
+          </p>
+          <p>
+            The normative statements in
+            <a href="https://www.rfc-editor.org/rfc/rfc9052#section-3.1">Header Parameters</a>,
+            <a href="https://www.rfc-editor.org/rfc/rfc8392#section-3">Claims</a>, and
+            <a href="https://www.ietf.org/archive/id/draft-ietf-cose-cwt-claims-in-headers-10.html">CBOR Web Token (CWT) Claims in COSE Headers</a>
+            apply to securing credentials and presentations.
+          </p>
+          <p>
+            It is <em class="rfc2119">RECOMMENDED</em> to use the IANA
+            <a href="https://www.iana.org/assignments/cwt/cwt.xhtml">CBOR Web Token Claims</a>
+            registry and the IANA
+            <a href="https://www.iana.org/assignments/cose/cose.xhtml">COSE Header Parameters</a>
+            registry to identify any claims and header parameters that might be
+            confused with members defined by [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+            These include but are not limited to: <code>iss</code>,
+            <code>kid</code>, <code>alg</code>, <code>iat</code>,
+            <code>exp</code>, and <code>cnf</code>.
+          </p>
+          <p>
+            When the <code>iat</code> (Issued At) and/or
+            <code>exp</code> (Expiration Time) CWT claims are present, they
+            represent the issuance and expiration time of the signature,
+            respectively.
+            Note that these are different from the
+            <code>validFrom</code> and <code>validUntil</code> properties
+            defined in
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#validity-period">Validity Period</a>,
+            which represent the validity of the data that is being secured.
+            Use of the <code>nbf</code> (Not Before) claim is <em class="rfc2119">NOT RECOMMENDED</em>,
+            as it makes little sense to attempt to assign a future date to
+            a signature.
+          </p>
+          <p>
+            Additional members may be present as header parameters and claims.
+            If they are not understood, they <em class="rfc2119">MUST</em> be ignored.
+          </p>
+        </section>
+      </section>
+    </section>
+    <section id="key_discovery"><div class="header-wrapper"><h2 id="key-discovery"><bdi class="secno">4. </bdi>Key Discovery</h2><a class="self-link" href="#key-discovery" aria-label="Permalink for Section 4."></a></div>
+      
+      <p>
+        To complete the
+        <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verify">verification</a> process,
+        a <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifier</a> needs to
+        obtain the cryptographic keys used to secure the
+        <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-credential">credential</a>.
+      </p>
+      <p>
+        There are several different ways to discover the verification keys of
+        the <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuers</a>
+        and <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders">holders</a>.
+      </p>
+      <section id="using-header-parameters-and-claims-for-key-discovery"><div class="header-wrapper"><h3 id="using-header-params-claims-key-discovery"><bdi class="secno">4.1 </bdi>Using Header Parameters and Claims for Key Discovery</h3><a class="self-link" href="#using-header-params-claims-key-discovery" aria-label="Permalink for Section 4.1"></a></div>
+        
+        <p>
+          These JOSE header parameters and JWT claims can be used by
+          <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifiers</a> to
+          discover verification keys.
+        </p>
+        <section id="kid-0"><div class="header-wrapper"><h4 id="kid"><bdi class="secno">4.1.1 </bdi>kid</h4><a class="self-link" href="#kid" aria-label="Permalink for Section 4.1.1"></a></div>
+          
+          <p>
+            If <code>kid</code> is present in the
+            <a href="https://www.rfc-editor.org/rfc/rfc7515#section-4.1">JOSE Header</a> or the
+            <a href="https://www.rfc-editor.org/rfc/rfc9052#section-3">COSE Header</a>,
+            a <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifier</a> can
+            use this parameter as a hint indicating which key was used to
+            secure the <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-19">verifiable credential</a>, when performing a
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verify">verification</a>
+            process as defined in <a href="https://www.rfc-editor.org/rfc/rfc7515#section-4.1.4">RFC7515</a>.
+          </p>
+          <p>
+            <code>kid</code> <em class="rfc2119">MUST</em> be present when the key of the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a>
+            or <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-subjects">subject</a> is
+            expressed as a DID URL.
+          </p>
+        </section>
+        <section id="iss-0"><div class="header-wrapper"><h4 id="iss"><bdi class="secno">4.1.2 </bdi>iss</h4><a class="self-link" href="#iss" aria-label="Permalink for Section 4.1.2"></a></div>
+          
+          <p>
+            If <code>iss</code> is present in the
+            <a href="https://www.rfc-editor.org/rfc/rfc7515#section-4.1">JOSE Header</a>,
+            the <a href="https://www.rfc-editor.org/rfc/rfc7519#section-4.1.1">JWT Claims</a>,
+            or the <a href="https://www.rfc-editor.org/rfc/rfc9052#section-3">COSE Header</a>,
+            a <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifier</a>
+            can use this parameter to obtain a
+            <a href="https://www.rfc-editor.org/rfc/rfc7517#section-4">JSON Web Key</a> to use in the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verify">verification</a> process.
+          </p>
+          <p>
+            The value of the <a href="https://www.w3.org/TR/vc-data-model-2.0/#issuer">issuer</a>
+            property can be either a string or an object.
+            When <code>issuer</code> value is a string, <code>iss</code> value,
+            if present, <em class="rfc2119">MUST</em> match <code>issuer</code> value. When
+            <code>issuer</code> value is an object with an <code>id</code>
+            value, <code>iss</code> value, if present, <em class="rfc2119">MUST</em> match
+            <code>issuer.id</code> value.
+          </p>
+          <p>
+            If <code>kid</code> is also present in the
+            <a href="https://www.rfc-editor.org/rfc/rfc7515#section-4.1">JOSE Header</a>,
+            it is used to distinguish the specific key used.
+          </p>
+        </section>
+        <section id="cnf-0"><div class="header-wrapper"><h4 id="cnf"><bdi class="secno">4.1.3 </bdi>cnf</h4><a class="self-link" href="#cnf" aria-label="Permalink for Section 4.1.3"></a></div>
+          
+          <p>
+            If <code>cnf</code> is present in the
+            <a href="https://www.rfc-editor.org/rfc/rfc7515#section-4.1">JOSE Header</a>,
+            the <a href="https://www.rfc-editor.org/rfc/rfc7519#section-4.1.1">JWT Claims</a>,
+            or the <a href="https://www.rfc-editor.org/rfc/rfc9052#section-3">COSE Header</a>,
+            a <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">verifier</a> <em class="rfc2119">MAY</em>
+            use this parameter to identify a proof-of-possession key in the
+            manner described in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7800" title="Proof-of-Possession Key Semantics for JSON Web Tokens (JWTs)">RFC7800</a></cite>] or [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc8747" title="Proof-of-Possession Key Semantics for CBOR Web Tokens (CWTs)">RFC8747</a></cite>] for use in the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verify">verification</a> process.
+          </p>
+          <p>
+            Use of a proof-of-possession key provided by the <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders">Holder</a> to the
+            <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">Issuer</a> to establish a cryptographic binding to the <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders">Holder</a>
+            in the <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-20">Verifiable Credential</a> that is verifiable by the
+            <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifier">Verifier</a> in the <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">Verifiable Presentation</a> is <em class="rfc2119">RECOMMENDED</em>.
+          </p>
+        </section>
+      </section>
+      <section id="well-known-uris-0"><div class="header-wrapper"><h3 id="well-known-uris"><bdi class="secno">4.2 </bdi>Well-Known URIs</h3><a class="self-link" href="#well-known-uris" aria-label="Permalink for Section 4.2"></a></div>
+        
+        <section id="jwt-issuer-0"><div class="header-wrapper"><h4 id="jwt-issuer"><bdi class="secno">4.2.1 </bdi>JWT Issuer</h4><a class="self-link" href="#jwt-issuer" aria-label="Permalink for Section 4.2.1"></a></div>
+          
+          <p>
+            When the <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a> value is a URL using the HTTPS scheme,
+            <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a> metadata including the <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a>'s <a data-link-type="dfn|abstract-op" href="#dfn-public-key" class="internalDFN" id="ref-for-dfn-public-key-1">public keys</a> can
+            be retrieved using the mechanism defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt-vc" title="SD-JWT-based Verifiable Credentials (SD-JWT VC)">SD-JWT-VC</a></cite>].
+          </p>
+          <div class="issue" id="issue-container-number-1"><div role="heading" class="issue-title marker" id="h-issue" aria-level="5"><span>Issue 1</span><span class="issue-label">: (AT RISK) Feature depends on demonstration of independent implementations</span></div><p class="">
+            This normative statement depends on the IETF OAuth working group
+            draft [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt-vc" title="SD-JWT-based Verifiable Credentials (SD-JWT VC)">SD-JWT-VC</a></cite>]. This feature is at risk and will be removed
+            from the specification if at least two independent, interoperable
+            implementations are not demonstrated.
+          </p></div>
+          <div class="example" id="example-a-kid-as-a-url-with-a-jwk-thumbprint-uri">
+        <div class="marker">
+    <a class="self-link" href="#example-a-kid-as-a-url-with-a-jwk-thumbprint-uri">Example<bdi> 10</bdi></a><span class="example-title">: A kid as a URL with a JWK Thumbprint URI</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"alg"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EdDSA"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"kid"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://vendor.example/issuers/42/keys/urn:ietf:params:oauth:jwk-thumbprint:sha-256:NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+        </section>
+      </section>
+      <section id="using-controlled-identifier-documents-0"><div class="header-wrapper"><h3 id="using-controlled-identifier-documents"><bdi class="secno">4.3 </bdi>Using Controlled Identifier Documents</h3><a class="self-link" href="#using-controlled-identifier-documents" aria-label="Permalink for Section 4.3"></a></div>
+        
+        <p>
+          When using <a data-link-type="dfn|abstract-op" href="#dfn-controlled-identifier-document" class="internalDFN" id="ref-for-dfn-controlled-identifier-document-1">controlled identifier documents</a> with this specification,
+          the following requirements apply.
+        </p>
+        <p>
+          The value of the <code>type</code> property of the verification method <em class="rfc2119">MUST</em> be
+          <code>JsonWebKey</code>.
+        </p>
+        <p>
+          Verification material <em class="rfc2119">MUST</em> be expressed in the <code>publicKeyJwk</code>
+          property of a <code>JsonWebKey</code>.
+          This key material is retrieved based on hints in the JOSE or COSE message
+          envelopes, such as <code>kid</code> or <code>iss</code>.
+          At the time of writing, there is no standard way to retrieve a
+          public key in JWK format from a DID URL or <a data-link-type="dfn|abstract-op" href="#dfn-controlled-identifier-document" class="internalDFN" id="ref-for-dfn-controlled-identifier-document-2">controlled identifier documents</a>.
+        </p>
+        
+        <p>
+          When <a href="#iss">iss</a> is absent, and the
+          <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-issuers">issuer</a> is identified
+          as a [<cite><a class="bibref" data-link-type="biblio" href="#bib-url" title="URL Standard">URL</a></cite>], the <a href="#kid">kid</a> <em class="rfc2119">MUST</em> be an absolute [<cite><a class="bibref" data-link-type="biblio" href="#bib-url" title="URL Standard">URL</a></cite>]
+          to a verification method listed in a <a data-link-type="dfn|abstract-op" href="#dfn-controlled-identifier-document" class="internalDFN" id="ref-for-dfn-controlled-identifier-document-3">controlled identifier documents</a> or
+          a <a href="https://www.w3.org/TR/did-core/#dfn-did-documents">DID Document</a>.
+        </p>
+        <p>
+          When using [<cite><a class="bibref" data-link-type="biblio" href="#bib-url" title="URL Standard">URL</a></cite>] identifiers, the <code>kid</code> is <em class="rfc2119">RECOMMENDED</em> to
+          be an absolute [<cite><a class="bibref" data-link-type="biblio" href="#bib-url" title="URL Standard">URL</a></cite>] that includes a JWK Thumbprint URI as defined
+          in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7638" title="JSON Web Key (JWK) Thumbprint">RFC7638</a></cite>].
+          For example:
+          <code>https://vendor.example/issuers/42/keys/urn:ietf:params:oauth:jwk-thumbprint:sha-256:NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs</code>
+        </p>
+        <div class="example" id="example-an-issuer-identified-by-a-controlled-identifier-document-identifier">
+        <div class="marker">
+    <a class="self-link" href="#example-an-issuer-identified-by-a-controlled-identifier-document-identifier">Example<bdi> 11</bdi></a><span class="example-title">: An issuer identified by a controlled identifier document identifier</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"issuer"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/issuers/565049"</span>
+  <span class="hljs-punctuation">}</span>
+  <span class="hljs-comment">// ...</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+<div class="example" id="example-a-kid-as-a-controlled-identifier-document-verification-method-identifier">
+        <div class="marker">
+    <a class="self-link" href="#example-a-kid-as-a-controlled-identifier-document-verification-method-identifier">Example<bdi> 12</bdi></a><span class="example-title">: A kid as a controlled identifier document verification method identifier</span>
+  </div> <pre aria-busy="false"><code class="hljs">{
+  "alg": "ES384",
+  "kid": "https://university.example/issuers/565049#key-123
+}</code></pre>
+      </div>
+        <p>
+          When the <a href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-holders">holder</a> is
+          identified as a [<cite><a class="bibref" data-link-type="biblio" href="#bib-url" title="URL Standard">URL</a></cite>], and <a href="#iss">iss</a> is absent, the
+          <a href="#kid">kid</a> <em class="rfc2119">MUST</em> be an absolute [<cite><a class="bibref" data-link-type="biblio" href="#bib-url" title="URL Standard">URL</a></cite>] to a
+          verification method listed in a <a data-link-type="dfn|abstract-op" href="#dfn-controlled-identifier-document" class="internalDFN" id="ref-for-dfn-controlled-identifier-document-4">controlled identifier document</a>.
+        </p>
+<div class="example" id="example-a-holder-identified-by-a-controlled-identifier-document-identifier">
+        <div class="marker">
+    <a class="self-link" href="#example-a-holder-identified-by-a-controlled-identifier-document-identifier">Example<bdi> 13</bdi></a><span class="example-title">: A holder identified by a controlled identifier document identifier</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"holder"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/issuers/565049"</span>
+  <span class="hljs-punctuation">}</span>
+  <span class="hljs-comment">// ...</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+<div class="example" id="example-a-kid-as-a-controlled-identifier-document-verification-method-identifier-0">
+        <div class="marker">
+    <a class="self-link" href="#example-a-kid-as-a-controlled-identifier-document-verification-method-identifier-0">Example<bdi> 14</bdi></a><span class="example-title">: A kid as a controlled identifier document verification method identifier</span>
+  </div> <pre aria-busy="false"><code class="hljs">{
+  "alg": "ES384",
+  "kid": "https://university.example/issuers/565049#key-123
+}</code></pre>
+      </div>
+      </section>
+    </section>
+    <section id="algorithms-0"><div class="header-wrapper"><h2 id="algorithms"><bdi class="secno">5. </bdi>Algorithms</h2><a class="self-link" href="#algorithms" aria-label="Permalink for Section 5."></a></div>
+      
+      <p>
+        This specification might be used with many different key discovery
+        protocols. Therefore, discovery of verification keys is described in
+        <a href="#key_discovery" class="sec-ref"><bdi class="secno">4. </bdi>Key Discovery</a>, and is assumed to have succeeded prior
+        to beginning the verification process.
+      </p>
+      <p>
+        As a general rule, verifiers <em class="rfc2119">SHOULD</em> strive to minimize the processing of
+        untrusted data.
+        This includes minimizing any processing of the protected header,
+        unprotected header, or payload as part of the key discovery procedures.
+      </p>
+      <p>
+        After verification has succeeded, additional validation checks <em class="rfc2119">SHOULD</em> be
+        performed as described in Section <a href="#validation-algorithm" class="sec-ref"><bdi class="secno">5.4 </bdi>Validation</a>
+      </p>
+      <p>
+        The outputs for the following algorithms are:
+      </p>
+      <ul>
+        <li>
+          <code>status</code>: a boolean indicating the result of verification,
+          <code>true</code> for success and <code>false</code> for failure.
+        </li>
+        <li>
+          <code>document</code>: a document conforming to the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>]
+        </li>
+        <li>
+          <code>mediaType</code>: <code>vc</code> or <code>vp</code>
+        </li>
+      </ul>
+      <section id="verifying-a-credential-or-presentation-secured-with-jose"><div class="header-wrapper"><h3 id="alg-jose"><bdi class="secno">5.1 </bdi>Verifying a Credential or Presentation Secured with JOSE</h3><a class="self-link" href="#alg-jose" aria-label="Permalink for Section 5.1"></a></div>
+        
+        <p>
+          The inputs for this algorithm are:
+        </p>
+        <ul>
+          <li>
+            <code>inputMediaType</code>: <code>vc+jwt</code> or <code>vp+jwt</code>
+          </li>
+          <li>
+            <code>inputDocument</code>: the verifiable credential secured as a JWT [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>]
+          </li>
+        </ul>
+        <p>
+          Upon receipt of the verifiable credential or presentation secured as
+          a JWT [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>], the holder or verifier follows this algorithm:
+        </p>
+        <ol>
+          <li>
+            Follow the algorithm defined in
+            <a href="https://www.rfc-editor.org/rfc/rfc7519#section-7.2">Validating a JWT</a> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>].
+          </li>
+          <li>
+            If processing completes successfully:
+            <ol>
+              <li>
+                Set <code>status</code> to <code>true</code>
+              </li>
+              <li>
+                Set <code>mediaType</code> to <code>vc</code> or <code>vp</code>
+              </li>
+              <li>
+                Set <code>document</code> to the decoded JWS payload.
+              </li>
+              <li>
+                Return
+              </li>
+            </ol>
+          </li>
+          <li>
+            If processing aborts for any reason or the JWT is rejected:
+            <ol>
+              <li>
+                Set <code>status</code> to <code>false</code>
+              </li>
+              <li>
+                Set <code>document</code> to <code>null</code>
+              </li>
+              <li>
+                Set <code>mediaType</code> to <code>null</code>
+              </li>
+              <li>
+                Return
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+      <section id="verifying-a-credential-or-presentation-secured-with-sd-jwt"><div class="header-wrapper"><h3 id="alg-sd-jwt"><bdi class="secno">5.2 </bdi>Verifying a Credential or Presentation Secured with SD-JWT</h3><a class="self-link" href="#alg-sd-jwt" aria-label="Permalink for Section 5.2"></a></div>
+        
+        <p>
+          The inputs for this algorithm are:
+        </p>
+        <ul>
+          <li>
+            <code>inputMediaType</code>: <code>vc+sd-jwt</code>
+          </li>
+          <li>
+            <code>inputDocument</code>: the verifiable credential secured with [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>]
+          </li>
+        </ul>
+        <p>
+          Upon receipt of the verifiable credential or presentation secured with
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>], the holder or verifier follows this algorithm:
+        </p>
+        <ol>
+          <li>
+            Follow the algorithms defined in <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt#section-8">SD-JWT</a>
+            for verification of the SD-JWT.
+          </li>
+          <li>
+            If processing completes successfully:
+            <ol>
+              <li>
+                Set <code>status</code> to <code>true</code>
+              </li>
+              <li>
+                Set <code>mediaType</code> to <code>vc</code>
+              </li>
+              <li>
+                Convert the SD-JWT payload back into the JWT Claims Set by
+                reversing the process in [<cite><a class="bibref" data-link-type="biblio" href="#bib-sd-jwt" title="Selective Disclosure for JWTs (SD-JWT)">SD-JWT</a></cite>]. Set <code>document</code>
+                to the JWT Claims Set.
+                (For examples of the transition from  JWT Claims Set to SD-JWT payload,
+                please see
+                <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt#appendix-A">SD-JWT examples</a>).
+              </li>
+              <li>
+                Return
+              </li>
+            </ol>
+          </li>
+          <li>
+            If processing aborts for any reason or the SD-JWT is rejected:
+            <ol>
+              <li>
+                Set <code>status</code> to <code>false</code>
+              </li>
+              <li>
+                Set <code>document</code> to <code>null</code>
+              </li>
+              <li>
+                Set <code>mediaType</code> to <code>null</code>
+              </li>
+              <li>
+                Return
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+      <section id="verifying-a-credential-or-presentation-secured-with-cose"><div class="header-wrapper"><h3 id="alg-cose"><bdi class="secno">5.3 </bdi>Verifying a Credential or Presentation Secured with
+         COSE</h3><a class="self-link" href="#alg-cose" aria-label="Permalink for Section 5.3"></a></div>
+        
+        <p>
+          The inputs for this algorithm are:
+        </p>
+        <ul>
+          <li>
+            <code>inputMediaType</code>: <code>vc+cose</code> or
+            <code>vp+cose</code>
+          </li>
+          <li>
+            <code>inputDocument</code>: the <a data-link-type="dfn|abstract-op" href="#dfn-verifiable-credentials" class="internalDFN" id="ref-for-dfn-verifiable-credentials-21">verifiable credential</a> or
+            <a data-link-type="dfn" href="https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiable-presentation">verifiable presentation</a> secured with <cite><a data-matched-text="[[[RFC9052]]]" href="https://www.rfc-editor.org/rfc/rfc9052">CBOR Object Signing and Encryption (COSE): Structures and Process</a></cite>
+          </li>
+        </ul>
+        <p>
+          Upon receipt of the verifiable credential or presentation secured with
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>], the holder or verifier follows this algorithm:
+        </p>
+        <ol>
+          <li>
+            Follow the algorithm defined in <cite><a data-matched-text="[[[RFC9052]]]" href="https://www.rfc-editor.org/rfc/rfc9052">CBOR Object Signing and Encryption (COSE): Structures and Process</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>] under the
+            Signing and Verification Process for COSE_Sign1.
+          </li>
+          <li>
+            If processing completes successfully:
+            <ol>
+              <li>
+                Set <code>status</code> to <code>true</code>
+              </li>
+              <li>
+                Set <code>mediaType</code> to <code>vc</code> or <code>vp</code>
+              </li>
+              <li>
+                Set <code>document</code> to the decoded COSE_Sign1 payload.
+              </li>
+              <li>
+                Return
+              </li>
+            </ol>
+          </li>
+          <li>
+            If processing aborts for any reason:
+            <ol>
+              <li>
+                Set <code>status</code> to <code>false</code>
+              </li>
+              <li>
+                Set <code>document</code> to <code>null</code>
+              </li>
+              <li>
+                Set <code>mediaType</code> to <code>null</code>
+              </li>
+              <li>
+                Return
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+      <section id="validation"><div class="header-wrapper"><h3 id="validation-algorithm"><bdi class="secno">5.4 </bdi>Validation</h3><a class="self-link" href="#validation-algorithm" aria-label="Permalink for Section 5.4"></a></div>
+      <p>
+        All claims expected for the <code>typ</code> <em class="rfc2119">MUST</em> be present.
+        All claims that are understood <em class="rfc2119">MUST</em> be evaluated according the
+        verifier's validation policies.
+        All claims that are not understood <em class="rfc2119">MUST</em> be ignored.
+      </p>
+      <p>
+        The verified <code>document</code> returned from verification <em class="rfc2119">MUST</em> be a
+        well-formed compact JSON-LD document, as described in
+        <a href="https://www.w3.org/TR/vc-data-model-2.0/#conformance">Verifiable Credentials Data Model v2.0</a>.
+      </p>
+      <p>
+        Schema extension mechanisms such as <code>credentialSchema</code>
+        <em class="rfc2119">SHOULD</em> be checked.
+        If the extension mechanism <code>type</code> is not understood,
+        this property <em class="rfc2119">MUST</em> be ignored.
+      </p>
+      <p>
+        Status extension mechanisms such as <code>credentialStatus</code>
+        <em class="rfc2119">SHOULD</em> be checked.
+        If the extension mechanism <code>type</code> is not understood,
+        this property <em class="rfc2119">MUST</em> be ignored.
+      </p>
+      <p>
+        Based on the validation policy of the verifier, the type of credentials,
+        and the type of securing mechanism, additional validation checks <em class="rfc2119">MAY</em> be
+        applied.
+        For example, dependencies between multiple credentials,
+        ordering or timing information associated with multiple credentials,
+        and/or multiple presentations could cause an otherwise valid credential
+        or presentation to be considered invalid.
+      </p>
+    </section></section>
+    <section class="informative" id="iana-considerations-0"><div class="header-wrapper"><h2 id="iana-considerations"><bdi class="secno">6. </bdi>IANA Considerations</h2><a class="self-link" href="#iana-considerations" aria-label="Permalink for Section 6."></a></div><p><em>This section is non-normative.</em></p>
+      
+      <section id="media-types-0"><div class="header-wrapper"><h3 id="media-types"><bdi class="secno">6.1 </bdi>Media Types</h3><a class="self-link" href="#media-types" aria-label="Permalink for Section 6.1"></a></div>
+        
+        <section id="vc-jwt-media-type"><div class="header-wrapper"><h4 id="vc-json-jwt"><bdi class="secno">6.1.1 </bdi><code>application/vc+jwt</code></h4><a class="self-link" href="#vc-json-jwt" aria-label="Permalink for Section 6.1.1"></a></div>
+          
+          <p>
+            This specification registers the <code>application/vc+jwt</code>
+            Media Type specifically for identifying a <cite><a href="https://www.rfc-editor.org/rfc/rfc7519">JSON Web Token (JWT)</a></cite>
+            with a payload conforming to the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#verifiable-credentials">Verifiable Credential Data Model</a>.
+          </p>
+          <table>
+            <tbody><tr>
+              <td>Type name:</td>
+              <td><code>application</code></td>
+            </tr>
+            <tr>
+              <td>Subtype name:</td>
+              <td><code>vc+jwt</code></td>
+            </tr>
+            <tr>
+              <td>Required parameters:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Optional parameters:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Encoding considerations:</td>
+              <td>
+                binary; <code>application/jwt</code> values are a series of base64url-encoded
+                values (some of which may be the empty string) separated by period ('.').
+              </td>
+            </tr>
+            <tr>
+              <td>Security considerations:</td>
+              <td>
+                <p>
+                  As defined in <a href="#security-considerations">this specification</a>.
+                  See also the security considerations in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>].
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>Interoperability considerations:</td>
+              <td>
+                <p>As defined in <a href="#conformance">this specification</a>.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>Published specification:</td>
+              <td><a href="https://www.w3.org/TR/vc-jose-cose">https://www.w3.org/TR/vc-jose-cose</a></td>
+            </tr>
+            <tr>
+              <td>Applications that will use this media:</td>
+              <td>
+                <p>
+                  <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credential issuer, holder, and verifier software,
+                  conforming to the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>],
+                  are among the applications that will use the media types.
+                  Conforming application types are described
+                  <a href="#conformance">here</a> and <a href="https://www.w3.org/TR/vc-data-model-2.0/#conformance">here</a>.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>Restrictions on usage:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Additional information:</td>
+              <td>
+                <ol type="1">
+                  <li>Deprecated alias names for this type: N/A</li>
+                  <li>Magic number(s): N/A</li>
+                  <li>File extension(s): N/A</li>
+                  <li>Macintosh file type code: N/A</li>
+                  <li>Object Identifiers: N/A</li>
+                </ol>
+              </td>
+            </tr>
+            <tr>
+              <td>Author:</td>
+              <td>Ivan Herman <a href="mailto:ivan@w3.org">ivan@w3.org</a>
+              </td>
+            </tr>
+            <tr>
+              <td>Intended usage:</td>
+              <td>COMMON</td>
+            </tr>
+            <tr>
+              <td>Change controller:</td>
+              <td>
+                <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credentials Working Group <a href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+              </td>
+            </tr>
+          </tbody></table>
+        </section>
+        <section id="vp-jwt-media-type"><div class="header-wrapper"><h4 id="vp-json-jwt"><bdi class="secno">6.1.2 </bdi><code>application/vp+jwt</code></h4><a class="self-link" href="#vp-json-jwt" aria-label="Permalink for Section 6.1.2"></a></div>
+          
+          <p>
+            This specification registers the <code>application/vp+jwt</code>
+            Media Type specifically for identifying a <cite><a href="https://www.rfc-editor.org/rfc/rfc7519">JSON Web Token (JWT)</a></cite>
+            with a payload conforming to the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations">
+            Verifiable Presentations definition in the Verifiable Credential Data Model</a>.
+          </p>
+          <table>
+            <tbody><tr>
+              <td>Type name:</td>
+              <td>application</td>
+            </tr>
+            <tr>
+              <td>Subtype name:</td>
+              <td>vp+jwt</td>
+            </tr>
+            <tr>
+              <td>Required parameters:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Optional parameters:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Encoding considerations:</td>
+              <td>
+                binary; <code>application/jwt</code> values are a series of base64url-encoded
+                values (some of which may be the empty string) separated by period ('.').
+              </td>
+            </tr>
+            <tr>
+              <td>Security considerations:</td>
+              <td>
+                <p>
+                  As defined in <a href="#security-considerations">this specification</a>.
+                  See also the security considerations in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>].
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>Interoperability considerations:</td>
+              <td>
+                <p>As defined in <a href="#conformance">this specification</a>.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>Published specification:</td>
+              <td><a href="https://www.w3.org/TR/vc-jose-cose">https://www.w3.org/TR/vc-jose-cose</a></td>
+            </tr>
+            <tr>
+              <td>Applications that will use this media:</td>
+              <td>
+                <p>
+                  <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credential issuer, holder, and verifier software,
+                  conforming to the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>], are among the
+                  applications that will use the media types.
+                  Conforming application types are described
+                  <a href="#conformance">here</a> and <a href="https://www.w3.org/TR/vc-data-model-2.0/#conformance">here</a>.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>Restrictions on usage:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Additional information:</td>
+              <td>
+                <ol type="1">
+                  <li>Deprecated alias names for this type: N/A</li>
+                  <li>Magic number(s): N/A</li>
+                  <li>File extension(s): N/A</li>
+                  <li>Macintosh file type code: N/A</li>
+                  <li>Object Identifiers: N/A</li>
+                </ol>
+              </td>
+            </tr>
+            <tr>
+              <td>Author:</td>
+              <td>Ivan Herman <a href="mailto:ivan@w3.org">ivan@w3.org</a>
+              </td>
+            </tr>
+            <tr>
+              <td>Intended usage:</td>
+              <td>COMMON</td>
+            </tr>
+            <tr>
+              <td>Change controller:</td>
+              <td>
+                <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credentials Working Group <a href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+              </td>
+            </tr>
+          </tbody></table>
+        </section>
+        <section id="vc-sd-jwt-media-type"><div class="header-wrapper"><h4 id="vc-json-sd-jwt"><bdi class="secno">6.1.3 </bdi><code>application/vc+sd-jwt</code></h4><a class="self-link" href="#vc-json-sd-jwt" aria-label="Permalink for Section 6.1.3"></a></div>
+          
+          <p>
+            This specification registers the <code>application/vc+sd-jwt</code>
+            Media Type specifically for identifying a <cite><a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt">Selective Disclosure for JWTs (SD-JWT)</a></cite>
+            with a payload conforming to the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#verifiable-credentials">Verifiable Credential Data Model</a>.
+          </p>
+          <table>
+            <tbody><tr>
+              <td>Type name:</td>
+              <td><code>application</code></td>
+            </tr>
+            <tr>
+              <td>Subtype name:</td>
+              <td><code>vc+sd-jwt</code></td>
+            </tr>
+            <tr>
+              <td>Required parameters:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Optional parameters:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Encoding considerations:</td>
+              <td>
+                binary; <code>application/sd-jwt</code> values are a series of base64url-encoded
+                values (some of which may be the empty string) separated by
+                period ('.') and tilde ('~') characters.
+              </td>
+            </tr>
+            <tr>
+              <td>Security considerations:</td>
+              <td>
+                <p>
+                  As defined in <a href="#security-considerations">this specification</a>.
+                  See also the security considerations in <cite><a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt">Selective Disclosure for JWTs (SD-JWT)</a></cite>.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>Interoperability considerations:</td>
+              <td>
+                <p>As defined in <a href="#conformance">this specification</a>.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>Published specification:</td>
+              <td><a href="https://www.w3.org/TR/vc-jose-cose">https://www.w3.org/TR/vc-jose-cose</a></td>
+            </tr>
+            <tr>
+              <td>Applications that will use this media:</td>
+              <td>
+                <p>
+                  <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credential issuer, holder, and verifier software,
+                  conforming to the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>], are among the
+                  applications that will use the media types.
+                  Conforming application types are described <a href="#conformance">here</a>
+                  and <a href="https://www.w3.org/TR/vc-data-model-2.0/#conformance">here</a>.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>Restrictions on usage:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Additional information:</td>
+              <td>
+                <ol type="1">
+                  <li>Deprecated alias names for this type: N/A</li>
+                  <li>Magic number(s): N/A</li>
+                  <li>File extension(s): N/A</li>
+                  <li>Macintosh file type code: N/A</li>
+                  <li>Object Identifiers: N/A</li>
+                </ol>
+              </td>
+            </tr>
+            <tr>
+              <td>Author:</td>
+              <td>Ivan Herman <a href="mailto:ivan@w3.org">ivan@w3.org</a>
+              </td>
+            </tr>
+            <tr>
+              <td>Intended usage:</td>
+              <td>COMMON</td>
+            </tr>
+            <tr>
+              <td>Change controller:</td>
+              <td>
+                <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credentials Working Group <a href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+              </td>
+            </tr>
+          </tbody></table>
+        </section>
+        <section id="vp-sd-jwt-media-type"><div class="header-wrapper"><h4 id="vp-json-sd-jwt"><bdi class="secno">6.1.4 </bdi><code>application/vp+sd-jwt</code></h4><a class="self-link" href="#vp-json-sd-jwt" aria-label="Permalink for Section 6.1.4"></a></div>
+          
+          <p>
+            This specification registers the <code>application/vp+sd-jwt</code>
+            Media Type specifically for identifying a <cite><a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt">Selective Disclosure for JWTs (SD-JWT)</a></cite>
+            with a payload conforming to the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations">
+            Verifiable Presentations definition in the Verifiable Credential Data Model</a>.
+          </p>
+          <table>
+            <tbody><tr>
+              <td>Type name:</td>
+              <td>application</td>
+            </tr>
+            <tr>
+              <td>Subtype name:</td>
+              <td>vp+sd-jwt</td>
+            </tr>
+            <tr>
+              <td>Required parameters:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Optional parameters:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Encoding considerations:</td>
+              <td>
+                binary; <code>application/sd-jwt</code> values are a series of base64url-encoded
+                values (some of which may be the empty string) separated by
+                period ('.') and tilde ('~') characters.
+              </td>
+            </tr>
+            <tr>
+              <td>Security considerations:</td>
+              <td>
+                <p>
+                  As defined in <a href="#security-considerations">this specification</a>.
+                  See also the security considerations in <cite><a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt">Selective Disclosure for JWTs (SD-JWT)</a></cite>.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>Interoperability considerations:</td>
+              <td>
+                <p>As defined in <a href="#conformance">this specification</a>.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>Published specification:</td>
+              <td><a href="https://www.w3.org/TR/vc-jose-cose">https://www.w3.org/TR/vc-jose-cose</a></td>
+            </tr>
+            <tr>
+              <td>Applications that will use this media:</td>
+              <td>
+                <p>
+                  <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credential issuer, holder, and verifier software,
+                  conforming to the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>],
+                  are among the applications that will use the media types.
+                  Conforming application types are described
+                  <a href="#conformance">here</a> and
+                  <a href="https://www.w3.org/TR/vc-data-model-2.0/#conformance">here</a>.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>Restrictions on usage:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Additional information:</td>
+              <td>
+                <ol type="1">
+                  <li>Deprecated alias names for this type: N/A</li>
+                  <li>Magic number(s): N/A</li>
+                  <li>File extension(s): N/A</li>
+                  <li>Macintosh file type code: N/A</li>
+                  <li>Object Identifiers: N/A</li>
+                </ol>
+              </td>
+            </tr>
+            <tr>
+              <td>Author:</td>
+              <td>
+                Ivan Herman <a href="mailto:ivan@w3.org">ivan@w3.org</a>
+              </td>
+            </tr>
+            <tr>
+              <td>Intended usage:</td>
+              <td>COMMON</td>
+            </tr>
+            <tr>
+              <td>Change controller:</td>
+              <td>
+                <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credentials Working Group <a href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+              </td>
+            </tr>
+          </tbody></table>
+        </section>
+        <section id="vc-json-cose-media-type"><div class="header-wrapper"><h4 id="vc-json-cose"><bdi class="secno">6.1.5 </bdi><code>application/vc+cose</code></h4><a class="self-link" href="#vc-json-cose" aria-label="Permalink for Section 6.1.5"></a></div>
+          
+          <p>
+            This specification registers the <code>application/vc+cose</code>
+            Media Type specifically for identifying a COSE object [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>]
+            with a payload conforming to the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#verifiable-credentials">Verifiable Credential Data Model</a>.
+          </p>
+          <table>
+            <tbody><tr>
+              <td>Type name:</td>
+              <td><code>application</code></td>
+            </tr>
+            <tr>
+              <td>Subtype name:</td>
+              <td><code>vc+cose</code></td>
+            </tr>
+            <tr>
+              <td>Required parameters:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Optional parameters:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Encoding considerations:</td>
+              <td>binary (CBOR)</td>
+            </tr>
+            <tr>
+              <td>Security considerations:</td>
+              <td>
+                <p>
+                  As defined in <a href="#security-considerations">this specification</a>.
+                  See also the security considerations in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>].
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>Interoperability considerations:</td>
+              <td>
+                <p>As defined in <a href="#conformance">this specification</a>.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>Published specification:</td>
+              <td><a href="https://www.w3.org/TR/vc-jose-cose">https://www.w3.org/TR/vc-jose-cose</a></td>
+            </tr>
+            <tr>
+              <td>Applications that will use this media:</td>
+              <td>
+                <p>
+                  <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credential issuer, holder, and verifier software,
+                  conforming to the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>], are among the
+                  applications that will use the media types. Conforming
+                  application types are described
+                  <a href="#conformance">here</a> and
+                  <a href="https://www.w3.org/TR/vc-data-model-2.0/#conformance">here</a>.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>Restrictions on usage:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Additional information:</td>
+              <td>
+                <ol type="1">
+                  <li>Deprecated alias names for this type: N/A</li>
+                  <li>Magic number(s): N/A</li>
+                  <li>File extension(s): N/A</li>
+                  <li>Macintosh file type code: N/A</li>
+                  <li>Object Identifiers: N/A</li>
+                </ol>
+              </td>
+            </tr>
+            <tr>
+              <td>Author:</td>
+              <td>Ivan Herman <a href="mailto:ivan@w3.org">ivan@w3.org</a>
+              </td>
+            </tr>
+            <tr>
+              <td>Intended usage:</td>
+              <td>COMMON</td>
+            </tr>
+            <tr>
+              <td>Change controller:</td>
+              <td>
+                <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credentials Working Group <a href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+              </td>
+            </tr>
+          </tbody></table>
+        </section>
+        <section id="vp-json-cose-media-type"><div class="header-wrapper"><h4 id="vp-json-cose"><bdi class="secno">6.1.6 </bdi><code>application/vp+cose</code></h4><a class="self-link" href="#vp-json-cose" aria-label="Permalink for Section 6.1.6"></a></div>
+          
+          <p>
+            This specification registers the <code>application/vp+cose</code>
+            Media Type specifically for identifying a COSE object [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>]
+            with a payload conforming to the
+            <a href="https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations">
+            Verifiable Presentations definition in the Verifiable Credential Data Model</a>.
+          </p>
+          <table>
+            <tbody><tr>
+              <td>Type name:</td>
+              <td><code>application</code></td>
+            </tr>
+            <tr>
+              <td>Subtype name:</td>
+              <td><code>vp+cose</code></td>
+            </tr>
+            <tr>
+              <td>Required parameters:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Optional parameters:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Encoding considerations:</td>
+              <td>binary (CBOR)</td>
+            </tr>
+            <tr>
+              <td>Security considerations:</td>
+              <td>
+                <p>
+                  As defined in <a href="#security-considerations">this specification</a>.
+                  See also the security considerations in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc9052" title="CBOR Object Signing and Encryption (COSE): Structures and Process">RFC9052</a></cite>].
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>Interoperability considerations:</td>
+              <td>
+                <p>As defined in <a href="#conformance">this specification</a>.</p>
+              </td>
+            </tr>
+            <tr>
+              <td>Published specification:</td>
+              <td><a href="https://www.w3.org/TR/vc-jose-cose">https://www.w3.org/TR/vc-jose-cose</a></td>
+            </tr>
+            <tr>
+              <td>Applications that will use this media:</td>
+              <td>
+                <p>
+                  <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credential issuer, holder, and verifier software,
+                  conforming to the [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>],
+                  are among the applications that will use the media types.
+                  Conforming application types are described
+                  <a href="#conformance">here</a> and
+                  <a href="https://www.w3.org/TR/vc-data-model-2.0/#conformance">here</a>.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>Restrictions on usage:</td>
+              <td>N/A</td>
+            </tr>
+            <tr>
+              <td>Additional information:</td>
+              <td>
+                <ol type="1">
+                  <li>Deprecated alias names for this type: N/A</li>
+                  <li>Magic number(s): N/A</li>
+                  <li>File extension(s): N/A</li>
+                  <li>Macintosh file type code: N/A</li>
+                  <li>Object Identifiers: N/A</li>
+                </ol>
+              </td>
+            </tr>
+            <tr>
+              <td>Author:</td>
+              <td>Ivan Herman <a href="mailto:ivan@w3.org">ivan@w3.org</a>
+              </td>
+            </tr>
+            <tr>
+              <td>Intended usage:</td>
+              <td>COMMON</td>
+            </tr>
+            <tr>
+              <td>Change controller:</td>
+              <td>
+                <abbr title="World Wide Web Consortium">W3C</abbr> Verifiable Credentials Working Group <a href="mailto:public-vc-wg@w3.org">public-vc-wg@w3.org</a>
+              </td>
+            </tr>
+          </tbody></table>
+        </section>
+      </section>
+    </section>
+    <section class="informative" id="other-considerations-0"><div class="header-wrapper"><h2 id="other-considerations"><bdi class="secno">7. </bdi>Other Considerations</h2><a class="self-link" href="#other-considerations" aria-label="Permalink for Section 7."></a></div><p><em>This section is non-normative.</em></p>
+      
+      <section id="privacy-considerations-0"><div class="header-wrapper"><h3 id="privacy-considerations"><bdi class="secno">7.1 </bdi>Privacy Considerations</h3><a class="self-link" href="#privacy-considerations" aria-label="Permalink for Section 7.1"></a></div>
+        
+        <p>
+          Verifiable Credentials often contain sensitive information that
+          needs to be protected to ensure the privacy and security of
+          organizations and individuals. This section outlines some privacy
+          considerations relevant to implementers and users.
+        </p>
+        <p>
+          Implementers are advised to note and abide by all privacy
+          considerations called out in [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+        </p>
+        <p>
+          Implementers are additionally advised to reference the
+          <a href="https://www.rfc-editor.org/rfc/rfc7519#section-12">Privacy Consideration</a>
+          section of the JWT specification and NIST Special Publication 800-122
+          [[SP-800-122] "Guide to Protecting the Confidentiality of Personally
+          Identifiable Information (PII)" for privacy guidance.
+        </p>
+        <p>
+          In addition to the privacy recommendations in the
+          [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>], the following considerations are given:
+        </p><ul>
+          <li>
+            <p>
+              Minimization of data: It is considered best practice for
+              Verifiable Credentials to only contain the minimum amount of
+              data necessary to achieve their intended purpose.
+              This helps to limit the amount of sensitive information that is
+              shared or stored unnecessarily.
+            </p>
+          </li>
+          <li>
+            <p>
+              Informed consent: It is considered best practice that
+              individuals be fully informed about how their data will be
+              used and provide the ability to consent to or decline the
+              use of their data.
+              This helps to ensure that individuals maintain control over their
+              own personal information.
+            </p>
+          </li>
+          <li>
+            <p>
+              Data protection: It is considered best practice to protect
+              Verifiable Credentials using strong encryption and other
+              security measures to prevent unauthorized access,
+              modification, or disclosure.
+            </p>
+          </li>
+        </ul>
+        <p>
+          These considerations are not exhaustive, and implementers and
+          users are advised to consult additional privacy resources and
+          best practices to ensure the privacy and security of Verifiable
+          Credentials implemented using this specification.
+        </p>
+      </section>
+      <section id="security-considerations-0"><div class="header-wrapper"><h3 id="security-considerations"><bdi class="secno">7.2 </bdi>Security Considerations</h3><a class="self-link" href="#security-considerations" aria-label="Permalink for Section 7.2"></a></div>
+        
+        <p>
+          This section outlines security considerations for implementers
+          and users of this specification.
+          It is important to carefully consider these factors to ensure the
+          security and integrity of Verifiable Credentials when implemented
+          using JOSE or COSE.
+        </p>
+        <p>
+          When implementing this specification, it is essential to address all
+          security issues relevant to broad cryptographic applications.
+          This especially includes protecting the user's asymmetric
+          private and symmetric secret keys, as well as employing
+          countermeasures against various attacks.
+          Failure to adequately address these issues could compromise the
+          security and integrity of Verifiable Credentials, potentially leading
+          to unauthorized access, modification, or disclosure of sensitive information.
+        </p>
+        <p>
+          Implementers are advised to follow best practices and
+          established cryptographic standards to ensure the secure
+          handling of keys and other sensitive data.
+          Additionally, conduct regular security assessments and audits to
+          identify and address any vulnerabilities or threats.
+        </p>
+        <p>
+          Follow all security considerations outlined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7515" title="JSON Web Signature (JWS)">RFC7515</a></cite>] and [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7519" title="JSON Web Token (JWT)">RFC7519</a></cite>].
+        </p>
+        <p>
+          When utilizing JSON-LD, take special care around remote retrieval of
+          contexts and follow the additional security considerations noted in [<cite><a class="bibref" data-link-type="biblio" href="#bib-json-ld11" title="JSON-LD 1.1">JSON-LD11</a></cite>].
+        </p>
+        <p>
+          As noted in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7515" title="JSON Web Signature (JWS)">RFC7515</a></cite>] when utilizing JSON [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7159" title="The JavaScript Object Notation (JSON) Data Interchange Format">RFC7159</a></cite>], strict
+          validation is a security requirement.
+          If malformed JSON is received, it may be impossible to reliably
+          interpret the producer's intent, potentially leading to ambiguous or
+          exploitable situations.
+          To prevent these risks, it is essential to use a JSON parser that
+          strictly validates the syntax of all input data.
+          It is essential that any JSON inputs that do not conform to the
+          JSON-text syntax defined in [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc7159" title="The JavaScript Object Notation (JSON) Data Interchange Format">RFC7159</a></cite>] be rejected in their entirety by JSON parsers.
+          Failure to reject invalid input could compromise the security and
+          integrity of Verifiable Credentials.
+        </p>
+      </section>
+      <section id="accessibility-0"><div class="header-wrapper"><h3 id="accessibility"><bdi class="secno">7.3 </bdi>Accessibility</h3><a class="self-link" href="#accessibility" aria-label="Permalink for Section 7.3"></a></div>
+        
+        <p>
+          When implementing this specification, it is crucial for
+          technical implementers to consider various accessibility factors.
+          Ignoring accessibility concerns renders the information unusable for
+          a significant portion of the population.
+          To ensure equal access for all individuals, regardless of their abilities,
+          it is vital to adhere to accessibility guidelines and standards,
+          such as the Web Content Accessibility Guidelines (WCAG 2.1) [<cite><a class="bibref" data-link-type="biblio" href="#bib-wcag21" title="Web Content Accessibility Guidelines (WCAG) 2.1">WCAG21</a></cite>].
+          This becomes even more critical when establishing systems that involve
+          cryptography, as they have historically posed challenges for assistive technologies.
+        </p>
+        <p>
+          Implementers are advised to note and abide by all accessibility
+          considerations called out in [<cite><a class="bibref" data-link-type="biblio" href="#bib-vc-data-model-2.0" title="Verifiable Credentials Data Model v2.0">VC-DATA-MODEL-2.0</a></cite>].
+        </p>
+      </section>
+    </section>
+    <section class="informative" id="examples-0"><div class="header-wrapper"><h2 id="examples"><bdi class="secno">8. </bdi>Examples</h2><a class="self-link" href="#examples" aria-label="Permalink for Section 8."></a></div><p><em>This section is non-normative.</em></p>
+      
+      <section id="controllers-0"><div class="header-wrapper"><h3 id="controllers"><bdi class="secno">8.1 </bdi>Controllers</h3><a class="self-link" href="#controllers" aria-label="Permalink for Section 8.1"></a></div>
+        
+        <div class="example" id="example-a-minimal-controlled-identifier-document">
+        <div class="marker">
+    <a class="self-link" href="#example-a-minimal-controlled-identifier-document">Example<bdi> 15</bdi></a><span class="example-title">: A minimal controlled identifier document</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://vendor.example"</span><span class="hljs-punctuation">,</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+        <div class="example" id="example-a-controlled-identifier-document-with-verification-method">
+        <div class="marker">
+    <a class="self-link" href="#example-a-controlled-identifier-document-with-verification-method">Example<bdi> 16</bdi></a><span class="example-title">: A controlled identifier document with verification method</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/issuers/565049"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"verificationMethod"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/issuers/565049#key-123"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"JsonWebKey"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"controller"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/issuers/565049"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"publicKeyJwk"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"kty"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EC"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"crv"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"P-384"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"alg"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ES384"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"x"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"PxgAmVYOQvSNcMYL2tOzoLwSWn4Ta3tIMPEUKR8pxeb-gmR11-DyKHBoIiY-2LhM"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"y"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"BZEBTkImVdpwvxR9THIRw16eblnj5-tZa7m-ww5uVd4kyPJNRoWUn2aT9ZuarAe-"</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">]</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+        <div class="example" id="example-a-controlled-identifier-document-with-verification-relationships">
+        <div class="marker">
+    <a class="self-link" href="#example-a-controlled-identifier-document-with-verification-relationships">Example<bdi> 17</bdi></a><span class="example-title">: A controlled identifier document with verification relationships</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/issuers/565049"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"verificationMethod"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/issuers/565049#key-123"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"JsonWebKey"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"controller"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://university.example/issuers/565049"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"publicKeyJwk"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"kty"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EC"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"crv"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"P-384"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"alg"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ES384"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"x"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"PxgAmVYOQvSNcMYL2tOzoLwSWn4Ta3tIMPEUKR8pxeb-gmR11-DyKHBoIiY-2LhM"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"y"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"BZEBTkImVdpwvxR9THIRw16eblnj5-tZa7m-ww5uVd4kyPJNRoWUn2aT9ZuarAe-"</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"authentication"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"https://university.example/issuers/565049#key-123"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"assertionMethod"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"https://university.example/issuers/565049#key-123"</span><span class="hljs-punctuation">]</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+        <div class="example" id="example-a-verifiable-credential-controlled-identifier-document">
+        <div class="marker">
+    <a class="self-link" href="#example-a-verifiable-credential-controlled-identifier-document">Example<bdi> 18</bdi></a><span class="example-title">: A verifiable credential controlled identifier document</span>
+  </div> <pre aria-busy="false"><code class="hljs json"><span class="hljs-punctuation">{</span>
+  <span class="hljs-attr">"@context"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span>
+    <span class="hljs-string">"https://www.w3.org/ns/did/v1"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-string">"https://w3id.org/security/jwk/v1"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-punctuation">{</span>
+        <span class="hljs-attr">"@vocab"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://vendor.example#"</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:vendor.example"</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"alsoKnownAs"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"https://vendor.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-string">"did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ"</span>
+  <span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"verificationMethod"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"#urn:ietf:params:oauth:jwk-thumbprint:sha-256:NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"JsonWebKey"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"controller"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:vendor.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"publicKeyJwk"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"kty"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EC"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"crv"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"P-521"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"alg"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ES512"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"x"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"AFTyMw-fIYJNg6fBVJvOPOsLxmnNj8HgqMChyRL0swLaefVAc7wrWZ8okQJqMmvv03JRUp277meQZM3JcvXFkH1v"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"y"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ALn96CrD88b4TClmkl1sk0xk2FgAIda97ZF8TUOjbeWSzbKnN2KB6pqlpbuJ2xIRXvsn5BWQVlAT2JGpGwDNMyV1"</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">,</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"#z6MkhEdpG12jyQegrr62ACRmNY8gc531W2j9Xo39cHphuCEH"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"JsonWebKey2020"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"controller"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"https://vendor.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"publicKeyJwk"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"kid"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"urn:ietf:params:oauth:jwk-thumbprint:sha-256:FfMbzOjMmQ4efT6kvwTIJjelTqjl0xjEIWQ2qobsRMM"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"kty"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"OKP"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"crv"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"Ed25519"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"alg"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EdDSA"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"x"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ANRjH_zxcKBxsjRPUtzRbp7FSVLKJXQ9APX9MP1j7k4"</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">,</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"#subject-authentication"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"JsonWebKey"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"controller"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:vendor.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"publicKeyJwk"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"kty"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EC"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"crv"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"P-384"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"alg"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ES384"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"x"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"PxgAmVYOQvSNcMYL2tOzoLwSWn4Ta3tIMPEUKR8pxeb-gmR11-DyKHBoIiY-2LhM"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"y"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"BZEBTkImVdpwvxR9THIRw16eblnj5-tZa7m-ww5uVd4kyPJNRoWUn2aT9ZuarAe-"</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">,</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"#credential-issuance"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"JsonWebKey"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"controller"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:vendor.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"publicKeyJwk"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"kty"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"EC"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"crv"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"P-256"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"alg"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ES256"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"x"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"MYvnaI87pfrn3FpTqW-yNiFcF1K7fedJiqapm20_q7c"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"y"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"9YEbT6Tyuc7xp9yRvhOUVKK_NIHkn5HpK9ZMgvK5pVw"</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">,</span> <span class="hljs-punctuation">{</span>
+    <span class="hljs-attr">"id"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"#key-agreement"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"type"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"JsonWebKey"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"controller"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"did:web:vendor.example"</span><span class="hljs-punctuation">,</span>
+    <span class="hljs-attr">"publicKeyJwk"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">{</span>
+      <span class="hljs-attr">"kty"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"OKP"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"crv"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"X25519"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"alg"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"ECDH-ES+A128KW"</span><span class="hljs-punctuation">,</span>
+      <span class="hljs-attr">"x"</span><span class="hljs-punctuation">:</span> <span class="hljs-string">"qLZkSTbstvMWPTivmiQglEFWG2Ff7gNDVoVisdZTr1I"</span>
+    <span class="hljs-punctuation">}</span>
+  <span class="hljs-punctuation">}</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"authentication"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"#subject-authentication"</span><span class="hljs-punctuation">]</span><span class="hljs-punctuation">,</span>
+  <span class="hljs-attr">"assertionMethod"</span><span class="hljs-punctuation">:</span> <span class="hljs-punctuation">[</span><span class="hljs-string">"#credential-issuance"</span><span class="hljs-punctuation">]</span>
+<span class="hljs-punctuation">}</span></code></pre>
+      </div>
+      </section>
+      <section id="credentials-0"><div class="header-wrapper"><h3 id="credentials"><bdi class="secno">8.2 </bdi>Credentials</h3><a class="self-link" href="#credentials" aria-label="Permalink for Section 8.2"></a></div>
+        
+        <div class="example" id="example-a-revocable-credential-with-multiple-subjects">
+        <div class="marker">
+    <a class="self-link" href="#example-a-revocable-credential-with-multiple-subjects">Example<bdi> 19</bdi></a><span class="example-title">: A revocable credential with multiple subjects</span>
+  </div> 
+      <div class="vc-tabbed"><input type="radio" id="vc-tab10unsigned" name="vc-tabs10" checked=""><input type="radio" id="vc-tab10jose" name="vc-tabs10"><input type="radio" id="vc-tab10cose" name="vc-tabs10"><input type="radio" id="vc-tab10sd-jwt" name="vc-tabs10"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab10unsigned"><abbr title="Unsecured credential">Credential</abbr></label></li><li class="vc-tab"><label for="vc-tab10jose"><abbr title="Secured with JOSE">jose</abbr></label></li><li class="vc-tab"><label for="vc-tab10cose"><abbr title="Secured with COSE">cose</abbr></label></li><li class="vc-tab"><label for="vc-tab10sd-jwt"><abbr title="Secured with SD-JWT">sd-jwt</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 540px;"><pre class="nohighlight vc" data-vc-tabs="jose sd-jwt cose">{
+  "@context": ["https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "https://contoso.example/credentials/23894672394",
+  "type": ["VerifiableCredential", "K9UnitCredential"],
+  "issuer": {
+    "id": "https://contoso.example"
+  },
+  "validFrom": "2015-04-16T05:11:32.432Z",
+  "credentialStatus": {
+    "id": "https://contoso.example/credentials/status/4#273762",
+    "type": "StatusList2021Entry",
+    "statusPurpose": "revocation",
+    "statusListIndex": "273762",
+    "statusListCredential": "https://contoso.example/credentials/status/4"
+  },
+  "credentialSubject": [{
+    "id": "did:example:1312387641",
+    "type": "Person"
+  }, {
+    "id": "did:example:63888231",
+    "type": "Dog"
+  }]
+}</pre></div><div class="vc-tab-content" style="min-height: 540px;">
+<div class="vc-jose-cose-jwt-tabbed">
+    <div class="vc-jose-cose-jwt-tab-content">
+<strong>Protected Headers</strong>
+<pre>{
+  "kid": "ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",
+  "alg": "ES256"
+}
+</pre>
+<strong>application/vc</strong>
+<pre>{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "https://contoso.example/credentials/23894672394",
+  "type": [
+    "VerifiableCredential",
+    "K9UnitCredential"
+  ],
+  "issuer": {
+    "id": "https://contoso.example"
+  },
+  "validFrom": "2015-04-16T05:11:32.432Z",
+  "credentialStatus": {
+    "id": "https://contoso.example/credentials/status/4#273762",
+    "type": "StatusList2021Entry",
+    "statusPurpose": "revocation",
+    "statusListIndex": "273762",
+    "statusListCredential": "https://contoso.example/credentials/status/4"
+  },
+  "credentialSubject": [
+    {
+      "id": "did:example:1312387641",
+      "type": "Person"
+    },
+    {
+      "id": "did:example:63888231",
+      "type": "Dog"
+    }
+  ]
+}
+</pre>
+<strong>application/vc+jwt</strong>
+<div class="jose-text">
+<div class="jwt-compact">
+<span class="jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
+.<span class="jwt-payload">eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9jcmVkZW50aWFscy8yMzg5NDY3MjM5NCIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJLOVVuaXRDcmVkZW50aWFsIl0sImlzc3VlciI6eyJpZCI6Imh0dHBzOi8vY29udG9zby5leGFtcGxlIn0sInZhbGlkRnJvbSI6IjIwMTUtMDQtMTZUMDU6MTE6MzIuNDMyWiIsImNyZWRlbnRpYWxTdGF0dXMiOnsiaWQiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9jcmVkZW50aWFscy9zdGF0dXMvNCMyNzM3NjIiLCJ0eXBlIjoiU3RhdHVzTGlzdDIwMjFFbnRyeSIsInN0YXR1c1B1cnBvc2UiOiJyZXZvY2F0aW9uIiwic3RhdHVzTGlzdEluZGV4IjoiMjczNzYyIiwic3RhdHVzTGlzdENyZWRlbnRpYWwiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9jcmVkZW50aWFscy9zdGF0dXMvNCJ9LCJjcmVkZW50aWFsU3ViamVjdCI6W3siaWQiOiJkaWQ6ZXhhbXBsZToxMzEyMzg3NjQxIiwidHlwZSI6IlBlcnNvbiJ9LHsiaWQiOiJkaWQ6ZXhhbXBsZTo2Mzg4ODIzMSIsInR5cGUiOiJEb2cifV19</span>
+.<span class="jwt-signature">2nCCKfLd1xSpBDpuEdo3_jSBqwUIZfG57xDMmwNmGAx58rQyW7kwq0ySx1boOxhgMyfRZTzFiHwtkHA0lADlcA</span>
+</div>
+</div>
+    </div>
+</div></div><div class="vc-tab-content" style="min-height: 540px;">
+<div class="vc-jose-cose-cose-tabbed">
+    <div class="vc-jose-cose-cose-tab-content">
+<strong>application/vc</strong>
+<pre>{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "https://contoso.example/credentials/23894672394",
+  "type": [
+    "VerifiableCredential",
+    "K9UnitCredential"
+  ],
+  "issuer": {
+    "id": "https://contoso.example"
+  },
+  "validFrom": "2015-04-16T05:11:32.432Z",
+  "credentialStatus": {
+    "id": "https://contoso.example/credentials/status/4#273762",
+    "type": "StatusList2021Entry",
+    "statusPurpose": "revocation",
+    "statusListIndex": "273762",
+    "statusListCredential": "https://contoso.example/credentials/status/4"
+  },
+  "credentialSubject": [
+    {
+      "id": "did:example:1312387641",
+      "type": "Person"
+    },
+    {
+      "id": "did:example:63888231",
+      "type": "Dog"
+    }
+  ]
+}
+</pre>
+<strong>application/vc+cose</strong>
+<div class="cose-text">
+d28444a1013822a059027c7b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f63726564656e7469616c732f3233383934363732333934222c2274797065223a5b2256657269666961626c6543726564656e7469616c222c224b39556e697443726564656e7469616c225d2c22697373756572223a7b226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c65227d2c2276616c696446726f6d223a22323031352d30342d31365430353a31313a33322e3433325a222c2263726564656e7469616c537461747573223a7b226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f63726564656e7469616c732f7374617475732f3423323733373632222c2274797065223a225374617475734c69737432303231456e747279222c22737461747573507572706f7365223a227265766f636174696f6e222c227374617475734c697374496e646578223a22323733373632222c227374617475734c69737443726564656e7469616c223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f63726564656e7469616c732f7374617475732f34227d2c2263726564656e7469616c5375626a656374223a5b7b226964223a226469643a6578616d706c653a31333132333837363431222c2274797065223a22506572736f6e227d2c7b226964223a226469643a6578616d706c653a3633383838323331222c2274797065223a22446f67227d5d7d5840631cba48a4f4f3942b8574ac576ca3becd1cb14ffc5bdeec456915129bfc491abd3931391a5c8ef1e1108591274cc6676941d99bf6efd6d3f650b54e930a01ee
+</div>
+    </div>
+</div></div><div class="vc-tab-content" style="min-height: 540px;"><div>
+
+<div class="sd-jwt-tabbed">
+    <input type="radio" id="sd-jwt-10-iinktqp-encoded" name="sd-jwt-10-iinktqp-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="sd-jwt-10-iinktqp-decoded" name="sd-jwt-10-iinktqp-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-10-iinktqp-disclosures" name="sd-jwt-10-iinktqp-tabs" tabindex="0">
+    <ul class="sd-jwt-tabs">
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-10-iinktqp-encoded">Encoded</label>
+      </li>
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-10-iinktqp-decoded">Decoded</label>
+      </li>
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-10-iinktqp-disclosures">Issuer Disclosures</label>
+      </li>
+    </ul>
+    <div class="sd-jwt-tab-content" id="sd-jwt-10-iinktqp-content-encoded">
+      
+<div class="sd-jwt-compact">
+<span class="sd-jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
+.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1NjU5NzksImV4cCI6MTc0Njc3NTU3OSwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjp7Il9zZCI6WyIxSXJZbWlEdTB0czZrRHJReGl2Q29vWTkzN3JRRmU2QVJxRkpjNWRsQmVnIl19LCJ2YWxpZEZyb20iOiIyMDE1LTA0LTE2VDA1OjExOjMyLjQzMloiLCJjcmVkZW50aWFsU3RhdHVzIjp7InN0YXR1c1B1cnBvc2UiOiJyZXZvY2F0aW9uIiwic3RhdHVzTGlzdEluZGV4IjoiMjczNzYyIiwic3RhdHVzTGlzdENyZWRlbnRpYWwiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9jcmVkZW50aWFscy9zdGF0dXMvNCIsIl9zZCI6WyI2d3UxM09ETVplWFItd2JaYkV2R0liczZvRzRDcEpFTGUydmk5Qm0yVk5jIiwiZC1ZaEtIeVh3TjZfN3k3aHQzSFhBWXBmWlBSNHF1RWNIU3FTMmNpSGNNZyJdfSwiY3JlZGVudGlhbFN1YmplY3QiOlt7Il9zZCI6WyJGUUxGSlVFOFNiczg0VXRyVXE4eXRYQ3pleUlTc1E5NzVzZ3ZPdm9rWldvIiwiT093dlFHbnFrMzJvWmVSdFpfbE1zNVRKbXRzU1B6OE5naGpxN3FXdGpJayJdfSx7Il9zZCI6WyJLazZacDFSN0NoaGVsNVFESzVVaWMzM2RTNlRwQm1lLUJHMFo3ZTkwU1pJIiwiZDNRUTR0MU5SX2hyOU9qQVYzT0pvek9DMkVSbWhrTVMwSWdvZUJHVXZSYyJdfV0sIl9zZCI6WyJUejdWaTBjSHY1SUtpc3FtRXlkX2JFYjRpTk9aRjM3U2loX1haVWduQW9vIiwielFvTGJLSXJZdHdmVHo0MWRudmFGQkhBZU51TTBRczJNQUExdEdOcE5NayJdfQ</span>
+.<span class="sd-jwt-signature">ErZqDE7lZt75i64nSqE5pC95vkLsNG9bP12ZrM0RS7nypW3EPYS4g46scjGS-IZ8zmZXnerqLOnQc-cc40GyPg</span>
+~<span class="sd-jwt-disclosure">WyJaZmM1VUdWOXlxNkF0RmJUcGdNc3p3IiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzLzIzODk0NjcyMzk0Il0</span>~<span class="sd-jwt-disclosure">WyJYMmhmenNabTdkTkU2dWtFdkxuV0lnIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIks5VW5pdENyZWRlbnRpYWwiXV0</span>~<span class="sd-jwt-disclosure">WyJkWlBPZ1pnZnhFazBUdklSMVpmdnhBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlIl0</span>~<span class="sd-jwt-disclosure">WyJNYmtGMUFrOGxRSVdiSzcwYWtJZUZ3IiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzL3N0YXR1cy80IzI3Mzc2MiJd</span>~<span class="sd-jwt-disclosure">WyJqaGhGaXNyZTBjWDMzYjJwcm9TSkpBIiwgInR5cGUiLCAiU3RhdHVzTGlzdDIwMjFFbnRyeSJd</span>~<span class="sd-jwt-disclosure">WyJ6cEdPMVBKNVZnTmVfOHVlREVsTy1RIiwgImlkIiwgImRpZDpleGFtcGxlOjEzMTIzODc2NDEiXQ</span>~<span class="sd-jwt-disclosure">WyJPVU1OMkk0ZTVKMmVWUlhEVHJ5ZG9RIiwgInR5cGUiLCAiUGVyc29uIl0</span>~<span class="sd-jwt-disclosure">WyJkSlhGXy1VT1VubFVCX0UzcWhZQXNBIiwgImlkIiwgImRpZDpleGFtcGxlOjYzODg4MjMxIl0</span>~<span class="sd-jwt-disclosure">WyJTTWNwR1ctOTJfaFNqSnlWa2JiNDdRIiwgInR5cGUiLCAiRG9nIl0</span>~
+</div>
+    </div>
+    <div class="sd-jwt-tab-content" id="sd-jwt-10-iinktqp-content-decoded">
+      <pre class="header-value">{<br>&nbsp;&nbsp;"kid":&nbsp;"ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",<br>&nbsp;&nbsp;"alg":&nbsp;"ES256"<br>}</pre>
+      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745565979,<br>&nbsp;&nbsp;"exp":&nbsp;1746775579,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"issuer":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"1IrYmiDu0ts6kDrQxivCooY937rQFe6ARqFJc5dlBeg"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"validFrom":&nbsp;"2015-04-16T05:11:32.432Z",<br>&nbsp;&nbsp;"credentialStatus":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"statusPurpose":&nbsp;"revocation",<br>&nbsp;&nbsp;&nbsp;&nbsp;"statusListIndex":&nbsp;"273762",<br>&nbsp;&nbsp;&nbsp;&nbsp;"statusListCredential":&nbsp;"https://contoso.example/credentials/status/4",<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"6wu13ODMZeXR-wbZbEvGIbs6oG4CpJELe2vi9Bm2VNc",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"d-YhKHyXwN6_7y7ht3HXAYpfZPR4quEcHSqS2ciHcMg"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"credentialSubject":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"FQLFJUE8Sbs84UtrUq8ytXCzeyISsQ975sgvOvokZWo",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"OOwvQGnqk32oZeRtZ_lMs5TJmtsSPz8Nghjq7qWtjIk"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Kk6Zp1R7Chhel5QDK5Uic33dS6TpBme-BG0Z7e90SZI",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"d3QQ4t1NR_hr9OjAV3OJozOC2ERmhkMS0IgoeBGUvRc"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"Tz7Vi0cHv5IKisqmEyd_bEb4iNOZF37Sih_XZUgnAoo",<br>&nbsp;&nbsp;&nbsp;&nbsp;"zQoLbKIrYtwfTz41dnvaFBHAeNuM0Qs2MAA1tGNpNMk"<br>&nbsp;&nbsp;]<br>}</pre>
+    </div>
+    <div class="sd-jwt-tab-content" id="sd-jwt-10-iinktqp-content-disclosures">
+      <div class="disclosures">
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-zQoLbKIrYtwfTz41dnvaFBHAeNuM0Qs2MAA1tGNpNMk">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">zQoLbKIrYtwfTz41dnvaFBHAeNuM0Qs2MAA1tGNpNMk</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJaZmM1VUdWOXlxNkF0RmJUcGdNc3p3IiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzLzIzODk0NjcyMzk0Il0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"Zfc5UGV9yq6AtFbTpgMszw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example/credentials/23894672394"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-Tz7Vi0cHv5IKisqmEyd_bEb4iNOZF37Sih_XZUgnAoo">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">Tz7Vi0cHv5IKisqmEyd_bEb4iNOZF37Sih_XZUgnAoo</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJYMmhmenNabTdkTkU2dWtFdkxuV0lnIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIks5VW5pdENyZWRlbnRpYWwiXV0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"X2hfzsZm7dNE6ukEvLnWIg",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"VerifiableCredential",<br>&nbsp;&nbsp;&nbsp;&nbsp;"K9UnitCredential"<br>&nbsp;&nbsp;]<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-1IrYmiDu0ts6kDrQxivCooY937rQFe6ARqFJc5dlBeg">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">1IrYmiDu0ts6kDrQxivCooY937rQFe6ARqFJc5dlBeg</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJkWlBPZ1pnZnhFazBUdklSMVpmdnhBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"dZPOgZgfxEk0TvIR1ZfvxA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-6wu13ODMZeXR-wbZbEvGIbs6oG4CpJELe2vi9Bm2VNc">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">6wu13ODMZeXR-wbZbEvGIbs6oG4CpJELe2vi9Bm2VNc</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJNYmtGMUFrOGxRSVdiSzcwYWtJZUZ3IiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzL3N0YXR1cy80IzI3Mzc2MiJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"MbkF1Ak8lQIWbK70akIeFw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example/credentials/status/4#273762"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-d-YhKHyXwN6_7y7ht3HXAYpfZPR4quEcHSqS2ciHcMg">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">d-YhKHyXwN6_7y7ht3HXAYpfZPR4quEcHSqS2ciHcMg</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJqaGhGaXNyZTBjWDMzYjJwcm9TSkpBIiwgInR5cGUiLCAiU3RhdHVzTGlzdDIwMjFFbnRyeSJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"jhhFisre0cX33b2proSJJA",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"StatusList2021Entry"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-OOwvQGnqk32oZeRtZ_lMs5TJmtsSPz8Nghjq7qWtjIk">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">OOwvQGnqk32oZeRtZ_lMs5TJmtsSPz8Nghjq7qWtjIk</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ6cEdPMVBKNVZnTmVfOHVlREVsTy1RIiwgImlkIiwgImRpZDpleGFtcGxlOjEzMTIzODc2NDEiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"zpGO1PJ5VgNe_8ueDElO-Q",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"did:example:1312387641"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-FQLFJUE8Sbs84UtrUq8ytXCzeyISsQ975sgvOvokZWo">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">FQLFJUE8Sbs84UtrUq8ytXCzeyISsQ975sgvOvokZWo</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJPVU1OMkk0ZTVKMmVWUlhEVHJ5ZG9RIiwgInR5cGUiLCAiUGVyc29uIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"OUMN2I4e5J2eVRXDTrydoQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"Person"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-Kk6Zp1R7Chhel5QDK5Uic33dS6TpBme-BG0Z7e90SZI">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">Kk6Zp1R7Chhel5QDK5Uic33dS6TpBme-BG0Z7e90SZI</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJkSlhGXy1VT1VubFVCX0UzcWhZQXNBIiwgImlkIiwgImRpZDpleGFtcGxlOjYzODg4MjMxIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"dJXF_-UOUnlUB_E3qhYAsA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"did:example:63888231"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-d3QQ4t1NR_hr9OjAV3OJozOC2ERmhkMS0IgoeBGUvRc">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">d3QQ4t1NR_hr9OjAV3OJozOC2ERmhkMS0IgoeBGUvRc</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJTTWNwR1ctOTJfaFNqSnlWa2JiNDdRIiwgInR5cGUiLCAiRG9nIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"SMcpGW-92_hSjJyVkbb47Q",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"Dog"<br>]</span></p>
+</div>
+</div>
+    </div>
+</div>
+
+</div></div></div></div>
+        <div class="example" id="example-a-credential-with-a-schema">
+        <div class="marker">
+    <a class="self-link" href="#example-a-credential-with-a-schema">Example<bdi> 20</bdi></a><span class="example-title">: A credential with a schema</span>
+  </div> 
+      <div class="vc-tabbed"><input type="radio" id="vc-tab11unsigned" name="vc-tabs11" checked=""><input type="radio" id="vc-tab11jose" name="vc-tabs11"><input type="radio" id="vc-tab11cose" name="vc-tabs11"><input type="radio" id="vc-tab11sd-jwt" name="vc-tabs11"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab11unsigned"><abbr title="Unsecured credential">Credential</abbr></label></li><li class="vc-tab"><label for="vc-tab11jose"><abbr title="Secured with JOSE">jose</abbr></label></li><li class="vc-tab"><label for="vc-tab11cose"><abbr title="Secured with COSE">cose</abbr></label></li><li class="vc-tab"><label for="vc-tab11sd-jwt"><abbr title="Secured with SD-JWT">sd-jwt</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 410px;"><pre class="nohighlight vc" data-vc-tabs="jose sd-jwt cose">{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "https://contoso.example/credentials/35327255",
+  "type": ["VerifiableCredential", "KYCExample"],
+  "issuer": "did:web:contoso.example",
+  "validFrom": "2019-05-25T03:10:16.992Z",
+  "validUntil": "2027-05-25T03:10:16.992Z",
+  "credentialSchema": {
+    "id": "https://contoso.example/bafybeigdyr...lqabf3oclgtqy55fbzdi",
+    "type": "JsonSchema"
+  },
+  "credentialSubject": {
+    "id": "did:example:1231588",
+    "type": "Person"
+  }
+}</pre></div><div class="vc-tab-content" style="min-height: 410px;">
+<div class="vc-jose-cose-jwt-tabbed">
+    <div class="vc-jose-cose-jwt-tab-content">
+<strong>Protected Headers</strong>
+<pre>{
+  "kid": "ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",
+  "alg": "ES256"
+}
+</pre>
+<strong>application/vc</strong>
+<pre>{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "https://contoso.example/credentials/35327255",
+  "type": [
+    "VerifiableCredential",
+    "KYCExample"
+  ],
+  "issuer": "did:web:contoso.example",
+  "validFrom": "2019-05-25T03:10:16.992Z",
+  "validUntil": "2027-05-25T03:10:16.992Z",
+  "credentialSchema": {
+    "id": "https://contoso.example/bafybeigdyr...lqabf3oclgtqy55fbzdi",
+    "type": "JsonSchema"
+  },
+  "credentialSubject": {
+    "id": "did:example:1231588",
+    "type": "Person"
+  }
+}
+</pre>
+<strong>application/vc+jwt</strong>
+<div class="jose-text">
+<div class="jwt-compact">
+<span class="jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
+.<span class="jwt-payload">eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaWQiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9jcmVkZW50aWFscy8zNTMyNzI1NSIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJLWUNFeGFtcGxlIl0sImlzc3VlciI6ImRpZDp3ZWI6Y29udG9zby5leGFtcGxlIiwidmFsaWRGcm9tIjoiMjAxOS0wNS0yNVQwMzoxMDoxNi45OTJaIiwidmFsaWRVbnRpbCI6IjIwMjctMDUtMjVUMDM6MTA6MTYuOTkyWiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiaWQiOiJodHRwczovL2NvbnRvc28uZXhhbXBsZS9iYWZ5YmVpZ2R5ci4uLmxxYWJmM29jbGd0cXk1NWZiemRpIiwidHlwZSI6Ikpzb25TY2hlbWEifSwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6ZXhhbXBsZToxMjMxNTg4IiwidHlwZSI6IlBlcnNvbiJ9fQ</span>
+.<span class="jwt-signature">hGoe60DdeGw1QK5Ni59upvSP5-DdXQcpJHqDXHTgIzyuEK5bL0w5pjyMQg3pboNF6TEoGEb122YIMuPs9QYedA</span>
+</div>
+</div>
+    </div>
+</div></div><div class="vc-tab-content" style="min-height: 410px;">
+<div class="vc-jose-cose-cose-tabbed">
+    <div class="vc-jose-cose-cose-tab-content">
+<strong>application/vc</strong>
+<pre>{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "https://contoso.example/credentials/35327255",
+  "type": [
+    "VerifiableCredential",
+    "KYCExample"
+  ],
+  "issuer": "did:web:contoso.example",
+  "validFrom": "2019-05-25T03:10:16.992Z",
+  "validUntil": "2027-05-25T03:10:16.992Z",
+  "credentialSchema": {
+    "id": "https://contoso.example/bafybeigdyr...lqabf3oclgtqy55fbzdi",
+    "type": "JsonSchema"
+  },
+  "credentialSubject": {
+    "id": "did:example:1231588",
+    "type": "Person"
+  }
+}
+</pre>
+<strong>application/vc+cose</strong>
+<div class="cose-text">
+d28444a1013822a05901e47b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f63726564656e7469616c732f3335333237323535222c2274797065223a5b2256657269666961626c6543726564656e7469616c222c224b59434578616d706c65225d2c22697373756572223a226469643a7765623a636f6e746f736f2e6578616d706c65222c2276616c696446726f6d223a22323031392d30352d32355430333a31303a31362e3939325a222c2276616c6964556e74696c223a22323032372d30352d32355430333a31303a31362e3939325a222c2263726564656e7469616c536368656d61223a7b226964223a2268747470733a2f2f636f6e746f736f2e6578616d706c652f62616679626569676479722e2e2e6c71616266336f636c67747179353566627a6469222c2274797065223a224a736f6e536368656d61227d2c2263726564656e7469616c5375626a656374223a7b226964223a226469643a6578616d706c653a31323331353838222c2274797065223a22506572736f6e227d7d584092951e60aa5f26b98270c1c6d4186fd04f54d25ebeac4f490ec06439459cb61519a7bd0629de08912816e9273970bca368cb742b3f25d47925d3b92b58f9831e
+</div>
+    </div>
+</div></div><div class="vc-tab-content" style="min-height: 410px;"><div>
+
+<div class="sd-jwt-tabbed">
+    <input type="radio" id="sd-jwt-11-ibdtjwb-encoded" name="sd-jwt-11-ibdtjwb-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="sd-jwt-11-ibdtjwb-decoded" name="sd-jwt-11-ibdtjwb-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-11-ibdtjwb-disclosures" name="sd-jwt-11-ibdtjwb-tabs" tabindex="0">
+    <ul class="sd-jwt-tabs">
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-11-ibdtjwb-encoded">Encoded</label>
+      </li>
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-11-ibdtjwb-decoded">Decoded</label>
+      </li>
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-11-ibdtjwb-disclosures">Issuer Disclosures</label>
+      </li>
+    </ul>
+    <div class="sd-jwt-tab-content" id="sd-jwt-11-ibdtjwb-content-encoded">
+      
+<div class="sd-jwt-compact">
+<span class="sd-jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
+.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1NjU5NzksImV4cCI6MTc0Njc3NTU3OSwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiZGlkOndlYjpjb250b3NvLmV4YW1wbGUiLCJ2YWxpZEZyb20iOiIyMDE5LTA1LTI1VDAzOjEwOjE2Ljk5MloiLCJ2YWxpZFVudGlsIjoiMjAyNy0wNS0yNVQwMzoxMDoxNi45OTJaIiwiY3JlZGVudGlhbFNjaGVtYSI6eyJfc2QiOlsiMFhteThmeTQ1aDBweDNFczNNZDR0NFRsbzdid0VWSE1yVUQ2djNweDE5WSIsIjl4WVVoWUpXVTZaWFNJR3hZVlN6cmoxcnhJemlCejZqakRSTWdHSEEzaDAiXX0sImNyZWRlbnRpYWxTdWJqZWN0Ijp7Il9zZCI6WyJCa2JJVlRBM3U0RDlsdWNnOU9kQlRnVlI2UlNFSkZjLXpVR2lWQ2xsdTQ0IiwidVZjZ19MNldmS1hyTEJnTi05WGpKTUZ4MWR5VlVyRTRxamJ3QzJIaDNHZyJdfSwiX3NkIjpbIlVXT2tTdlljSmlkQ3lhbVl4SVUwQlpRaVIwSlZTa0pvOVUzTHpuZHFseWsiLCJuNmdQUXp6LVZyRG14ZXBUWE9OdUNNcTBqWGgySEJTMTdEZXlsTU1IU3VJIl19</span>
+.<span class="sd-jwt-signature">-kfP3LH0xRqFbmO6V90TBeiMc3ZqehP3Ow9utyRUAlyLnOfuTb6wU934PMsr5fKOJMRwxbweC3HDkgjz1_EPKA</span>
+~<span class="sd-jwt-disclosure">WyJ2aUdHenlGMFJkdExCTDFLOVlxU3hBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzLzM1MzI3MjU1Il0</span>~<span class="sd-jwt-disclosure">WyJvcDBwM1IwMkNTcW8wdEdRdkpFT1lBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIktZQ0V4YW1wbGUiXV0</span>~<span class="sd-jwt-disclosure">WyJQTHc3RnhOTHRBMEdMaWtCcl9sM0dBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2JhZnliZWlnZHlyLi4ubHFhYmYzb2NsZ3RxeTU1ZmJ6ZGkiXQ</span>~<span class="sd-jwt-disclosure">WyJrdkRrWkpERjZpNEN4NVlHbUxRWTFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span>~<span class="sd-jwt-disclosure">WyJSNERfV0FnSFU4WGRzRkx5eUxFaThnIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMzE1ODgiXQ</span>~<span class="sd-jwt-disclosure">WyJ1NVRZOFpsUlp4Q3JHck1GeENlTlBBIiwgInR5cGUiLCAiUGVyc29uIl0</span>~
+</div>
+    </div>
+    <div class="sd-jwt-tab-content" id="sd-jwt-11-ibdtjwb-content-decoded">
+      <pre class="header-value">{<br>&nbsp;&nbsp;"kid":&nbsp;"ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",<br>&nbsp;&nbsp;"alg":&nbsp;"ES256"<br>}</pre>
+      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745565979,<br>&nbsp;&nbsp;"exp":&nbsp;1746775579,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"issuer":&nbsp;"did:web:contoso.example",<br>&nbsp;&nbsp;"validFrom":&nbsp;"2019-05-25T03:10:16.992Z",<br>&nbsp;&nbsp;"validUntil":&nbsp;"2027-05-25T03:10:16.992Z",<br>&nbsp;&nbsp;"credentialSchema":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"0Xmy8fy45h0px3Es3Md4t4Tlo7bwEVHMrUD6v3px19Y",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"9xYUhYJWU6ZXSIGxYVSzrj1rxIziBz6jjDRMgGHA3h0"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"credentialSubject":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"BkbIVTA3u4D9lucg9OdBTgVR6RSEJFc-zUGiVCllu44",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"uVcg_L6WfKXrLBgN-9XjJMFx1dyVUrE4qjbwC2Hh3Gg"<br>&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;},<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"UWOkSvYcJidCyamYxIU0BZQiR0JVSkJo9U3Lzndqlyk",<br>&nbsp;&nbsp;&nbsp;&nbsp;"n6gPQzz-VrDmxepTXONuCMq0jXh2HBS17DeylMMHSuI"<br>&nbsp;&nbsp;]<br>}</pre>
+    </div>
+    <div class="sd-jwt-tab-content" id="sd-jwt-11-ibdtjwb-content-disclosures">
+      <div class="disclosures">
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-UWOkSvYcJidCyamYxIU0BZQiR0JVSkJo9U3Lzndqlyk">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">UWOkSvYcJidCyamYxIU0BZQiR0JVSkJo9U3Lzndqlyk</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ2aUdHenlGMFJkdExCTDFLOVlxU3hBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2NyZWRlbnRpYWxzLzM1MzI3MjU1Il0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"viGGzyF0RdtLBL1K9YqSxA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example/credentials/35327255"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-n6gPQzz-VrDmxepTXONuCMq0jXh2HBS17DeylMMHSuI">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">n6gPQzz-VrDmxepTXONuCMq0jXh2HBS17DeylMMHSuI</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJvcDBwM1IwMkNTcW8wdEdRdkpFT1lBIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIktZQ0V4YW1wbGUiXV0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"op0p3R02CSqo0tGQvJEOYA",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"VerifiableCredential",<br>&nbsp;&nbsp;&nbsp;&nbsp;"KYCExample"<br>&nbsp;&nbsp;]<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-9xYUhYJWU6ZXSIGxYVSzrj1rxIziBz6jjDRMgGHA3h0">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">9xYUhYJWU6ZXSIGxYVSzrj1rxIziBz6jjDRMgGHA3h0</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJQTHc3RnhOTHRBMEdMaWtCcl9sM0dBIiwgImlkIiwgImh0dHBzOi8vY29udG9zby5leGFtcGxlL2JhZnliZWlnZHlyLi4ubHFhYmYzb2NsZ3RxeTU1ZmJ6ZGkiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"PLw7FxNLtA0GLikBr_l3GA",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"https://contoso.example/bafybeigdyr...lqabf3oclgtqy55fbzdi"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-0Xmy8fy45h0px3Es3Md4t4Tlo7bwEVHMrUD6v3px19Y">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">0Xmy8fy45h0px3Es3Md4t4Tlo7bwEVHMrUD6v3px19Y</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJrdkRrWkpERjZpNEN4NVlHbUxRWTFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"kvDkZJDF6i4Cx5YGmLQY1A",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"JsonSchema"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-uVcg_L6WfKXrLBgN-9XjJMFx1dyVUrE4qjbwC2Hh3Gg">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">uVcg_L6WfKXrLBgN-9XjJMFx1dyVUrE4qjbwC2Hh3Gg</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJSNERfV0FnSFU4WGRzRkx5eUxFaThnIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMzE1ODgiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"R4D_WAgHU8XdsFLyyLEi8g",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"did:example:1231588"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-BkbIVTA3u4D9lucg9OdBTgVR6RSEJFc-zUGiVCllu44">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">BkbIVTA3u4D9lucg9OdBTgVR6RSEJFc-zUGiVCllu44</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ1NVRZOFpsUlp4Q3JHck1GeENlTlBBIiwgInR5cGUiLCAiUGVyc29uIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"u5TY8ZlRZxCrGrMFxCeNPA",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"Person"<br>]</span></p>
+</div>
+</div>
+    </div>
+</div>
+
+</div></div></div></div>
+      </section>
+      <section id="presentations-0"><div class="header-wrapper"><h3 id="presentations"><bdi class="secno">8.3 </bdi>Presentations</h3><a class="self-link" href="#presentations" aria-label="Permalink for Section 8.3"></a></div>
+        
+        <div class="example" id="example-presentation">
+        <div class="marker">
+    <a class="self-link" href="#example-presentation">Example<bdi> 21</bdi></a><span class="example-title">: Presentation</span>
+  </div> 
+      <div class="vc-tabbed"><input type="radio" id="vc-tab12unsigned" name="vc-tabs12" checked=""><input type="radio" id="vc-tab12jose" name="vc-tabs12"><input type="radio" id="vc-tab12cose" name="vc-tabs12"><input type="radio" id="vc-tab12sd-jwt" name="vc-tabs12"><ul class="vc-tabs"><li class="vc-tab"><label for="vc-tab12unsigned"><abbr title="Unsecured presentation">Presentation</abbr></label></li><li class="vc-tab"><label for="vc-tab12jose"><abbr title="Secured with JOSE">jose</abbr></label></li><li class="vc-tab"><label for="vc-tab12cose"><abbr title="Secured with COSE">cose</abbr></label></li><li class="vc-tab"><label for="vc-tab12sd-jwt"><abbr title="Secured with SD-JWT">sd-jwt</abbr></label></li></ul><div class="vc-tab-content" style="min-height: 518px;"><pre class="nohighlight vc" data-vc-tabs="jose sd-jwt cose">{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "VerifiablePresentation",
+  "verifiableCredential": [
+    {
+      "@context": "https://www.w3.org/ns/credentials/v2",
+      "id": "data:application/vc+cose;base64,0oREo...+Q==",
+      "type": "EnvelopedVerifiableCredential"
+    },
+    {
+      "@context": "https://www.w3.org/ns/credentials/v2",
+      "id": "data:application/vc+jwt,eyVjV...RMjU",
+      "type": "EnvelopedVerifiableCredential"
+    },
+    {
+      "@context": "https://www.w3.org/ns/credentials/v2",
+      "id": "data:application/vc+sd-jwt,eyVjV...RMjU~",
+      "type": "EnvelopedVerifiableCredential"
+    }
+  ]
+}</pre></div><div class="vc-tab-content" style="min-height: 518px;">
+<div class="vc-jose-cose-jwt-tabbed">
+    <div class="vc-jose-cose-jwt-tab-content">
+<strong>Protected Headers</strong>
+<pre>{
+  "kid": "ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",
+  "alg": "ES256"
+}
+</pre>
+<strong>application/vp</strong>
+<pre>{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "VerifiablePresentation",
+  "verifiableCredential": [
+    {
+      "@context": "https://www.w3.org/ns/credentials/v2",
+      "id": "data:application/vc+cose;base64url,YmFzZTY0LDBvUkVvLi4uK1E9PQ",
+      "type": "EnvelopedVerifiableCredential"
+    },
+    {
+      "@context": "https://www.w3.org/ns/credentials/v2",
+      "id": "data:application/vc+jwt,eyVjV...RMjU;data:application/vc+jwt,eyVjV...RMjU",
+      "type": "EnvelopedVerifiableCredential"
+    },
+    {
+      "@context": "https://www.w3.org/ns/credentials/v2",
+      "id": "data:application/vc+sd-jwt,eyVjV...RMjU~;data:application/vc+sd-jwt,eyVjV...RMjU~",
+      "type": "EnvelopedVerifiableCredential"
+    }
+  ]
+}
+</pre>
+<strong>application/vp+jwt</strong>
+<div class="jose-text">
+<div class="jwt-compact">
+<span class="jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
+.<span class="jwt-payload">eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidHlwZSI6IlZlcmlmaWFibGVQcmVzZW50YXRpb24iLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6W3siQGNvbnRleHQiOiJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJpZCI6ImRhdGE6YXBwbGljYXRpb24vdmMrY29zZTtiYXNlNjR1cmwsWW1GelpUWTBMREJ2VWtWdkxpNHVLMUU5UFEiLCJ0eXBlIjoiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwifSx7IkBjb250ZXh0IjoiaHR0cHM6Ly93d3cudzMub3JnL25zL2NyZWRlbnRpYWxzL3YyIiwiaWQiOiJkYXRhOmFwcGxpY2F0aW9uL3ZjK2p3dCxleVZqVi4uLlJNalU7ZGF0YTphcHBsaWNhdGlvbi92Yytqd3QsZXlWalYuLi5STWpVIiwidHlwZSI6IkVudmVsb3BlZFZlcmlmaWFibGVDcmVkZW50aWFsIn0seyJAY29udGV4dCI6Imh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImlkIjoiZGF0YTphcHBsaWNhdGlvbi92YytzZC1qd3QsZXlWalYuLi5STWpVfjtkYXRhOmFwcGxpY2F0aW9uL3ZjK3NkLWp3dCxleVZqVi4uLlJNalV-IiwidHlwZSI6IkVudmVsb3BlZFZlcmlmaWFibGVDcmVkZW50aWFsIn1dfQ</span>
+.<span class="jwt-signature">lWpzCZhXFKC0smk_TAHhNu4ozpx5wQMQC24alnXvlqOamhXtF1x4nBD2rBq1JGOqZm5PmbbkyWC9tQlIMd49FA</span>
+</div>
+</div>
+    </div>
+</div></div><div class="vc-tab-content" style="min-height: 518px;">
+<div class="vc-jose-cose-cose-tabbed">
+    <div class="vc-jose-cose-cose-tab-content">
+<strong>application/vp</strong>
+<pre>{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": "VerifiablePresentation",
+  "verifiableCredential": [
+    {
+      "@context": "https://www.w3.org/ns/credentials/v2",
+      "id": "data:application/vc+cose;base64url,WW1GelpUWTBMREJ2VWtWdkxpNHVLMUU5UFE",
+      "type": "EnvelopedVerifiableCredential"
+    },
+    {
+      "@context": "https://www.w3.org/ns/credentials/v2",
+      "id": "data:application/vc+jwt,eyVjV...RMjU;data:application/vc+jwt,eyVjV...RMjU",
+      "type": "EnvelopedVerifiableCredential"
+    },
+    {
+      "@context": "https://www.w3.org/ns/credentials/v2",
+      "id": "data:application/vc+sd-jwt,eyVjV...RMjU~;data:application/vc+sd-jwt,eyVjV...RMjU~",
+      "type": "EnvelopedVerifiableCredential"
+    }
+  ]
+}
+</pre>
+<strong>application/vp+cose</strong>
+<div class="cose-text">
+d28444a1013822a05902a77b2240636f6e74657874223a5b2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f6578616d706c65732f7632225d2c2274797065223a2256657269666961626c6550726573656e746174696f6e222c2276657269666961626c6543726564656e7469616c223a5b7b2240636f6e74657874223a2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c226964223a22646174613a6170706c69636174696f6e2f76632b636f73653b62617365363475726c2c57573147656c70555754424d52454a3256577457646b78704e48564c4d555535554645222c2274797065223a22456e76656c6f70656456657269666961626c6543726564656e7469616c227d2c7b2240636f6e74657874223a2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c226964223a22646174613a6170706c69636174696f6e2f76632b6a77742c6579566a562e2e2e524d6a553b646174613a6170706c69636174696f6e2f76632b6a77742c6579566a562e2e2e524d6a55222c2274797065223a22456e76656c6f70656456657269666961626c6543726564656e7469616c227d2c7b2240636f6e74657874223a2268747470733a2f2f7777772e77332e6f72672f6e732f63726564656e7469616c732f7632222c226964223a22646174613a6170706c69636174696f6e2f76632b73642d6a77742c6579566a562e2e2e524d6a557e3b646174613a6170706c69636174696f6e2f76632b73642d6a77742c6579566a562e2e2e524d6a557e222c2274797065223a22456e76656c6f70656456657269666961626c6543726564656e7469616c227d5d7d5840d25d3e6717f55ed57a2dcc76dc4da803374f3f25c52cd838a9e097e731b68fa1decded49c2cea80f5ac5d88fff29a4f9cc59379975c27ebe094598af9fc6b054
+</div>
+    </div>
+</div></div><div class="vc-tab-content" style="min-height: 518px;"><div>
+
+<div class="sd-jwt-tabbed">
+    <input type="radio" id="sd-jwt-12-iufi6qs-encoded" name="sd-jwt-12-iufi6qs-tabs" checked="checked" tabindex="0">
+    <input type="radio" id="sd-jwt-12-iufi6qs-decoded" name="sd-jwt-12-iufi6qs-tabs" tabindex="0">
+    <input type="radio" id="sd-jwt-12-iufi6qs-disclosures" name="sd-jwt-12-iufi6qs-tabs" tabindex="0">
+    <ul class="sd-jwt-tabs">
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-12-iufi6qs-encoded">Encoded</label>
+      </li>
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-12-iufi6qs-decoded">Decoded</label>
+      </li>
+      <li class="sd-jwt-tab">
+        <label for="sd-jwt-12-iufi6qs-disclosures">Issuer Disclosures</label>
+      </li>
+    </ul>
+    <div class="sd-jwt-tab-content" id="sd-jwt-12-iufi6qs-content-encoded">
+      
+<div class="sd-jwt-compact">
+<span class="sd-jwt-header">eyJraWQiOiJFeEhrQk1XOWZtYmt2VjI2Nm1ScHVQMnNVWV9OX0VXSU4xbGFwVXpPOHJvIiwiYWxnIjoiRVMyNTYifQ</span>
+.<span class="sd-jwt-payload">eyJpYXQiOjE3NDU1NjU5NzksImV4cCI6MTc0Njc3NTU3OSwiX3NkX2FsZyI6InNoYS0yNTYiLCJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwidmVyaWZpYWJsZUNyZWRlbnRpYWwiOlt7IkBjb250ZXh0IjoiaHR0cHM6Ly93d3cudzMub3JnL25zL2NyZWRlbnRpYWxzL3YyIiwiX3NkIjpbIkt0NzJ5Nlk1bUtlZ3RxQWh6M1lScEtuQ0xnUnFjX3p2UGZMaWNhY29XUm8iLCJ2MHlsVEkyeUVpbk9QbUxtaGVRREpnY2FLNzVjZ1JodVB3cGpSV3lGOG5VIl19LHsiQGNvbnRleHQiOiJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJfc2QiOlsiLV85QkJuX0RrN2xtNjdiVFJSRTB0ZlVvMDFrLS1iMjNuQ1p0T0VpTTdmYyIsIlc1Uk9xa1BtejVqOHU4Zl9lMldydzJrZWVwb040ZFVmc3d3TGVyd0RqZTAiXX0seyJAY29udGV4dCI6Imh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsIl9zZCI6WyJGbjhUTXlYdWh4UUgxaFlXVXdraUlZVlBQZzdfWE5vRjVoN29RYk1nSkVnIiwiajFlTVVlSzNPSzhOaGEzeDdnRm9TaGV6Smwtek9TaFJXSDVhTFNNYkZTWSJdfV0sIl9zZCI6WyJNZVF5WUt6Y3FsZUhzME14MXdWZXJVdlEwdW01VjZVdktPTnJ6Vk5wMlZjIl19</span>
+.<span class="sd-jwt-signature">xYP0pDpzMX5vqi5_xSfE3NO-yVLYfWMBkVGubBJkseDuRb-8mQrFIBHr_RNWojPNSn1zg7FeMycyqe8R3E0EQg</span>
+~<span class="sd-jwt-disclosure">WyJ5SGpwaEVvcC1PRzVoYUJodi1OYUJ3IiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span>~<span class="sd-jwt-disclosure">WyJkNENleVE0UzQzMm9nVGhQRElSQUpnIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrY29zZTtiYXNlNjR1cmwsIFdXMUdlbHBVV1RCTVJFSjJWV3RXZGt4cE5IVkxNVVU1VUZFIl0</span>~<span class="sd-jwt-disclosure">WyJzN2hMaG9TN24zV0lYV3R0ejRuWDB3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span>~<span class="sd-jwt-disclosure">WyJQZ0ZGTC1ERlpSX1pCdTRsb1dXZUN3IiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrand0LCBleVZqVi4uLlJNalU7ZGF0YTphcHBsaWNhdGlvbi92Yytqd3QsIGV5VmpWLi4uUk1qVSJd</span>~<span class="sd-jwt-disclosure">WyJYZGlvVk9TTWUzSHBiNHUyeFZJR1lnIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span>~<span class="sd-jwt-disclosure">WyJWaVIzaDJ5b0lYQ2tvb3FaVkZMSzJnIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleVZqVi4uLlJNalV-O2RhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleVZqVi4uLlJNalV-Il0</span>~<span class="sd-jwt-disclosure">WyJVZkpvYTJHYUlOUXJFbS0zY05LX3RRIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span>~
+</div>
+    </div>
+    <div class="sd-jwt-tab-content" id="sd-jwt-12-iufi6qs-content-decoded">
+      <pre class="header-value">{<br>&nbsp;&nbsp;"kid":&nbsp;"ExHkBMW9fmbkvV266mRpuP2sUY_N_EWIN1lapUzO8ro",<br>&nbsp;&nbsp;"alg":&nbsp;"ES256"<br>}</pre>
+      <pre class="header-value">{<br>&nbsp;&nbsp;"iat":&nbsp;1745565979,<br>&nbsp;&nbsp;"exp":&nbsp;1746775579,<br>&nbsp;&nbsp;"_sd_alg":&nbsp;"sha-256",<br>&nbsp;&nbsp;"@context":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;"https://www.w3.org/ns/credentials/examples/v2"<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"verifiableCredential":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"@context":&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Kt72y6Y5mKegtqAhz3YRpKnCLgRqc_zvPfLicacoWRo",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"v0ylTI2yEinOPmLmheQDJgcaK75cgRhuPwpjRWyF8nU"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"@context":&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"-_9BBn_Dk7lm67bTRRE0tfUo01k--b23nCZtOEiM7fc",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"W5ROqkPmz5j8u8f_e2Wrw2keepoN4dUfswwLerwDje0"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;},<br>&nbsp;&nbsp;&nbsp;&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"@context":&nbsp;"https://www.w3.org/ns/credentials/v2",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"Fn8TMyXuhxQH1hYWUwkiIYVPPg7_XNoF5h7oQbMgJEg",<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"j1eMUeK3OK8Nha3x7gFoShezJl-zOShRWH5aLSMbFSY"<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>&nbsp;&nbsp;],<br>&nbsp;&nbsp;"_sd":&nbsp;[<br>&nbsp;&nbsp;&nbsp;&nbsp;"MeQyYKzcqleHs0Mx1wVerUvQ0um5V6UvKONrzVNp2Vc"<br>&nbsp;&nbsp;]<br>}</pre>
+    </div>
+    <div class="sd-jwt-tab-content" id="sd-jwt-12-iufi6qs-content-disclosures">
+      <div class="disclosures">
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-MeQyYKzcqleHs0Mx1wVerUvQ0um5V6UvKONrzVNp2Vc">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">MeQyYKzcqleHs0Mx1wVerUvQ0um5V6UvKONrzVNp2Vc</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJ5SGpwaEVvcC1PRzVoYUJodi1OYUJ3IiwgInR5cGUiLCAiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"yHjphEop-OG5haBhv-NaBw",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"VerifiablePresentation"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-Kt72y6Y5mKegtqAhz3YRpKnCLgRqc_zvPfLicacoWRo">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">Kt72y6Y5mKegtqAhz3YRpKnCLgRqc_zvPfLicacoWRo</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJkNENleVE0UzQzMm9nVGhQRElSQUpnIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrY29zZTtiYXNlNjR1cmwsIFdXMUdlbHBVV1RCTVJFSjJWV3RXZGt4cE5IVkxNVVU1VUZFIl0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"d4CeyQ4S432ogThPDIRAJg",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vc+cose;base64url,&nbsp;WW1GelpUWTBMREJ2VWtWdkxpNHVLMUU5UFE"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-v0ylTI2yEinOPmLmheQDJgcaK75cgRhuPwpjRWyF8nU">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">v0ylTI2yEinOPmLmheQDJgcaK75cgRhuPwpjRWyF8nU</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJzN2hMaG9TN24zV0lYV3R0ejRuWDB3IiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"s7hLhoS7n3WIXWttz4nX0w",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiableCredential"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim--_9BBn_Dk7lm67bTRRE0tfUo01k--b23nCZtOEiM7fc">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">-_9BBn_Dk7lm67bTRRE0tfUo01k--b23nCZtOEiM7fc</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJQZ0ZGTC1ERlpSX1pCdTRsb1dXZUN3IiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrand0LCBleVZqVi4uLlJNalU7ZGF0YTphcHBsaWNhdGlvbi92Yytqd3QsIGV5VmpWLi4uUk1qVSJd</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"PgFFL-DFZR_ZBu4loWWeCw",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vc+jwt,&nbsp;eyVjV...RMjU;data:application/vc+jwt,&nbsp;eyVjV...RMjU"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-W5ROqkPmz5j8u8f_e2Wrw2keepoN4dUfswwLerwDje0">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">W5ROqkPmz5j8u8f_e2Wrw2keepoN4dUfswwLerwDje0</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJYZGlvVk9TTWUzSHBiNHUyeFZJR1lnIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"XdioVOSMe3Hpb4u2xVIGYg",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiableCredential"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-j1eMUeK3OK8Nha3x7gFoShezJl-zOShRWH5aLSMbFSY">Claim: <span class="claim-name">id</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">j1eMUeK3OK8Nha3x7gFoShezJl-zOShRWH5aLSMbFSY</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJWaVIzaDJ5b0lYQ2tvb3FaVkZMSzJnIiwgImlkIiwgImRhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleVZqVi4uLlJNalV-O2RhdGE6YXBwbGljYXRpb24vdmMrc2Qtand0LCBleVZqVi4uLlJNalV-Il0</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"ViR3h2yoIXCkooqZVFLK2g",<br>&nbsp;&nbsp;"id",<br>&nbsp;&nbsp;"data:application/vc+sd-jwt,&nbsp;eyVjV...RMjU~;data:application/vc+sd-jwt,&nbsp;eyVjV...RMjU~"<br>]</span></p>
+</div>
+
+
+<div class="disclosure">
+    <h3 id="sd-jwt-claim-Fn8TMyXuhxQH1hYWUwkiIYVPPg7_XNoF5h7oQbMgJEg">Claim: <span class="claim-name">type</span></h3>
+    <p><strong>SHA-256 Hash:</strong> <span class="hash">Fn8TMyXuhxQH1hYWUwkiIYVPPg7_XNoF5h7oQbMgJEg</span></p>
+    <p><strong>Disclosure(s):</strong> <span class="disclosure-value">WyJVZkpvYTJHYUlOUXJFbS0zY05LX3RRIiwgInR5cGUiLCAiRW52ZWxvcGVkVmVyaWZpYWJsZUNyZWRlbnRpYWwiXQ</span></p>
+    <p><strong>Contents:</strong> <span class="contents">[<br>&nbsp;&nbsp;"UfJoa2GaINQrEm-3cNK_tQ",<br>&nbsp;&nbsp;"type",<br>&nbsp;&nbsp;"EnvelopedVerifiableCredential"<br>]</span></p>
+</div>
+</div>
+    </div>
+</div>
+
+</div></div></div></div>
+      </section>
+      <section id="data-uris"><div class="header-wrapper"><h3 id="date-uris"><bdi class="secno">8.4 </bdi>Data URIs</h3><a class="self-link" href="#date-uris" aria-label="Permalink for Section 8.4"></a></div>
+        
+        <div class="example" id="example-a-simple-uri-encoded-sd-jwt-verifiable-credential">
+        <div class="marker">
+    <a class="self-link" href="#example-a-simple-uri-encoded-sd-jwt-verifiable-credential">Example<bdi> 22</bdi></a><span class="example-title">: A simple URI-encoded SD-JWT Verifiable Credential</span>
+  </div> <pre aria-busy="false"><code class="hljs">data:application/vc+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlNJM1JITm91aDhvODFOT09OUFFVQUw3RWdaLWtJNl94ajlvUkV2WDF4T3ciLCJ0eXAiOiJ2YytsZCtqc29uK3NkLWp3dCIsImN0eSI6InZjK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiX3NkIjpbIkU3dU1sSWFyS29iYXJTdEZGRjctZm5qaV9sQVdnM3BGMkV5dVc4dWFYakUiLCJYelRaSVgyNGdDSWxSQVFHclFoNU5FRm1XWkQtZ3Z3dkIybzB5Y0FwNFZzIl19LCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJfc2QiOlsiT3oxUEZIMG0tWk9TdEhwUVZyeGlmVlpKRzhvNmlQQmNnLVZ2SXQwd2plcyJdfSwiX3NkIjpbIkVZQ1daMTZZMHB5X1VNNzRHU3NVYU9zT19mdDExTlVSaFFUTS1TT1lFTVEiXX0sIl9zZCI6WyJqT055NnZUbGNvVlAzM25oSTdERGN3ekVka3d2R3VVRXlLUjdrWEVLd3VVIiwid21BdHpwc0dRbDJveS1PY2JrSEVZcE8xb3BoX3VYcWVWVTRKekF0aFFibyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vdW5pdmVyc2l0eS5leGFtcGxlL2lzc3VlcnMvNTY1MDQ5IiwiaWF0IjoxNjk3Mjg5OTk2LCJleHAiOjE3Mjg5MTIzOTYsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6InZFdV84WGxZT0ZFU2hTcVRpZ2JSYWduZ0ZGM1p5U0xrclNHekh3azFBT1loanhlazVhV21HY2UwZU05S0pWOEIiLCJ5IjoiRUpNY2czWXBzUTB3M2RLNHlVa25QczE1Z0lsY2Yyay03dzFKLTNlYlBiOERENmQtUkhBeGUwMDkzSWpfdTRCOSJ9fX0.rYzbxb6j1dwop8_s491iArVVJNm6A6C3b742gOm_qYO3zdkyQU4_VxxOSJ8ECcmWj2r5KyiCNC1ojfO4Yms-zBsjt7PoMYpYWBplsqXpiIvnehmM7D0eOLi40uHXki0X~WyJSWTg1YTZNMmEwX3VDWlFTVGZmTFdRIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~WyJMeG5GYTBXVm8wRUluVy1QdS1fd1dRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJUQVdrakpCaVpxdC1rVU54X1EweUJBIiwgImlkIiwgImh0dHBzOi8vZXhhbXBsZS5vcmcvZXhhbXBsZXMvZGVncmVlLmpzb24iXQ~WyJTd2xuZFpPZzZEZ1ZERFp5X0RvYVFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyJuSnJlU3E1Nzg3RGZMSDJCbU03cXFRIiwgImlkIiwgImRpZDpleGFtcGxlOjEyMyJd~WyIxMjNNd3hNcHRiek02YUk2aW03ME1RIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~</code></pre>
+      </div>
+        <div class="example" id="example-a-simple-uri-encoded-sd-jwt-verifiable-presentation">
+        <div class="marker">
+    <a class="self-link" href="#example-a-simple-uri-encoded-sd-jwt-verifiable-presentation">Example<bdi> 23</bdi></a><span class="example-title">: A simple URI-encoded SD-JWT Verifiable Presentation</span>
+  </div> <pre aria-busy="false"><code class="hljs">data:application/vp+sd-jwt,eyJhbGciOiJFUzM4NCIsImtpZCI6IlNJM1JITm91aDhvODFOT09OUFFVQUw3RWdaLWtJNl94ajlvUkV2WDF4T3ciLCJ0eXAiOiJ2YytsZCtqc29uK3NkLWp3dCIsImN0eSI6InZjK2xkK2pzb24ifQ.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvZXhhbXBsZXMvdjIiXSwiaXNzdWVyIjoiaHR0cHM6Ly91bml2ZXJzaXR5LmV4YW1wbGUvaXNzdWVycy81NjUwNDkiLCJ2YWxpZEZyb20iOiIyMDEwLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTY2hlbWEiOnsiX3NkIjpbIkU3dU1sSWFyS29iYXJTdEZGRjctZm5qaV9sQVdnM3BGMkV5dVc4dWFYakUiLCJYelRaSVgyNGdDSWxSQVFHclFoNU5FRm1XWkQtZ3Z3dkIybzB5Y0FwNFZzIl19LCJjcmVkZW50aWFsU3ViamVjdCI6eyJkZWdyZWUiOnsibmFtZSI6IkJhY2hlbG9yIG9mIFNjaWVuY2UgYW5kIEFydHMiLCJfc2QiOlsiT3oxUEZIMG0tWk9TdEhwUVZyeGlmVlpKRzhvNmlQQmNnLVZ2SXQwd2plcyJdfSwiX3NkIjpbIkVZQ1daMTZZMHB5X1VNNzRHU3NVYU9zT19mdDExTlVSaFFUTS1TT1lFTVEiXX0sIl9zZCI6WyJqT055NnZUbGNvVlAzM25oSTdERGN3ekVka3d2R3VVRXlLUjdrWEVLd3VVIiwid21BdHpwc0dRbDJveS1PY2JrSEVZcE8xb3BoX3VYcWVWVTRKekF0aFFibyJdLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vdW5pdmVyc2l0eS5leGFtcGxlL2lzc3VlcnMvNTY1MDQ5IiwiaWF0IjoxNjk3Mjg5OTk2LCJleHAiOjE3Mjg5MTIzOTYsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsImFsZyI6IkVTMzg0IiwieCI6InZFdV84WGxZT0ZFU2hTcVRpZ2JSYWduZ0ZGM1p5U0xrclNHekh3azFBT1loanhlazVhV21HY2UwZU05S0pWOEIiLCJ5IjoiRUpNY2czWXBzUTB3M2RLNHlVa25QczE1Z0lsY2Yyay03dzFKLTNlYlBiOERENmQtUkhBeGUwMDkzSWpfdTRCOSJ9fX0.rYzbxb6j1dwop8_s491iArVVJNm6A6C3b742gOm_qYO3zdkyQU4_VxxOSJ8ECcmWj2r5KyiCNC1ojfO4Yms-zBsjt7PoMYpYWBplsqXpiIvnehmM7D0eOLi40uHXki0X~WyJTd2xuZFpPZzZEZ1ZERFp5X0RvYVFBIiwgInR5cGUiLCAiSnNvblNjaGVtYSJd~WyIxMjNNd3hNcHRiek02YUk2aW03ME1RIiwgInR5cGUiLCAiQmFjaGVsb3JEZWdyZWUiXQ~WyJMeG5GYTBXVm8wRUluVy1QdS1fd1dRIiwgInR5cGUiLCBbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwgIkV4YW1wbGVBbHVtbmlDcmVkZW50aWFsIl1d~WyJSWTg1YTZNMmEwX3VDWlFTVGZmTFdRIiwgImlkIiwgImh0dHA6Ly91bml2ZXJzaXR5LmV4YW1wbGUvY3JlZGVudGlhbHMvMTg3MiJd~eyJhbGciOiJFUzM4NCIsInR5cCI6ImtiK2p3dCJ9.eyJub25jZSI6IkVmeTROTFJPX3ZvSkszdDIzcUNfQlEiLCJhdWQiOiJodHRwczovL3ZlcmlmaWVyLmV4YW1wbGUiLCJpYXQiOjE2OTcyODk5OTZ9.6G-1nVcrDKFzR6BdbcFHcbtassEb8NZ7ZavTYz3SJ-e4pXleXs0tNcCkUCwMI70gsuOY0AXzeDPbHjp5GKyLDVuNWgWCt3Wo2VSaCwUkyfLyvhkCsmkF9kvFhMIOhp1i~</code></pre>
+      </div>
+        <div class="example" id="example-a-simple-uri-encoded-cose-verifiable-presentation">
+        <div class="marker">
+    <a class="self-link" href="#example-a-simple-uri-encoded-cose-verifiable-presentation">Example<bdi> 24</bdi></a><span class="example-title">: A simple URI-encoded COSE Verifiable Presentation</span>
+  </div> <pre aria-busy="false"><code class="hljs">data:application/vp+cose;base64,0oREoQE4IqBZDSJ7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy9leGFtcGxlcy92MiJdLCJ0eXBlIjoiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiIsInZlcmlmaWFibGVDcmVkZW50aWFsIjpbeyJAY29udGV4dCI6Imh0dHBzOi8vd3d3LnczLm9yZy9ucy9jcmVkZW50aWFscy92MiIsImlkIjoiZGF0YTphcHBsaWNhdGlvbi92Yy1sZCtzZC1qd3QsZXlKcmFXUWlPaUpGZUVoclFrMVhPV1p0WW10MlZqSTJObTFTY0hWUU1uTlZXVjlPWDBWWFNVNHhiR0Z3VlhwUE9ISnZJaXdpWVd4bklqb2lSVk15TlRZaWZRLmV5SmZjMlJmWVd4bklqb2ljMmhoTFRJMU5pSXNJa0JqYjI1MFpYaDBJanBiSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk5dWN5OWpjbVZrWlc1MGFXRnNjeTkyTWlJc0ltaDBkSEJ6T2k4dmQzZDNMbmN6TG05eVp5OXVjeTlqY21Wa1pXNTBhV0ZzY3k5bGVHRnRjR3hsY3k5Mk1pSmRMQ0pwYzNOMVpYSWlPaUpvZEhSd2N6b3ZMM1Z1YVhabGNuTnBkSGt1WlhoaGJYQnNaUzlwYzNOMVpYSnpMelUyTlRBME9TSXNJblpoYkdsa1JuSnZiU0k2SWpJd01UQXRNREV0TURGVU1UazZNak02TWpSYUlpd2lZM0psWkdWdWRHbGhiRk5qYUdWdFlTSTZleUpmYzJRaU9sc2lOV0pCZURNdGVIQm1RV3hWUzBaSk9YTnVNMmhXUTIxd1IydHJjVWx6V21NekxVeGlNek5tV21waWF5SXNJbHBqUVhaSU1EaHNkRUp5U1VwbVNXaDBPRjl0UzFCZll6TnNjRzVZTVdOSGNsbHRWRzh3WjFsQ2VUZ2lYWDBzSW1OeVpXUmxiblJwWVd4VGRXSnFaV04wSWpwN0ltUmxaM0psWlNJNmV5SnVZVzFsSWpvaVFtRmphR1ZzYjNJZ2IyWWdVMk5wWlc1alpTQmhibVFnUVhKMGN5SXNJbDl6WkNJNld5SlNUMVEzTVVsMGRUTk1ObFZYV0ZWcWJ5MW9XVmRKUWpZM2JIVlBUa1ZFVWxOQ2FHeEVWRU54VlU5UklsMTlMQ0pmYzJRaU9sc2lUVVZ1WlhObk1saFBVazVqWTNOQ1RXVmFYekUyTURKbmVUUXdVaTAwV1VKMlZsSXdlRkU0YjBZNFl5SmRmU3dpWDNOa0lqcGJJa1ZsYzJKaWF5MW1jR1p3ZDJaTU9YZE9jekZ4Y2paMGFVNDNabkV0U1hReldWTTJWM1pDYmw5aVdHOGlMQ0phYjFJMVpHUmhja2R0WmsxNU5FaHVWMHhWYWs1VVJuRlVSak5ZUmpacGRGQm5abmxHUWtoVlgzRlZJbDE5Lmd3M3BheGJrTGpwaThDVHN5UnBYS2JDN3RwVmEwcTJzV0tTRC1fZGNidVoxTHBaVjNvUThJZnpjbTJiRThSWTNmbUpnYnV5QTlnYlBMM3NRQmFUemtnIH5XeUpTZVVReFZsQjRWSEJ2Ym10UGVYWnBjemt0YTI5M0lpd2dJbWxrSWl3Z0ltaDBkSEE2THk5MWJtbDJaWEp6YVhSNUxtVjRZVzF3YkdVdlkzSmxaR1Z1ZEdsaGJITXZNVGczTWlKZH5XeUpmVmpkMWVUZDNheTFSTTNWWmQyWnBaME52V1VWQklpd2dJblI1Y0dVaUxDQmJJbFpsY21sbWFXRmliR1ZEY21Wa1pXNTBhV0ZzSWl3Z0lrVjRZVzF3YkdWQmJIVnRibWxEY21Wa1pXNTBhV0ZzSWwxZH5XeUpoYXpkcU1UbG5ZVk10UkRKTFgyaHpZM1JWWkdOUklpd2dJbWxrSWl3Z0ltaDBkSEJ6T2k4dlpYaGhiWEJzWlM1dmNtY3ZaWGhoYlhCc1pYTXZaR1ZuY21WbExtcHpiMjRpWFF+V3lKVVRqQlhhWFZaUmtoWFdrVjJaRFpJUVVKSFFTMW5JaXdnSW5SNWNHVWlMQ0FpU25OdmJsTmphR1Z0WVNKZH5XeUpWTW5Cek1reFlWRVJWYlZoM01EY3hSVkJtUlVwbklpd2dJbWxrSWl3Z0ltUnBaRHBsZUdGdGNHeGxPakV5TXlKZH5XeUpzUTA0MmVUTkVhVE5EVWs5VlgzSnVYelJFTldSbklpd2dJblI1Y0dVaUxDQWlRbUZqYUdWc2IzSkVaV2R5WldVaVhRfjtkYXRhOmFwcGxpY2F0aW9uL3ZjLWxkK3NkLWp3dCxleUpyYVdRaU9pSkZlRWhyUWsxWE9XWnRZbXQyVmpJMk5tMVNjSFZRTW5OVldWOU9YMFZYU1U0eGJHRndWWHBQT0hKdklpd2lZV3huSWpvaVJWTXlOVFlpZlEuZXlKZmMyUmZZV3huSWpvaWMyaGhMVEkxTmlJc0lrQmpiMjUwWlhoMElqcGJJbWgwZEhCek9pOHZkM2QzTG5jekxtOXlaeTl1Y3k5amNtVmtaVzUwYVdGc2N5OTJNaUlzSW1oMGRIQnpPaTh2ZDNkM0xuY3pMbTl5Wnk5dWN5OWpjbVZrWlc1MGFXRnNjeTlsZUdGdGNHeGxjeTkyTWlKZExDSnBjM04xWlhJaU9pSm9kSFJ3Y3pvdkwzVnVhWFpsY25OcGRIa3VaWGhoYlhCc1pTOXBjM04xWlhKekx6VTJOVEEwT1NJc0luWmhiR2xrUm5KdmJTSTZJakl3TVRBdE1ERXRNREZVTVRrNk1qTTZNalJhSWl3aVkzSmxaR1Z1ZEdsaGJGTmphR1Z0WVNJNmV5SmZjMlFpT2xzaU5XSkJlRE10ZUhCbVFXeFZTMFpKT1hOdU0yaFdRMjF3UjJ0cmNVbHpXbU16TFV4aU16Tm1XbXBpYXlJc0lscGpRWFpJTURoc2RFSnlTVXBtU1doME9GOXRTMUJmWXpOc2NHNVlNV05IY2xsdFZHOHdaMWxDZVRnaVhYMHNJbU55WldSbGJuUnBZV3hUZFdKcVpXTjBJanA3SW1SbFozSmxaU0k2ZXlKdVlXMWxJam9pUW1GamFHVnNiM0lnYjJZZ1UyTnBaVzVqWlNCaGJtUWdRWEowY3lJc0lsOXpaQ0k2V3lKU1QxUTNNVWwwZFROTU5sVlhXRlZxYnkxb1dWZEpRalkzYkhWUFRrVkVVbE5DYUd4RVZFTnhWVTlSSWwxOUxDSmZjMlFpT2xzaVRVVnVaWE5uTWxoUFVrNWpZM05DVFdWYVh6RTJNREpuZVRRd1VpMDBXVUoyVmxJd2VGRTRiMFk0WXlKZGZTd2lYM05rSWpwYklrVmxjMkppYXkxbWNHWndkMlpNT1hkT2N6RnhjalowYVU0M1puRXRTWFF6V1ZNMlYzWkNibDlpV0c4aUxDSmFiMUkxWkdSaGNrZHRaazE1TkVodVYweFZhazVVUm5GVVJqTllSalpwZEZCblpubEdRa2hWWDNGVklsMTkuZ3czcGF4YmtManBpOENUc3lScFhLYkM3dHBWYTBxMnNXS1NELV9kY2J1WjFMcFpWM29ROElmemNtMmJFOFJZM2ZtSmdidXlBOWdiUEwzc1FCYVR6a2cgfld5SlNlVVF4VmxCNFZIQnZibXRQZVhacGN6a3RhMjkzSWl3Z0ltbGtJaXdnSW1oMGRIQTZMeTkxYm1sMlpYSnphWFI1TG1WNFlXMXdiR1V2WTNKbFpHVnVkR2xoYkhNdk1UZzNNaUpkfld5SmZWamQxZVRkM2F5MVJNM1ZaZDJacFowTnZXVVZCSWl3Z0luUjVjR1VpTENCYklsWmxjbWxtYVdGaWJHVkRjbVZrWlc1MGFXRnNJaXdnSWtWNFlXMXdiR1ZCYkhWdGJtbERjbVZrWlc1MGFXRnNJbDFkfld5SmhhemRxTVRsbllWTXRSREpMWDJoelkzUlZaR05SSWl3Z0ltbGtJaXdnSW1oMGRIQnpPaTh2WlhoaGJYQnNaUzV2Y21jdlpYaGhiWEJzWlhNdlpHVm5jbVZsTG1wemIyNGlYUX5XeUpVVGpCWGFYVlpSa2hYV2tWMlpEWklRVUpIUVMxbklpd2dJblI1Y0dVaUxDQWlTbk52YmxOamFHVnRZU0pkfld5SlZNbkJ6TWt4WVZFUlZiVmgzTURjeFJWQm1SVXBuSWl3Z0ltbGtJaXdnSW1ScFpEcGxlR0Z0Y0d4bE9qRXlNeUpkfld5SnNRMDQyZVRORWFUTkRVazlWWDNKdVh6UkVOV1JuSWl3Z0luUjVjR1VpTENBaVFtRmphR1ZzYjNKRVpXZHlaV1VpWFF+IiwidHlwZSI6IkVudmVsb3BlZFZlcmlmaWFibGVDcmVkZW50aWFsIn1dfVhA4c9H+cu0VfS8NsItpzbB1mpvjP5y2DCxTCW+bY6/4SNPCaeP+uR+JRpJ+GzVNz7/W7ZlHoXguhgBBjWhlnhh+Q==</code></pre>
+      </div>
+      </section>
+      <section id="cose-examples-0"><div class="header-wrapper"><h3 id="cose-examples"><bdi class="secno">8.5 </bdi>COSE Examples</h3><a class="self-link" href="#cose-examples" aria-label="Permalink for Section 8.5"></a></div>
+        
+        <p>
+          These examples rely on
+          <a href="https://www.rfc-editor.org/rfc/rfc7049#section-6">CBOR Diagnostic Notation</a>.
+          Remember that all actual interchange always happens in the binary format.
+        </p>
+        <div class="example" id="example-a-cose-sign-1-protected-header-for-a-verifiable-credential">
+        <div class="marker">
+    <a class="self-link" href="#example-a-cose-sign-1-protected-header-for-a-verifiable-credential">Example<bdi> 25</bdi></a><span class="example-title">: A COSE Sign 1 Protected Header for a Verifiable Credential</span>
+  </div> <pre aria-busy="false"><code class="hljs javascript">{                                   <span class="hljs-regexp">/ Protected                     /</span>
+  <span class="hljs-number">1</span>: -<span class="hljs-number">35</span>,                           <span class="hljs-regexp">/ Algorithm                     /</span>
+  <span class="hljs-number">3</span>: application/vc,                <span class="hljs-regexp">/ Content type                  /</span>
+  <span class="hljs-number">4</span>: h<span class="hljs-string">'177f12cb...1933d554'</span>,        <span class="hljs-regexp">/ Key identifier                /</span>
+  <span class="hljs-number">15</span>: {                             <span class="hljs-regexp">/ CWT Claims                    /</span>
+    <span class="hljs-number">1</span>: <span class="hljs-attr">urn</span>:<span class="hljs-attr">example</span>:<span class="hljs-number">123</span>,             <span class="hljs-regexp">/ Issuer                        /</span>
+    <span class="hljs-number">2</span>: <span class="hljs-attr">urn</span>:<span class="hljs-attr">example</span>:<span class="hljs-number">456</span>,             <span class="hljs-regexp">/ Subject                       /</span>
+  },
+}</code></pre>
+      </div>
+        <div class="example" id="example-a-cose-sign-1-protected-header-for-a-verifiable-presentation">
+        <div class="marker">
+    <a class="self-link" href="#example-a-cose-sign-1-protected-header-for-a-verifiable-presentation">Example<bdi> 26</bdi></a><span class="example-title">: A COSE Sign 1 Protected Header for a Verifiable Presentation</span>
+  </div> <pre aria-busy="false"><code class="hljs javascript">{                                   <span class="hljs-regexp">/ Protected                     /</span>
+  <span class="hljs-number">1</span>: -<span class="hljs-number">35</span>,                           <span class="hljs-regexp">/ Algorithm                     /</span>
+  <span class="hljs-number">3</span>: application/vp,                <span class="hljs-regexp">/ Content type                  /</span>
+  <span class="hljs-number">4</span>: h<span class="hljs-string">'177f12cb...1933d554'</span>,        <span class="hljs-regexp">/ Key identifier                /</span>
+  <span class="hljs-number">15</span>: {                             <span class="hljs-regexp">/ CWT Claims                    /</span>
+    <span class="hljs-number">1</span>: <span class="hljs-attr">urn</span>:<span class="hljs-attr">example</span>:<span class="hljs-number">123</span>,             <span class="hljs-regexp">/ Issuer                        /</span>
+    <span class="hljs-number">2</span>: <span class="hljs-attr">urn</span>:<span class="hljs-attr">example</span>:<span class="hljs-number">456</span>,             <span class="hljs-regexp">/ Subject                       /</span>
+  },
+}</code></pre>
+      </div>
+        <div class="example" id="example-a-cose-sign-1-with-an-attached-payload">
+        <div class="marker">
+    <a class="self-link" href="#example-a-cose-sign-1-with-an-attached-payload">Example<bdi> 27</bdi></a><span class="example-title">: A COSE Sign 1 with an attached payload</span>
+  </div> <pre aria-busy="false"><code class="hljs javascript"><span class="hljs-number">18</span>(                                 <span class="hljs-regexp">/ COSE Sign 1                   /</span>
+    [
+      h<span class="hljs-string">'a4013822...3a343536'</span>,       <span class="hljs-regexp">/ Protected Header              /</span>
+      {}                            / <span class="hljs-title class_">Unprotected</span> <span class="hljs-title class_">Header</span>            /
+      h<span class="hljs-string">'0fbe22a0...3a009118'</span>,       <span class="hljs-regexp">/ Attached payload              /</span>
+      h<span class="hljs-string">'09772c7f...5c4e736f'</span>        / <span class="hljs-title class_">Signature</span>                     /
+    ]
+)</code></pre>
+      </div>
+        <p>
+          The payload can be either a credential or presentation as described in
+          <a href="https://www.w3.org/TR/vc-data-model-2.0/#securing-mechanisms">Securing Mechanisms</a>.
+        </p>
+      </section>
+    </section>
+    <section class="appendix informative" id="revision-history"><div class="header-wrapper"><h2 id="a-revision-history"><bdi class="secno">A. </bdi>Revision History</h2><a class="self-link" href="#revision-history" aria-label="Permalink for Appendix A."></a></div><p><em>This section is non-normative.</em></p>
+      
+      <p>
+This section describes substantive changes that have been made to this specification.
+      </p>
+      <p>
+Changes since the
+<a href="https://www.w3.org/TR/2024/CRD-vc-jose-cose-20240425/">First Candidate Recommendation</a>:
+      </p>
+
+      <ul>
+        <li>
+Updated to use the <cite><a data-matched-text="[[[CID-1.0]]]" href="https://www.w3.org/TR/cid-1.0/">Controlled Identifiers v1.0</a></cite> specification.
+        </li>
+	<li>
+Changed media types from application/{vc,vp}+ld+json+{jwt,sd-jwt,cose}
+to application/{vc,vp}+{jwt,sd-jwt,cose}.
+	</li>
+	<li>
+Use <a href="https://www.rfc-editor.org/rfc/rfc9596#section-2">COSE "typ" (type) Header Parameter</a>.
+	</li>
+	<li>
+Described differentiating between secured content of different types
+using the <code>cty</code> header parameter.
+	</li>
+	<li>
+Added considerations about what which parameters may be selectively disclosed.
+	</li>
+	<li>
+Described encrypting secured credentials and presentations.
+	</li>
+	<li>
+Said that use of the <code>nbf</code> (Not Before) claim is <em class="rfc2119">NOT RECOMMENDED</em>.
+	</li>
+	<li>
+Updated many examples.
+	</li>
+      </ul>
+
+    </section>
+    <section class="appendix informative" id="acknowledgements"><div class="header-wrapper"><h2 id="b-acknowledgements"><bdi class="secno">B. </bdi>Acknowledgements</h2><a class="self-link" href="#acknowledgements" aria-label="Permalink for Appendix B."></a></div><p><em>This section is non-normative.</em></p>
+      
+      <p>
+        The Working Group thanks Orie Steele for his substantive intellectual
+        and content contributions to this specification.
+        It wouldn't be the same without them.
+      </p>
+    </section>
+  
+
+<section id="references" class="appendix"><div class="header-wrapper"><h2 id="c-references"><bdi class="secno">C. </bdi>References</h2><a class="self-link" href="#references" aria-label="Permalink for Appendix C."></a></div><section id="normative-references"><div class="header-wrapper"><h3 id="c-1-normative-references"><bdi class="secno">C.1 </bdi>Normative references</h3><a class="self-link" href="#normative-references" aria-label="Permalink for Appendix C.1"></a></div>
+    
+    <dl class="bibliography"><dt id="bib-cid-1.0">[CID-1.0]</dt><dd>
+      <a href="https://www.w3.org/TR/cid-1.0/"><cite>Controlled Identifiers v1.0</cite></a>. Michael Jones; Manu Sporny.  W3C. 20 March 2025. W3C Proposed Recommendation. URL: <a href="https://www.w3.org/TR/cid-1.0/">https://www.w3.org/TR/cid-1.0/</a>
+    </dd><dt id="bib-did-core">[DID-CORE]</dt><dd>
+      <a href="https://www.w3.org/TR/did-core/"><cite>Decentralized Identifiers (DIDs) v1.0</cite></a>. Manu Sporny; Amy Guy; Markus Sabadello; Drummond Reed.  W3C. 19 July 2022. W3C Recommendation. URL: <a href="https://www.w3.org/TR/did-core/">https://www.w3.org/TR/did-core/</a>
+    </dd><dt id="bib-json-ld11">[JSON-LD11]</dt><dd>
+      <a href="https://www.w3.org/TR/json-ld11/"><cite>JSON-LD 1.1</cite></a>. Gregg Kellogg; Pierre-Antoine Champin; Dave Longley.  W3C. 16 July 2020. W3C Recommendation. URL: <a href="https://www.w3.org/TR/json-ld11/">https://www.w3.org/TR/json-ld11/</a>
+    </dd><dt id="bib-rfc2119">[RFC2119]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc2119"><cite>Key words for use in RFCs to Indicate Requirement Levels</cite></a>. S. Bradner.  IETF. March 1997. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc2119">https://www.rfc-editor.org/rfc/rfc2119</a>
+    </dd><dt id="bib-rfc2397">[RFC2397]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc2397"><cite>The "data" URL scheme</cite></a>. L. Masinter.  IETF. August 1998. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc2397">https://www.rfc-editor.org/rfc/rfc2397</a>
+    </dd><dt id="bib-rfc6838">[RFC6838]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc6838"><cite>Media Type Specifications and Registration Procedures</cite></a>. N. Freed; J. Klensin; T. Hansen.  IETF. January 2013. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc6838">https://www.rfc-editor.org/rfc/rfc6838</a>
+    </dd><dt id="bib-rfc7515">[RFC7515]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc7515"><cite>JSON Web Signature (JWS)</cite></a>. M. Jones; J. Bradley; N. Sakimura.  IETF. May 2015. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc7515">https://www.rfc-editor.org/rfc/rfc7515</a>
+    </dd><dt id="bib-rfc7516">[RFC7516]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc7516"><cite>JSON Web Encryption (JWE)</cite></a>. M. Jones; J. Hildebrand.  IETF. May 2015. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc7516">https://www.rfc-editor.org/rfc/rfc7516</a>
+    </dd><dt id="bib-rfc7517">[RFC7517]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc7517"><cite>JSON Web Key (JWK)</cite></a>. M. Jones.  IETF. May 2015. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc7517">https://www.rfc-editor.org/rfc/rfc7517</a>
+    </dd><dt id="bib-rfc7519">[RFC7519]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc7519"><cite>JSON Web Token (JWT)</cite></a>. M. Jones; J. Bradley; N. Sakimura.  IETF. May 2015. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc7519">https://www.rfc-editor.org/rfc/rfc7519</a>
+    </dd><dt id="bib-rfc7638">[RFC7638]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc7638"><cite>JSON Web Key (JWK) Thumbprint</cite></a>. M. Jones; N. Sakimura.  IETF. September 2015. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc7638">https://www.rfc-editor.org/rfc/rfc7638</a>
+    </dd><dt id="bib-rfc7800">[RFC7800]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc7800"><cite>Proof-of-Possession Key Semantics for JSON Web Tokens (JWTs)</cite></a>. M. Jones; J. Bradley; H. Tschofenig.  IETF. April 2016. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc7800">https://www.rfc-editor.org/rfc/rfc7800</a>
+    </dd><dt id="bib-rfc8174">[RFC8174]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc8174"><cite>Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words</cite></a>. B. Leiba.  IETF. May 2017. Best Current Practice. URL: <a href="https://www.rfc-editor.org/rfc/rfc8174">https://www.rfc-editor.org/rfc/rfc8174</a>
+    </dd><dt id="bib-rfc8392">[RFC8392]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc8392"><cite>CBOR Web Token (CWT)</cite></a>. M. Jones; E. Wahlstroem; S. Erdtman; H. Tschofenig.  IETF. May 2018. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc8392">https://www.rfc-editor.org/rfc/rfc8392</a>
+    </dd><dt id="bib-rfc8747">[RFC8747]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc8747"><cite>Proof-of-Possession Key Semantics for CBOR Web Tokens (CWTs)</cite></a>. M. Jones; L. Seitz; G. Selander; S. Erdtman; H. Tschofenig.  IETF. March 2020. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc8747">https://www.rfc-editor.org/rfc/rfc8747</a>
+    </dd><dt id="bib-rfc8949">[RFC8949]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc8949"><cite>Concise Binary Object Representation (CBOR)</cite></a>. C. Bormann; P. Hoffman.  IETF. December 2020. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc8949">https://www.rfc-editor.org/rfc/rfc8949</a>
+    </dd><dt id="bib-rfc9052">[RFC9052]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc9052"><cite>CBOR Object Signing and Encryption (COSE): Structures and Process</cite></a>. J. Schaad.  IETF. August 2022. Internet Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9052">https://www.rfc-editor.org/rfc/rfc9052</a>
+    </dd><dt id="bib-rfc9596">[RFC9596]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc9596"><cite>CBOR Object Signing and Encryption (COSE) "typ" (type) Header Parameter</cite></a>. M.B. Jones; O. Steele.  IETF. June 2024. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc9596">https://www.rfc-editor.org/rfc/rfc9596</a>
+    </dd><dt id="bib-sd-jwt">[SD-JWT]</dt><dd>
+      <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt"><cite>Selective Disclosure for JWTs (SD-JWT)</cite></a>. Daniel Fett; Kristina Yasuda; Brian Campbell.  IETF. Internet-Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt">https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt</a>
+    </dd><dt id="bib-sd-jwt-vc">[SD-JWT-VC]</dt><dd>
+      <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc"><cite>SD-JWT-based Verifiable Credentials (SD-JWT VC)</cite></a>. Oliver Terbu; Daniel Fett; Brian Campbell.  IETF. Internet-Draft. URL: <a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc">https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc</a>
+    </dd><dt id="bib-url">[URL]</dt><dd>
+      <a href="https://url.spec.whatwg.org/"><cite>URL Standard</cite></a>. Anne van Kesteren.  WHATWG. Living Standard. URL: <a href="https://url.spec.whatwg.org/">https://url.spec.whatwg.org/</a>
+    </dd><dt id="bib-vc-data-model-2.0">[VC-DATA-MODEL-2.0]</dt><dd>
+      <a href="https://www.w3.org/TR/vc-data-model-2.0/"><cite>Verifiable Credentials Data Model v2.0</cite></a>. Ivan Herman; Michael Jones; Manu Sporny; Ted Thibodeau Jr; Gabe Cohen.  W3C. 20 March 2025. W3C Proposed Recommendation. URL: <a href="https://www.w3.org/TR/vc-data-model-2.0/">https://www.w3.org/TR/vc-data-model-2.0/</a>
+    </dd></dl>
+  </section><section id="informative-references"><div class="header-wrapper"><h3 id="c-2-informative-references"><bdi class="secno">C.2 </bdi>Informative references</h3><a class="self-link" href="#informative-references" aria-label="Permalink for Appendix C.2"></a></div>
+    
+    <dl class="bibliography"><dt id="bib-jwt">[JWT]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc7519"><cite>JSON Web Token (JWT)</cite></a>. M. Jones; J. Bradley; N. Sakimura.  IETF. May 2015. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc7519">https://www.rfc-editor.org/rfc/rfc7519</a>
+    </dd><dt id="bib-rfc7049">[RFC7049]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc7049"><cite>Concise Binary Object Representation (CBOR)</cite></a>. C. Bormann; P. Hoffman.  IETF. October 2013. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc7049">https://www.rfc-editor.org/rfc/rfc7049</a>
+    </dd><dt id="bib-rfc7159">[RFC7159]</dt><dd>
+      <a href="https://www.rfc-editor.org/rfc/rfc7159"><cite>The JavaScript Object Notation (JSON) Data Interchange Format</cite></a>. T. Bray, Ed. IETF. March 2014. Proposed Standard. URL: <a href="https://www.rfc-editor.org/rfc/rfc7159">https://www.rfc-editor.org/rfc/rfc7159</a>
+    </dd><dt id="bib-wcag21">[WCAG21]</dt><dd>
+      <a href="https://www.w3.org/TR/WCAG21/"><cite>Web Content Accessibility Guidelines (WCAG) 2.1</cite></a>. Michael Cooper; Andrew Kirkpatrick; Joshue O'Connor; Alastair Campbell.  W3C. 12 December 2024. W3C Recommendation. URL: <a href="https://www.w3.org/TR/WCAG21/">https://www.w3.org/TR/WCAG21/</a>
+    </dd></dl>
+  </section></section><p role="navigation" id="back-to-top">
+    <a href="#title"><abbr title="Back to Top">↑</abbr></a>
+  </p><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-jws-document" aria-label="Links in this document to definition: conforming JWS document">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-jws-document" aria-label="Permalink for definition: conforming JWS document. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-conforming-jws-document-1" title="§ 1.1.1 Conformance Classes">§ 1.1.1 Conformance Classes</a> <a href="#ref-for-dfn-conforming-jws-document-2" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-conforming-jws-document-3" title="§ 3.1.1 Securing JSON-LD Verifiable Credentials with JOSE">§ 3.1.1 Securing JSON-LD Verifiable Credentials with JOSE</a> 
+    </li><li>
+      <a href="#ref-for-dfn-conforming-jws-document-4" title="§ 3.1.2 Securing JSON-LD Verifiable Presentations with JOSE">§ 3.1.2 Securing JSON-LD Verifiable Presentations with JOSE</a> 
+    </li><li>
+      <a href="#ref-for-dfn-conforming-jws-document-5" title="§ 3.2.1 Securing JSON-LD Verifiable Credentials with SD-JWT">§ 3.2.1 Securing JSON-LD Verifiable Credentials with SD-JWT</a> 
+    </li><li>
+      <a href="#ref-for-dfn-conforming-jws-document-6" title="§ 3.2.2 Securing JSON-LD Verifiable Presentations with SD-JWT">§ 3.2.2 Securing JSON-LD Verifiable Presentations with SD-JWT</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-jws-issuer-implementation" aria-label="Links in this document to definition: conforming JWS issuer implementation">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-jws-issuer-implementation" aria-label="Permalink for definition: conforming JWS issuer implementation. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-conforming-jws-issuer-implementation-1" title="§ 3.1.1 Securing JSON-LD Verifiable Credentials with JOSE">§ 3.1.1 Securing JSON-LD Verifiable Credentials with JOSE</a> 
+    </li><li>
+      <a href="#ref-for-dfn-conforming-jws-issuer-implementation-2" title="§ 3.1.2 Securing JSON-LD Verifiable Presentations with JOSE">§ 3.1.2 Securing JSON-LD Verifiable Presentations with JOSE</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-jws-verifier-implementation" aria-label="Links in this document to definition: conforming JWS verifier implementation">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-jws-verifier-implementation" aria-label="Permalink for definition: conforming JWS verifier implementation. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-conforming-jws-verifier-implementation-1" title="§ 3.1.1 Securing JSON-LD Verifiable Credentials with JOSE">§ 3.1.1 Securing JSON-LD Verifiable Credentials with JOSE</a> 
+    </li><li>
+      <a href="#ref-for-dfn-conforming-jws-verifier-implementation-2" title="§ 3.1.2 Securing JSON-LD Verifiable Presentations with JOSE">§ 3.1.2 Securing JSON-LD Verifiable Presentations with JOSE</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-sd-jwt-document" aria-label="Links in this document to definition: conforming SD-JWT document">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-sd-jwt-document" aria-label="Permalink for definition: conforming SD-JWT document. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-conforming-sd-jwt-document-1" title="§ 1.1.1 Conformance Classes">§ 1.1.1 Conformance Classes</a> <a href="#ref-for-dfn-conforming-sd-jwt-document-2" title="Reference 2">(2)</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-sd-jwt-issuer-implementation" aria-label="Links in this document to definition: conforming SD-JWT issuer implementation">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-sd-jwt-issuer-implementation" aria-label="Permalink for definition: conforming SD-JWT issuer implementation. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-conforming-sd-jwt-issuer-implementation-1" title="§ 3.2.1 Securing JSON-LD Verifiable Credentials with SD-JWT">§ 3.2.1 Securing JSON-LD Verifiable Credentials with SD-JWT</a> 
+    </li><li>
+      <a href="#ref-for-dfn-conforming-sd-jwt-issuer-implementation-2" title="§ 3.2.2 Securing JSON-LD Verifiable Presentations with SD-JWT">§ 3.2.2 Securing JSON-LD Verifiable Presentations with SD-JWT</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-sd-jwt-verifier-implementation" aria-label="Links in this document to definition: conforming SD-JWT verifier implementation">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-sd-jwt-verifier-implementation" aria-label="Permalink for definition: conforming SD-JWT verifier implementation. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-conforming-sd-jwt-verifier-implementation-1" title="§ 3.2.1 Securing JSON-LD Verifiable Credentials with SD-JWT">§ 3.2.1 Securing JSON-LD Verifiable Credentials with SD-JWT</a> 
+    </li><li>
+      <a href="#ref-for-dfn-conforming-sd-jwt-verifier-implementation-2" title="§ 3.2.2 Securing JSON-LD Verifiable Presentations with SD-JWT">§ 3.2.2 Securing JSON-LD Verifiable Presentations with SD-JWT</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-cose-document" aria-label="Links in this document to definition: conforming COSE document">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-cose-document" aria-label="Permalink for definition: conforming COSE document. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-conforming-cose-document-1" title="§ 1.1.1 Conformance Classes">§ 1.1.1 Conformance Classes</a> <a href="#ref-for-dfn-conforming-cose-document-2" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-conforming-cose-document-3" title="§ 3.3.1 Securing JSON-LD Verifiable Credentials with COSE">§ 3.3.1 Securing JSON-LD Verifiable Credentials with COSE</a> 
+    </li><li>
+      <a href="#ref-for-dfn-conforming-cose-document-4" title="§ 3.3.2 Securing JSON-LD Verifiable Presentations with COSE">§ 3.3.2 Securing JSON-LD Verifiable Presentations with COSE</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-cose-issuer-implementation" aria-label="Links in this document to definition: conforming COSE issuer implementation">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-cose-issuer-implementation" aria-label="Permalink for definition: conforming COSE issuer implementation. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-conforming-cose-issuer-implementation-1" title="§ 3.3.1 Securing JSON-LD Verifiable Credentials with COSE">§ 3.3.1 Securing JSON-LD Verifiable Credentials with COSE</a> 
+    </li><li>
+      <a href="#ref-for-dfn-conforming-cose-issuer-implementation-2" title="§ 3.3.2 Securing JSON-LD Verifiable Presentations with COSE">§ 3.3.2 Securing JSON-LD Verifiable Presentations with COSE</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-conforming-cose-verifier-implementation" aria-label="Links in this document to definition: conforming COSE verifier implementation">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-conforming-cose-verifier-implementation" aria-label="Permalink for definition: conforming COSE verifier implementation. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-conforming-cose-verifier-implementation-1" title="§ 3.3.1 Securing JSON-LD Verifiable Credentials with COSE">§ 3.3.1 Securing JSON-LD Verifiable Credentials with COSE</a> 
+    </li><li>
+      <a href="#ref-for-dfn-conforming-cose-verifier-implementation-2" title="§ 3.3.2 Securing JSON-LD Verifiable Presentations with COSE">§ 3.3.2 Securing JSON-LD Verifiable Presentations with COSE</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-public-key" aria-label="Links in this document to definition: public key">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-public-key" aria-label="Permalink for definition: public key. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-public-key-1" title="§ 4.2.1 JWT Issuer">§ 4.2.1 JWT Issuer</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-private-key" aria-label="Links in this document to definition: private key">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-private-key" aria-label="Permalink for definition: private key. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-private-key-1" title="§ 2. Terminology">§ 2. Terminology</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-verifiable-credentials" aria-label="Links in this document to definition: verifiable credential">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-verifiable-credentials" aria-label="Permalink for definition: verifiable credential. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-verifiable-credentials-1" title="§ 1.1.2.1 JWT Format and Requirements">§ 1.1.2.1 JWT Format and Requirements</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-credentials-2" title="§ 3.1.1 Securing JSON-LD Verifiable Credentials with JOSE">§ 3.1.1 Securing JSON-LD Verifiable Credentials with JOSE</a> <a href="#ref-for-dfn-verifiable-credentials-3" title="Reference 2">(2)</a> <a href="#ref-for-dfn-verifiable-credentials-4" title="Reference 3">(3)</a> <a href="#ref-for-dfn-verifiable-credentials-5" title="Reference 4">(4)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-credentials-6" title="§ 3.1.3 JOSE Header Parameters and JWT Claims">§ 3.1.3 JOSE Header Parameters and JWT Claims</a> <a href="#ref-for-dfn-verifiable-credentials-7" title="Reference 2">(2)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-credentials-8" title="§ 3.2.1 Securing JSON-LD Verifiable Credentials with SD-JWT">§ 3.2.1 Securing JSON-LD Verifiable Credentials with SD-JWT</a> <a href="#ref-for-dfn-verifiable-credentials-9" title="Reference 2">(2)</a> <a href="#ref-for-dfn-verifiable-credentials-10" title="Reference 3">(3)</a> <a href="#ref-for-dfn-verifiable-credentials-11" title="Reference 4">(4)</a> <a href="#ref-for-dfn-verifiable-credentials-12" title="Reference 5">(5)</a> <a href="#ref-for-dfn-verifiable-credentials-13" title="Reference 6">(6)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-credentials-14" title="§ 3.3.1 Securing JSON-LD Verifiable Credentials with COSE">§ 3.3.1 Securing JSON-LD Verifiable Credentials with COSE</a> <a href="#ref-for-dfn-verifiable-credentials-15" title="Reference 2">(2)</a> <a href="#ref-for-dfn-verifiable-credentials-16" title="Reference 3">(3)</a> <a href="#ref-for-dfn-verifiable-credentials-17" title="Reference 4">(4)</a> <a href="#ref-for-dfn-verifiable-credentials-18" title="Reference 5">(5)</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-credentials-19" title="§ 4.1.1 kid">§ 4.1.1 kid</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-credentials-20" title="§ 4.1.3 cnf">§ 4.1.3 cnf</a> 
+    </li><li>
+      <a href="#ref-for-dfn-verifiable-credentials-21" title="§ 5.3 Verifying a Credential or Presentation Secured with COSE">§ 5.3 Verifying a Credential or Presentation Secured with COSE</a> 
+    </li>
+  </ul>
+    </div><div class="dfn-panel" hidden="" role="dialog" aria-modal="true" id="dfn-panel-for-dfn-controlled-identifier-document" aria-label="Links in this document to definition: controlled identifier document">
+      <span class="caret"></span>
+      <div>
+        <a class="self-link" href="#dfn-controlled-identifier-document" aria-label="Permalink for definition: controlled identifier document. Activate to close this dialog.">Permalink</a>
+         
+      </div>
+      <p><b>Referenced in:</b></p>
+      <ul>
+    <li>
+      <a href="#ref-for-dfn-controlled-identifier-document-1" title="§ 4.3 Using Controlled Identifier Documents">§ 4.3 Using Controlled Identifier Documents</a> <a href="#ref-for-dfn-controlled-identifier-document-2" title="Reference 2">(2)</a> <a href="#ref-for-dfn-controlled-identifier-document-3" title="Reference 3">(3)</a> <a href="#ref-for-dfn-controlled-identifier-document-4" title="Reference 4">(4)</a> 
+    </li>
+  </ul>
+    </div><script id="respec-highlight-vars">(() => {
+// @ts-check
+
+if (document.respec) {
+  document.respec.ready.then(setupVarHighlighter);
+} else {
+  setupVarHighlighter();
+}
+
+function setupVarHighlighter() {
+  document
+    .querySelectorAll("var")
+    .forEach(varElem => varElem.addEventListener("click", highlightListener));
+}
+
+function highlightListener(ev) {
+  ev.stopPropagation();
+  const { target: varElem } = ev;
+  const hightligtedElems = highlightVars(varElem);
+  const resetListener = () => {
+    const hlColor = getHighlightColor(varElem);
+    hightligtedElems.forEach(el => removeHighlight(el, hlColor));
+    [...HL_COLORS.keys()].forEach(key => HL_COLORS.set(key, true));
+  };
+  if (hightligtedElems.length) {
+    document.body.addEventListener("click", resetListener, { once: true });
+  }
+}
+
+// availability of highlight colors. colors from var.css
+const HL_COLORS = new Map([
+  ["respec-hl-c1", true],
+  ["respec-hl-c2", true],
+  ["respec-hl-c3", true],
+  ["respec-hl-c4", true],
+  ["respec-hl-c5", true],
+  ["respec-hl-c6", true],
+  ["respec-hl-c7", true],
+]);
+
+function getHighlightColor(target) {
+  // return current colors if applicable
+  const { value } = target.classList;
+  const re = /respec-hl-\w+/;
+  const activeClass = re.test(value) && value.match(re);
+  if (activeClass) return activeClass[0];
+
+  // first color preference
+  if (HL_COLORS.get("respec-hl-c1") === true) return "respec-hl-c1";
+
+  // otherwise get some other available color
+  return [...HL_COLORS.keys()].find(c => HL_COLORS.get(c)) || "respec-hl-c1";
+}
+
+function highlightVars(varElem) {
+  const textContent = norm(varElem.textContent);
+  const parent = varElem.closest(".algorithm, section");
+  const highlightColor = getHighlightColor(varElem);
+
+  const varsToHighlight = [...parent.querySelectorAll("var")].filter(
+    el =>
+      norm(el.textContent) === textContent &&
+      el.closest(".algorithm, section") === parent
+  );
+
+  // update availability of highlight color
+  const colorStatus = varsToHighlight[0].classList.contains("respec-hl");
+  HL_COLORS.set(highlightColor, colorStatus);
+
+  // highlight vars
+  if (colorStatus) {
+    varsToHighlight.forEach(el => removeHighlight(el, highlightColor));
+    return [];
+  } else {
+    varsToHighlight.forEach(el => addHighlight(el, highlightColor));
+  }
+  return varsToHighlight;
+}
+
+function removeHighlight(el, highlightColor) {
+  el.classList.remove("respec-hl", highlightColor);
+  // clean up empty class attributes so they don't come in export
+  if (!el.classList.length) el.removeAttribute("class");
+}
+
+function addHighlight(elem, highlightColor) {
+  elem.classList.add("respec-hl", highlightColor);
+}
+
+/**
+ * Same as `norm` from src/core/utils, but our build process doesn't allow
+ * imports in runtime scripts, so duplicated here.
+ * @param {string} str
+ */
+function norm(str) {
+  return str.trim().replace(/\s+/g, " ");
+}
+})()</script><script id="respec-dfn-panel">(() => {
+// @ts-check
+if (document.respec) {
+  document.respec.ready.then(setupPanel);
+} else {
+  setupPanel();
+}
+
+function setupPanel() {
+  const listener = panelListener();
+  document.body.addEventListener("keydown", listener);
+  document.body.addEventListener("click", listener);
+}
+
+function panelListener() {
+  /** @type {HTMLElement} */
+  let panel = null;
+  return event => {
+    const { target, type } = event;
+
+    if (!(target instanceof HTMLElement)) return;
+
+    // For keys, we only care about Enter key to activate the panel
+    // otherwise it's activated via a click.
+    if (type === "keydown" && event.key !== "Enter") return;
+
+    const action = deriveAction(event);
+
+    switch (action) {
+      case "show": {
+        hidePanel(panel);
+        /** @type {HTMLElement} */
+        const dfn = target.closest("dfn, .index-term");
+        panel = document.getElementById(`dfn-panel-for-${dfn.id}`);
+        const coords = deriveCoordinates(event);
+        displayPanel(dfn, panel, coords);
+        break;
+      }
+      case "dock": {
+        panel.style.left = null;
+        panel.style.top = null;
+        panel.classList.add("docked");
+        break;
+      }
+      case "hide": {
+        hidePanel(panel);
+        panel = null;
+        break;
+      }
+    }
+  };
+}
+
+/**
+ * @param {MouseEvent|KeyboardEvent} event
+ */
+function deriveCoordinates(event) {
+  const target = /** @type HTMLElement */ (event.target);
+
+  // We prevent synthetic AT clicks from putting
+  // the dialog in a weird place. The AT events sometimes
+  // lack coordinates, so they have clientX/Y = 0
+  const rect = target.getBoundingClientRect();
+  if (
+    event instanceof MouseEvent &&
+    event.clientX >= rect.left &&
+    event.clientY >= rect.top
+  ) {
+    // The event probably happened inside the bounding rect...
+    return { x: event.clientX, y: event.clientY };
+  }
+
+  // Offset to the middle of the element
+  const x = rect.x + rect.width / 2;
+  // Placed at the bottom of the element
+  const y = rect.y + rect.height;
+  return { x, y };
+}
+
+/**
+ * @param {Event} event
+ */
+function deriveAction(event) {
+  const target = /** @type {HTMLElement} */ (event.target);
+  const hitALink = !!target.closest("a");
+  if (target.closest("dfn:not([data-cite]), .index-term")) {
+    return hitALink ? "none" : "show";
+  }
+  if (target.closest(".dfn-panel")) {
+    if (hitALink) {
+      return target.classList.contains("self-link") ? "hide" : "dock";
+    }
+    const panel = target.closest(".dfn-panel");
+    return panel.classList.contains("docked") ? "hide" : "none";
+  }
+  if (document.querySelector(".dfn-panel:not([hidden])")) {
+    return "hide";
+  }
+  return "none";
+}
+
+/**
+ * @param {HTMLElement} dfn
+ * @param {HTMLElement} panel
+ * @param {{ x: number, y: number }} clickPosition
+ */
+function displayPanel(dfn, panel, { x, y }) {
+  panel.hidden = false;
+  // distance (px) between edge of panel and the pointing triangle (caret)
+  const MARGIN = 20;
+
+  const dfnRects = dfn.getClientRects();
+  // Find the `top` offset when the `dfn` can be spread across multiple lines
+  let closestTop = 0;
+  let minDiff = Infinity;
+  for (const rect of dfnRects) {
+    const { top, bottom } = rect;
+    const diffFromClickY = Math.abs((top + bottom) / 2 - y);
+    if (diffFromClickY < minDiff) {
+      minDiff = diffFromClickY;
+      closestTop = top;
+    }
+  }
+
+  const top = window.scrollY + closestTop + dfnRects[0].height;
+  const left = x - MARGIN;
+  panel.style.left = `${left}px`;
+  panel.style.top = `${top}px`;
+
+  // Find if the panel is flowing out of the window
+  const panelRect = panel.getBoundingClientRect();
+  const SCREEN_WIDTH = Math.min(window.innerWidth, window.screen.width);
+  if (panelRect.right > SCREEN_WIDTH) {
+    const newLeft = Math.max(MARGIN, x + MARGIN - panelRect.width);
+    const newCaretOffset = left - newLeft;
+    panel.style.left = `${newLeft}px`;
+    /** @type {HTMLElement} */
+    const caret = panel.querySelector(".caret");
+    caret.style.left = `${newCaretOffset}px`;
+  }
+
+  // As it's a dialog, we trap focus.
+  // TODO: when <dialog> becomes a implemented, we should really
+  // use that.
+  trapFocus(panel, dfn);
+}
+
+/**
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function trapFocus(panel, dfn) {
+  /** @type NodeListOf<HTMLAnchorElement> elements */
+  const anchors = panel.querySelectorAll("a[href]");
+  // No need to trap focus
+  if (!anchors.length) return;
+
+  // Move focus to first anchor element
+  const first = anchors.item(0);
+  first.focus();
+
+  const trapListener = createTrapListener(anchors, panel, dfn);
+  panel.addEventListener("keydown", trapListener);
+
+  // Hiding the panel releases the trap
+  const mo = new MutationObserver(records => {
+    const [record] = records;
+    const target = /** @type HTMLElement */ (record.target);
+    if (target.hidden) {
+      panel.removeEventListener("keydown", trapListener);
+      mo.disconnect();
+    }
+  });
+  mo.observe(panel, { attributes: true, attributeFilter: ["hidden"] });
+}
+
+/**
+ *
+ * @param {NodeListOf<HTMLAnchorElement>} anchors
+ * @param {HTMLElement} panel
+ * @param {HTMLElement} dfn
+ * @returns
+ */
+function createTrapListener(anchors, panel, dfn) {
+  const lastIndex = anchors.length - 1;
+  let currentIndex = 0;
+  return event => {
+    switch (event.key) {
+      // Hitting "Tab" traps us in a nice loop around elements.
+      case "Tab": {
+        event.preventDefault();
+        currentIndex += event.shiftKey ? -1 : +1;
+        if (currentIndex < 0) {
+          currentIndex = lastIndex;
+        } else if (currentIndex > lastIndex) {
+          currentIndex = 0;
+        }
+        anchors.item(currentIndex).focus();
+        break;
+      }
+
+      // Hitting "Enter" on an anchor releases the trap.
+      case "Enter":
+        hidePanel(panel);
+        break;
+
+      // Hitting "Escape" returns focus to dfn.
+      case "Escape":
+        hidePanel(panel);
+        dfn.focus();
+        return;
+    }
+  };
+}
+
+/** @param {HTMLElement} panel */
+function hidePanel(panel) {
+  if (!panel) return;
+  panel.hidden = true;
+  panel.classList.remove("docked");
+}
+})()</script><script src="https://www.w3.org/scripts/TR/2021/fixup.js"></script></body></html>


### PR DESCRIPTION
I have reused the errata management used for DID which, in turn, originates from the standard W3C practice these days.

If and when merged, the `Errata` and `PossibleErratum` labels must be added to the repo.

I have also generated a static preview for the REC for the publication. See, however #342. This version removes the at risk statement from SD-JWT but I have no touched the issue on Well known URIs. The PR must be updated with the resolution of #342.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/pull/343.html" title="Last updated on Apr 25, 2025, 3:27 PM UTC (3ce931a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-jose-cose/343/7c4c2bc...3ce931a.html" title="Last updated on Apr 25, 2025, 3:27 PM UTC (3ce931a)">Diff</a>